### PR TITLE
fix: standardize cougr-core dependency declarations (#37)

### DIFF
--- a/examples/flappy_bird/Cargo.toml
+++ b/examples/flappy_bird/Cargo.toml
@@ -9,7 +9,7 @@ description = "Flappy Bird on-chain game example using cougr-core ECS framework"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = { branch = "main", git = "https://github.com/salazarsebas/Cougr.git" }
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/pokemon_mini/Cargo.toml
+++ b/examples/pokemon_mini/Cargo.toml
@@ -9,7 +9,7 @@ description = "Pokémon Mini on-chain game example using cougr-core ECS framewor
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = { branch = "main", git = "https://github.com/salazarsebas/Cougr.git" }
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/snake/Cargo.toml
+++ b/examples/snake/Cargo.toml
@@ -9,7 +9,7 @@ description = "Snake on-chain game example using cougr-core ECS framework"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = { branch = "main", git = "https://github.com/salazarsebas/Cougr.git" }
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
### Description
Standardized `cougr-core` dependency declarations in three examples that were previously using local path references. This fix enables external contributors to build these games and ensures CI compatibility.

### Changes
- Updated `Cargo.toml` in `flappy_bird`, `pokemon_mini`, and `snake`.
- Replaced `path = "../../"` with `branch = "main", git = "https://github.com/salazarsebas/Cougr.git"`.
- Verified character-for-character parity with the other 8 examples in the repository.

### Verification Results
- **Builds**: All 3 examples compile successfully resolving from the remote Git repository.
- **Tests**: A total of 75 tests passed across the 3 affected games (9 in flappy_bird, 36 in pokemon_mini, 30 in snake).
- **Cargo.lock**: All locks are pinned to the current `main` commit `7c4535e0`.

### Evidence
<img width="1920" height="1080" alt="CrougExito" src="https://github.com/user-attachments/assets/931ff39a-3499-4f8c-815f-0cc582fbafec" />

Cualquier cosita me avisaaas, graciaaas <3 

closes #37 