### PR TITLE
feat(example): add proof_of_hunt with stellar-zk flow and x402 premiu…

### DIFF
--- a/.github/workflows/proof_of_hunt.yml
+++ b/.github/workflows/proof_of_hunt.yml
@@ -1,0 +1,64 @@
+name: Proof of Hunt CI
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'examples/proof_of_hunt/**'
+      - '.github/workflows/proof_of_hunt.yml'
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'examples/proof_of_hunt/**'
+      - '.github/workflows/proof_of_hunt.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+
+      - name: Install Rust target for Soroban
+        run: |
+          source $HOME/.cargo/env
+          rustup target add wasm32v1-none
+
+      - name: Install Stellar CLI with Homebrew
+        run: |
+          brew update
+          brew install stellar-cli
+          stellar --version
+
+      - name: cargo fmt --check
+        run: |
+          source $HOME/.cargo/env
+          cargo fmt --check
+        working-directory: examples/proof_of_hunt
+
+      - name: cargo clippy (deny warnings)
+        run: |
+          source $HOME/.cargo/env
+          cargo clippy --all-targets --all-features -- -D warnings
+        working-directory: examples/proof_of_hunt
+
+      - name: cargo test
+        run: |
+          source $HOME/.cargo/env
+          cargo test
+        working-directory: examples/proof_of_hunt
+
+      - name: stellar contract build
+        run: |
+          source $HOME/.cargo/env
+          stellar contract build
+        working-directory: examples/proof_of_hunt

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,7 @@ stellar contract build
 | `pac_man` | Maze action | Grid navigation and adversarial movement patterns |
 | `pokemon_mini` | Turn-based battle | Combat sequencing and match state transitions |
 | `pong` | Arcade | Minimal competitive loop and ECS fundamentals |
+| `proof_of_hunt` | Hidden-state exploration | stellar-zk style proof verification and x402 premium actions |
 | `rock_paper_scissors` | Commit-reveal | Hidden choices and reveal resolution |
 | `snake` | Arcade | Growth mechanics and collision rules |
 | `space_invaders` | Wave shooter | Formation movement and repeated tick systems |

--- a/examples/proof_of_hunt/Cargo.toml
+++ b/examples/proof_of_hunt/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "proof_of_hunt"
+version = "0.1.0"
+edition = "2021"
+description = "Proof-of-Hunt Soroban example with stellar-zk proof validation and x402 premium actions"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cougr-core = { path = "../../" }
+soroban-sdk = "25.1.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+lto = true
+codegen-units = 1

--- a/examples/proof_of_hunt/README.md
+++ b/examples/proof_of_hunt/README.md
@@ -1,0 +1,110 @@
+# Proof of Hunt (Stellar + Soroban)
+
+Proof of Hunt is a hidden-map treasure discovery example for Soroban that combines:
+
+- hidden world state committed off-chain
+- proof-backed exploration and deterministic progression on-chain
+- premium actions modeled for x402 settlement flows
+
+This example is intentionally contract-only: no frontend, no multiplayer layer.
+
+## Why This Is Stellar-Specific
+
+This example demonstrates three Stellar-native patterns working together:
+
+1. Soroban contract state for deterministic gameplay and progression.
+2. stellar-zk style Groth16 verifier flow on-chain using Soroban BN254 pairing checks.
+3. x402-style premium action credits represented as settled payment units before hint consumption.
+
+References:
+
+- https://crates.io/crates/stellar-zk
+- https://github.com/salazarsebas/stellar-zk
+- https://developers.stellar.org/docs/build/apps/x402
+
+## Hidden State And Proof Flow
+
+### Off-chain committed data
+
+The hidden map is represented off-chain and committed by root hash:
+
+- map commitment root (`BytesN<32>`)
+- map dimensions (`width`, `height`)
+- implicit treasure distribution encoded in proof public inputs
+
+### What is proven on-chain
+
+For each exploration:
+
+- `(x, y)` belongs to a valid proof statement bound to the same commitment root
+- leaf + sibling path resolves to the committed root
+- Groth16 proof verifies through BN254 pairing checks
+- nullifier has not been replayed
+
+### Anti-cheat and privacy properties
+
+- Players cannot claim arbitrary discoveries because proof public inputs are tied to coordinates and root.
+- Replay is blocked by nullifier storage.
+- Full hidden map remains off-chain; only commitment and selective proof metadata are revealed.
+
+## x402 Premium Action Model
+
+`purchase_hint(player, hint_type)` consumes pre-settled premium credits.
+
+This maps to an x402 backend flow where a payment gateway verifies and settles payment off-chain, then credits the user in-contract via `credit_x402_payment(...)`.
+
+- `hint_type = 0`: hint action (cost 1 credit)
+- `hint_type = 1`: scan action (cost 2 credits)
+
+## Contract API
+
+Required functions:
+
+- `init_game(env, player, map_commitment, width, height)`
+- `explore(env, player, x, y, proof)`
+- `purchase_hint(env, player, hint_type)`
+- `get_state(env) -> GameState`
+- `is_finished(env) -> bool`
+
+Additional helper functions:
+
+- `set_verification_key(env, owner, vk_bytes)`
+- `credit_x402_payment(env, owner, player, units, receipt_hash)`
+
+## Architecture Components
+
+- `MapCommitmentComponent`: commitment root, width, height, derived treasure count
+- `PlayerStateComponent`: position, score, health, discoveries
+- `ExplorationComponent`: explored cell tracking
+- `HintUsageComponent`: hints/scans used
+- `GameStatusComponent`: active/won/lost
+
+### Systems
+
+- `ExplorationSystem`: coordinate bounds + replay prevention
+- `ProofValidationSystem`: public input checks + Merkle path + Groth16 verify
+- `DiscoveryResolutionSystem`: score/health/discovery updates
+- `HintPurchaseSystem`: x402 credit consumption
+- `EndConditionSystem`: won/lost transitions
+
+## Build And Test
+
+All commands are Soroban target aligned (`wasm32v1-none`):
+
+```bash
+cd examples/proof_of_hunt
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+stellar contract build
+```
+
+## Notes On stellar-zk Integration
+
+The contract uses the same Groth16 verifier model used by stellar-zk templates:
+
+- BN254 proof point decoding
+- verification key layout parsing
+- multi-pairing check (`env.crypto().bn254().pairing_check`)
+
+For CI tests in this repository, a deterministic zero-proof test path is enabled only under `#[cfg(test)]` so tests remain fully deterministic without external trusted setup artifacts.

--- a/examples/proof_of_hunt/src/lib.rs
+++ b/examples/proof_of_hunt/src/lib.rs
@@ -1,0 +1,654 @@
+#![no_std]
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype,
+    crypto::bn254::{Bn254G1Affine, Bn254G2Affine, Fr},
+    panic_with_error, symbol_short, Address, Bytes, BytesN, Env, TryFromVal, Vec,
+};
+
+const MAX_HEALTH: u32 = 3;
+const HINT_COST: u32 = 1;
+const SCAN_COST: u32 = 2;
+const PUB_INPUTS_LEN: u32 = 128;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ProofOfHuntError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    InvalidMapDimensions = 3,
+    InvalidCoordinate = 4,
+    AlreadyExplored = 5,
+    InvalidPublicInputCount = 6,
+    PublicInputMismatch = 7,
+    InvalidMerklePath = 8,
+    InvalidVerificationKey = 9,
+    VerificationFailed = 10,
+    NullifierAlreadyUsed = 11,
+    Unauthorized = 12,
+    PaymentRequired = 13,
+    InvalidHintType = 14,
+    GameFinished = 15,
+    InvalidReceipt = 16,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GameStatus {
+    Active,
+    Won,
+    Lost,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProofInput {
+    pub proof: BytesN<256>,
+    pub public_inputs: Bytes,
+    pub nullifier: BytesN<32>,
+    pub leaf_hash: BytesN<32>,
+    pub sibling_hash: BytesN<32>,
+    pub sibling_on_left: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerState {
+    pub position_x: u32,
+    pub position_y: u32,
+    pub score: i128,
+    pub health: u32,
+    pub discoveries: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HintUsage {
+    pub hints_used: u32,
+    pub scans_used: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GameState {
+    pub player: Address,
+    pub map_commitment: BytesN<32>,
+    pub width: u32,
+    pub height: u32,
+    pub treasure_count: u32,
+    pub discovered_cells: u32,
+    pub status: GameStatus,
+    pub player_state: PlayerState,
+    pub hint_usage: HintUsage,
+    pub x402_credits: u32,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Owner,
+    Player,
+    MapCommitment,
+    Width,
+    Height,
+    TreasureCount,
+    DiscoveredCells,
+    Status,
+    PlayerState,
+    HintUsage,
+    ExploredCell(u32),
+    VerificationKey,
+    Nullifier(BytesN<32>),
+    X402Credits(Address),
+    X402Receipt(BytesN<32>),
+}
+
+#[contract]
+pub struct ProofOfHuntContract;
+
+#[allow(deprecated)]
+#[contractimpl]
+impl ProofOfHuntContract {
+    pub fn init_game(
+        env: Env,
+        player: Address,
+        map_commitment: BytesN<32>,
+        width: u32,
+        height: u32,
+    ) {
+        if env.storage().instance().has(&DataKey::Owner) {
+            panic_with_error!(&env, ProofOfHuntError::AlreadyInitialized);
+        }
+        if width == 0 || height == 0 {
+            panic_with_error!(&env, ProofOfHuntError::InvalidMapDimensions);
+        }
+
+        player.require_auth();
+
+        let treasure_count = core::cmp::max(1, (width * height) / 8);
+        let initial_state = PlayerState {
+            position_x: 0,
+            position_y: 0,
+            score: 0,
+            health: MAX_HEALTH,
+            discoveries: 0,
+        };
+
+        env.storage().instance().set(&DataKey::Owner, &player);
+        env.storage().instance().set(&DataKey::Player, &player);
+        env.storage()
+            .instance()
+            .set(&DataKey::MapCommitment, &map_commitment);
+        env.storage().instance().set(&DataKey::Width, &width);
+        env.storage().instance().set(&DataKey::Height, &height);
+        env.storage()
+            .instance()
+            .set(&DataKey::TreasureCount, &treasure_count);
+        env.storage()
+            .instance()
+            .set(&DataKey::DiscoveredCells, &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::Status, &GameStatus::Active);
+        env.storage()
+            .instance()
+            .set(&DataKey::PlayerState, &initial_state);
+        env.storage().instance().set(
+            &DataKey::HintUsage,
+            &HintUsage {
+                hints_used: 0,
+                scans_used: 0,
+            },
+        );
+        env.storage()
+            .instance()
+            .set(&DataKey::VerificationKey, &default_vk(&env, 4));
+        env.storage()
+            .persistent()
+            .set(&DataKey::X402Credits(player.clone()), &0u32);
+
+        env.events().publish(
+            (symbol_short!("init"),),
+            (player, map_commitment, width, height, treasure_count),
+        );
+    }
+
+    pub fn set_verification_key(env: Env, owner: Address, vk_bytes: Bytes) {
+        ensure_initialized(&env);
+        owner.require_auth();
+
+        let stored_owner: Address =
+            get_instance_or_panic(&env, &DataKey::Owner, ProofOfHuntError::NotInitialized);
+        if owner != stored_owner {
+            panic_with_error!(&env, ProofOfHuntError::Unauthorized);
+        }
+
+        validate_vk_shape(&env, &vk_bytes, 4);
+        env.storage()
+            .instance()
+            .set(&DataKey::VerificationKey, &vk_bytes);
+    }
+
+    pub fn credit_x402_payment(
+        env: Env,
+        owner: Address,
+        player: Address,
+        units: u32,
+        receipt_hash: BytesN<32>,
+    ) {
+        ensure_initialized(&env);
+        owner.require_auth();
+
+        let stored_owner: Address =
+            get_instance_or_panic(&env, &DataKey::Owner, ProofOfHuntError::NotInitialized);
+        if owner != stored_owner {
+            panic_with_error!(&env, ProofOfHuntError::Unauthorized);
+        }
+        if units == 0 {
+            panic_with_error!(&env, ProofOfHuntError::InvalidReceipt);
+        }
+
+        let receipt_key = DataKey::X402Receipt(receipt_hash.clone());
+        if env.storage().persistent().has(&receipt_key) {
+            panic_with_error!(&env, ProofOfHuntError::InvalidReceipt);
+        }
+
+        let credit_key = DataKey::X402Credits(player.clone());
+        let current: u32 = env.storage().persistent().get(&credit_key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&credit_key, &(current + units));
+        env.storage().persistent().set(&receipt_key, &true);
+
+        env.events()
+            .publish((symbol_short!("x402"),), (player, units, receipt_hash));
+    }
+
+    pub fn explore(env: Env, player: Address, x: u32, y: u32, proof: ProofInput) {
+        ensure_initialized(&env);
+        ensure_active(&env);
+
+        player.require_auth();
+        let stored_player: Address =
+            get_instance_or_panic(&env, &DataKey::Player, ProofOfHuntError::NotInitialized);
+        if player != stored_player {
+            panic_with_error!(&env, ProofOfHuntError::Unauthorized);
+        }
+
+        let width: u32 =
+            get_instance_or_panic(&env, &DataKey::Width, ProofOfHuntError::NotInitialized);
+        let height: u32 =
+            get_instance_or_panic(&env, &DataKey::Height, ProofOfHuntError::NotInitialized);
+        if x >= width || y >= height {
+            panic_with_error!(&env, ProofOfHuntError::InvalidCoordinate);
+        }
+
+        let cell_idx = y * width + x;
+        let explored_key = DataKey::ExploredCell(cell_idx);
+        if env.storage().persistent().has(&explored_key) {
+            panic_with_error!(&env, ProofOfHuntError::AlreadyExplored);
+        }
+
+        if proof.public_inputs.len() != PUB_INPUTS_LEN {
+            panic_with_error!(&env, ProofOfHuntError::InvalidPublicInputCount);
+        }
+
+        let commitment: BytesN<32> = get_instance_or_panic(
+            &env,
+            &DataKey::MapCommitment,
+            ProofOfHuntError::NotInitialized,
+        );
+
+        // Public input layout (4 x 32-byte field elements):
+        // [0] outcome bit, [1] x, [2] y, [3] root.
+        let pi_x = read_u32_from_field(&proof.public_inputs, 32);
+        let pi_y = read_u32_from_field(&proof.public_inputs, 64);
+        if pi_x != x || pi_y != y {
+            panic_with_error!(&env, ProofOfHuntError::PublicInputMismatch);
+        }
+
+        if !field_equals_bytesn32(&proof.public_inputs.slice(96..128), &commitment) {
+            panic_with_error!(&env, ProofOfHuntError::PublicInputMismatch);
+        }
+
+        let computed_root = hash_path(
+            &env,
+            &proof.leaf_hash,
+            &proof.sibling_hash,
+            proof.sibling_on_left,
+        );
+        if computed_root != commitment {
+            panic_with_error!(&env, ProofOfHuntError::InvalidMerklePath);
+        }
+
+        verify_groth16(&env, &proof);
+
+        let is_treasure = read_u32_from_field(&proof.public_inputs, 0) == 1;
+
+        let mut state: PlayerState = get_instance_or_panic(
+            &env,
+            &DataKey::PlayerState,
+            ProofOfHuntError::NotInitialized,
+        );
+        state.position_x = x;
+        state.position_y = y;
+
+        let mut discovered_cells: u32 = get_instance_or_panic(
+            &env,
+            &DataKey::DiscoveredCells,
+            ProofOfHuntError::NotInitialized,
+        );
+        discovered_cells += 1;
+
+        if is_treasure {
+            state.score += 100;
+            state.discoveries += 1;
+        } else {
+            state.score += 5;
+            if state.health > 0 {
+                state.health -= 1;
+            }
+        }
+
+        let treasure_count: u32 = get_instance_or_panic(
+            &env,
+            &DataKey::TreasureCount,
+            ProofOfHuntError::NotInitialized,
+        );
+        let mut status = GameStatus::Active;
+        if state.discoveries >= treasure_count {
+            status = GameStatus::Won;
+        } else if state.health == 0 {
+            status = GameStatus::Lost;
+        }
+
+        env.storage().instance().set(&DataKey::PlayerState, &state);
+        env.storage()
+            .instance()
+            .set(&DataKey::DiscoveredCells, &discovered_cells);
+        env.storage().instance().set(&DataKey::Status, &status);
+        env.storage().persistent().set(&explored_key, &true);
+
+        env.events().publish(
+            (symbol_short!("explore"),),
+            (player, x, y, is_treasure, state.score, state.health),
+        );
+    }
+
+    pub fn purchase_hint(env: Env, player: Address, hint_type: u32) {
+        ensure_initialized(&env);
+        ensure_active(&env);
+
+        player.require_auth();
+        let stored_player: Address =
+            get_instance_or_panic(&env, &DataKey::Player, ProofOfHuntError::NotInitialized);
+        if player != stored_player {
+            panic_with_error!(&env, ProofOfHuntError::Unauthorized);
+        }
+
+        let cost = match hint_type {
+            0 => HINT_COST,
+            1 => SCAN_COST,
+            _ => panic_with_error!(&env, ProofOfHuntError::InvalidHintType),
+        };
+
+        let credit_key = DataKey::X402Credits(player.clone());
+        let credits: u32 = env.storage().persistent().get(&credit_key).unwrap_or(0);
+        if credits < cost {
+            panic_with_error!(&env, ProofOfHuntError::PaymentRequired);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&credit_key, &(credits - cost));
+
+        let mut usage: HintUsage =
+            get_instance_or_panic(&env, &DataKey::HintUsage, ProofOfHuntError::NotInitialized);
+        let mut state: PlayerState = get_instance_or_panic(
+            &env,
+            &DataKey::PlayerState,
+            ProofOfHuntError::NotInitialized,
+        );
+
+        if hint_type == 0 {
+            usage.hints_used += 1;
+            state.score += 3;
+        } else {
+            usage.scans_used += 1;
+            state.score += 1;
+        }
+
+        env.storage().instance().set(&DataKey::HintUsage, &usage);
+        env.storage().instance().set(&DataKey::PlayerState, &state);
+
+        env.events().publish(
+            (symbol_short!("hint"),),
+            (player, hint_type, cost, credits - cost),
+        );
+    }
+
+    pub fn get_state(env: Env) -> GameState {
+        ensure_initialized(&env);
+
+        let player: Address =
+            get_instance_or_panic(&env, &DataKey::Player, ProofOfHuntError::NotInitialized);
+        let player_state: PlayerState = get_instance_or_panic(
+            &env,
+            &DataKey::PlayerState,
+            ProofOfHuntError::NotInitialized,
+        );
+        let hint_usage: HintUsage =
+            get_instance_or_panic(&env, &DataKey::HintUsage, ProofOfHuntError::NotInitialized);
+
+        GameState {
+            player: player.clone(),
+            map_commitment: get_instance_or_panic(
+                &env,
+                &DataKey::MapCommitment,
+                ProofOfHuntError::NotInitialized,
+            ),
+            width: get_instance_or_panic(&env, &DataKey::Width, ProofOfHuntError::NotInitialized),
+            height: get_instance_or_panic(&env, &DataKey::Height, ProofOfHuntError::NotInitialized),
+            treasure_count: get_instance_or_panic(
+                &env,
+                &DataKey::TreasureCount,
+                ProofOfHuntError::NotInitialized,
+            ),
+            discovered_cells: get_instance_or_panic(
+                &env,
+                &DataKey::DiscoveredCells,
+                ProofOfHuntError::NotInitialized,
+            ),
+            status: get_instance_or_panic(&env, &DataKey::Status, ProofOfHuntError::NotInitialized),
+            player_state,
+            hint_usage,
+            x402_credits: env
+                .storage()
+                .persistent()
+                .get(&DataKey::X402Credits(player))
+                .unwrap_or(0),
+        }
+    }
+
+    pub fn is_finished(env: Env) -> bool {
+        ensure_initialized(&env);
+        let status: GameStatus =
+            get_instance_or_panic(&env, &DataKey::Status, ProofOfHuntError::NotInitialized);
+        status != GameStatus::Active
+    }
+}
+
+fn ensure_initialized(env: &Env) {
+    if !env.storage().instance().has(&DataKey::Owner) {
+        panic_with_error!(env, ProofOfHuntError::NotInitialized);
+    }
+}
+
+fn ensure_active(env: &Env) {
+    let status: GameStatus =
+        get_instance_or_panic(env, &DataKey::Status, ProofOfHuntError::NotInitialized);
+    if status != GameStatus::Active {
+        panic_with_error!(env, ProofOfHuntError::GameFinished);
+    }
+}
+
+fn get_instance_or_panic<T: soroban_sdk::TryFromVal<Env, soroban_sdk::Val>>(
+    env: &Env,
+    key: &DataKey,
+    error: ProofOfHuntError,
+) -> T {
+    match env.storage().instance().get::<DataKey, T>(key) {
+        Some(v) => v,
+        None => panic_with_error!(env, error),
+    }
+}
+
+fn hash_path(
+    env: &Env,
+    leaf: &BytesN<32>,
+    sibling: &BytesN<32>,
+    sibling_on_left: bool,
+) -> BytesN<32> {
+    let mut combined = Bytes::new(env);
+
+    if sibling_on_left {
+        append_bytesn32(env, &mut combined, sibling);
+        append_bytesn32(env, &mut combined, leaf);
+    } else {
+        append_bytesn32(env, &mut combined, leaf);
+        append_bytesn32(env, &mut combined, sibling);
+    }
+
+    env.crypto().sha256(&combined).into()
+}
+
+fn append_bytesn32(env: &Env, target: &mut Bytes, value: &BytesN<32>) {
+    for i in 0..32 {
+        target.push_back(
+            value
+                .get(i)
+                .unwrap_or_else(|| panic_with_error!(env, ProofOfHuntError::PublicInputMismatch)),
+        );
+    }
+}
+
+fn field_equals_bytesn32(field: &Bytes, value: &BytesN<32>) -> bool {
+    if field.len() != 32 {
+        return false;
+    }
+    for i in 0..32 {
+        if field.get(i).unwrap_or(255) != value.get(i).unwrap_or(254) {
+            return false;
+        }
+    }
+    true
+}
+
+fn read_u32_from_field(public_inputs: &Bytes, offset: u32) -> u32 {
+    let b0 = public_inputs.get(offset + 28).unwrap_or(0) as u32;
+    let b1 = public_inputs.get(offset + 29).unwrap_or(0) as u32;
+    let b2 = public_inputs.get(offset + 30).unwrap_or(0) as u32;
+    let b3 = public_inputs.get(offset + 31).unwrap_or(0) as u32;
+    (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+}
+
+fn default_vk(env: &Env, num_inputs: u32) -> Bytes {
+    // stellar-zk Groth16 verifier key format:
+    // alpha(64) | beta(128) | gamma(128) | delta(128) | ic_count(4) | ic[](64 each)
+    let mut vk = Bytes::new(env);
+
+    for _ in 0..(64 + 128 + 128 + 128) {
+        vk.push_back(0);
+    }
+
+    let ic_count = num_inputs + 1;
+    vk.push_back(((ic_count >> 24) & 0xFF) as u8);
+    vk.push_back(((ic_count >> 16) & 0xFF) as u8);
+    vk.push_back(((ic_count >> 8) & 0xFF) as u8);
+    vk.push_back((ic_count & 0xFF) as u8);
+
+    for _ in 0..(ic_count * 64) {
+        vk.push_back(0);
+    }
+
+    vk
+}
+
+fn validate_vk_shape(env: &Env, vk: &Bytes, expected_inputs: u32) {
+    if vk.len() < 452 {
+        panic_with_error!(env, ProofOfHuntError::InvalidVerificationKey);
+    }
+
+    let ic_count = decode_u32(vk, 448);
+    if ic_count != expected_inputs + 1 {
+        panic_with_error!(env, ProofOfHuntError::InvalidVerificationKey);
+    }
+
+    let required = 452 + (ic_count * 64);
+    if vk.len() < required {
+        panic_with_error!(env, ProofOfHuntError::InvalidVerificationKey);
+    }
+}
+
+fn decode_u32(bytes: &Bytes, offset: u32) -> u32 {
+    let b0 = bytes.get(offset).unwrap_or(0) as u32;
+    let b1 = bytes.get(offset + 1).unwrap_or(0) as u32;
+    let b2 = bytes.get(offset + 2).unwrap_or(0) as u32;
+    let b3 = bytes.get(offset + 3).unwrap_or(0) as u32;
+    (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+}
+
+fn verify_groth16(env: &Env, proof: &ProofInput) {
+    let nk = DataKey::Nullifier(proof.nullifier.clone());
+    if env.storage().persistent().has(&nk) {
+        panic_with_error!(env, ProofOfHuntError::NullifierAlreadyUsed);
+    }
+
+    let vk: Bytes = get_instance_or_panic(
+        env,
+        &DataKey::VerificationKey,
+        ProofOfHuntError::InvalidVerificationKey,
+    );
+    validate_vk_shape(env, &vk, 4);
+
+    let num_inputs = proof.public_inputs.len() / 32;
+    let ic_count = decode_u32(&vk, 448);
+    if num_inputs + 1 != ic_count {
+        panic_with_error!(env, ProofOfHuntError::InvalidPublicInputCount);
+    }
+
+    #[cfg(test)]
+    {
+        // CI-friendly deterministic path while still keeping the stellar-zk verifier logic in production.
+        if is_zero_proof(&proof.proof) {
+            env.storage().persistent().set(&nk, &true);
+            return;
+        }
+    }
+
+    let proof_bytes = Bytes::from_slice(env, &proof.proof.to_array());
+    let a_bytes = proof_bytes.slice(0..64);
+    let b_bytes = proof_bytes.slice(64..192);
+    let c_bytes = proof_bytes.slice(192..256);
+
+    let bn254 = env.crypto().bn254();
+
+    let a = Bn254G1Affine::from_bytes(bytesn_from_bytes::<64>(env, &a_bytes));
+    let b = Bn254G2Affine::from_bytes(bytesn_from_bytes::<128>(env, &b_bytes));
+    let c = Bn254G1Affine::from_bytes(bytesn_from_bytes::<64>(env, &c_bytes));
+
+    let alpha = Bn254G1Affine::from_bytes(bytesn_from_bytes::<64>(env, &vk.slice(0..64)));
+    let beta = Bn254G2Affine::from_bytes(bytesn_from_bytes::<128>(env, &vk.slice(64..192)));
+    let gamma = Bn254G2Affine::from_bytes(bytesn_from_bytes::<128>(env, &vk.slice(192..320)));
+    let delta = Bn254G2Affine::from_bytes(bytesn_from_bytes::<128>(env, &vk.slice(320..448)));
+
+    let ic_base = 452u32;
+    let mut vk_x = Bn254G1Affine::from_bytes(bytesn_from_bytes::<64>(
+        env,
+        &vk.slice(ic_base..(ic_base + 64)),
+    ));
+
+    for i in 0..num_inputs {
+        let input_offset = i * 32;
+        let fr = Fr::from_bytes(bytesn_from_bytes::<32>(
+            env,
+            &proof.public_inputs.slice(input_offset..(input_offset + 32)),
+        ));
+        let ic_offset = ic_base + ((i + 1) * 64);
+        let ic_point = Bn254G1Affine::from_bytes(bytesn_from_bytes::<64>(
+            env,
+            &vk.slice(ic_offset..(ic_offset + 64)),
+        ));
+        let term = bn254.g1_mul(&ic_point, &fr);
+        vk_x = bn254.g1_add(&vk_x, &term);
+    }
+
+    let neg_a = -a;
+
+    let g1_vec = Vec::from_array(env, [neg_a, alpha, vk_x, c]);
+    let g2_vec = Vec::from_array(env, [b, beta, gamma, delta]);
+
+    if !bn254.pairing_check(g1_vec, g2_vec) {
+        panic_with_error!(env, ProofOfHuntError::VerificationFailed);
+    }
+
+    env.storage().persistent().set(&nk, &true);
+}
+
+fn bytesn_from_bytes<const N: usize>(env: &Env, bytes: &Bytes) -> BytesN<N> {
+    BytesN::<N>::try_from_val(env, bytes.as_val())
+        .unwrap_or_else(|_| panic_with_error!(env, ProofOfHuntError::InvalidVerificationKey))
+}
+
+#[cfg(test)]
+fn is_zero_proof(proof: &BytesN<256>) -> bool {
+    for i in 0..256 {
+        if proof.get(i).unwrap_or(1) != 0 {
+            return false;
+        }
+    }
+    true
+}

--- a/examples/proof_of_hunt/src/test.rs
+++ b/examples/proof_of_hunt/src/test.rs
@@ -1,0 +1,205 @@
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Bytes, BytesN, Env};
+
+fn setup() -> (Env, ProofOfHuntContractClient<'static>, Address) {
+    let env = Env::default();
+    let contract_id = env.register(ProofOfHuntContract, ());
+    let client = ProofOfHuntContractClient::new(&env, &contract_id);
+    let player = Address::generate(&env);
+    (env, client, player)
+}
+
+fn append_u32_field(env: &Env, out: &mut Bytes, value: u32) {
+    for _ in 0..28 {
+        out.push_back(0);
+    }
+    let arr = value.to_be_bytes();
+    out.append(&Bytes::from_array(env, &arr));
+}
+
+fn hash_pair(env: &Env, left: &BytesN<32>, right: &BytesN<32>) -> BytesN<32> {
+    let mut bytes = Bytes::new(env);
+    for i in 0..32 {
+        bytes.push_back(left.get(i).unwrap());
+    }
+    for i in 0..32 {
+        bytes.push_back(right.get(i).unwrap());
+    }
+    env.crypto().sha256(&bytes).into()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn proof_input(
+    env: &Env,
+    root: &BytesN<32>,
+    x: u32,
+    y: u32,
+    is_treasure: bool,
+    leaf_hash: &BytesN<32>,
+    sibling_hash: &BytesN<32>,
+    sibling_on_left: bool,
+    nullifier_seed: u8,
+) -> ProofInput {
+    let mut public_inputs = Bytes::new(env);
+    append_u32_field(env, &mut public_inputs, if is_treasure { 1 } else { 0 });
+    append_u32_field(env, &mut public_inputs, x);
+    append_u32_field(env, &mut public_inputs, y);
+    for i in 0..32 {
+        public_inputs.push_back(root.get(i).unwrap());
+    }
+
+    ProofInput {
+        proof: BytesN::from_array(env, &[0u8; 256]),
+        public_inputs,
+        nullifier: BytesN::from_array(env, &[nullifier_seed; 32]),
+        leaf_hash: leaf_hash.clone(),
+        sibling_hash: sibling_hash.clone(),
+        sibling_on_left,
+    }
+}
+
+#[test]
+fn test_initialization() {
+    let (env, client, player) = setup();
+    env.mock_all_auths();
+
+    let leaf = BytesN::from_array(&env, &[7u8; 32]);
+    let sibling = BytesN::from_array(&env, &[9u8; 32]);
+    let root = hash_pair(&env, &leaf, &sibling);
+
+    client.init_game(&player, &root, &4, &4);
+
+    let state = client.get_state();
+    assert_eq!(state.player, player);
+    assert_eq!(state.map_commitment, root);
+    assert_eq!(state.width, 4);
+    assert_eq!(state.height, 4);
+    assert_eq!(state.player_state.health, MAX_HEALTH);
+    assert_eq!(state.status, GameStatus::Active);
+}
+
+#[test]
+fn test_valid_exploration_proof_acceptance() {
+    let (env, client, player) = setup();
+    env.mock_all_auths();
+
+    let leaf = BytesN::from_array(&env, &[5u8; 32]);
+    let sibling = BytesN::from_array(&env, &[6u8; 32]);
+    let root = hash_pair(&env, &leaf, &sibling);
+
+    client.init_game(&player, &root, &4, &4);
+
+    let proof = proof_input(&env, &root, 1, 2, true, &leaf, &sibling, false, 1);
+    client.explore(&player, &1, &2, &proof);
+
+    let state = client.get_state();
+    assert_eq!(state.player_state.position_x, 1);
+    assert_eq!(state.player_state.position_y, 2);
+    assert_eq!(state.player_state.discoveries, 1);
+    assert_eq!(state.discovered_cells, 1);
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_proof_rejection() {
+    let (env, client, player) = setup();
+    env.mock_all_auths();
+
+    let leaf = BytesN::from_array(&env, &[11u8; 32]);
+    let sibling = BytesN::from_array(&env, &[22u8; 32]);
+    let root = hash_pair(&env, &leaf, &sibling);
+
+    client.init_game(&player, &root, &4, &4);
+
+    let wrong_root = BytesN::from_array(&env, &[33u8; 32]);
+    let bad_proof = proof_input(&env, &wrong_root, 0, 0, false, &leaf, &sibling, false, 2);
+    client.explore(&player, &0, &0, &bad_proof);
+}
+
+#[test]
+fn test_progression_updates_after_valid_exploration() {
+    let (env, client, player) = setup();
+    env.mock_all_auths();
+
+    let leaf_a = BytesN::from_array(&env, &[1u8; 32]);
+    let sibling_a = BytesN::from_array(&env, &[2u8; 32]);
+    let root = hash_pair(&env, &leaf_a, &sibling_a);
+
+    client.init_game(&player, &root, &4, &4);
+
+    let p1 = proof_input(&env, &root, 0, 0, false, &leaf_a, &sibling_a, false, 3);
+    client.explore(&player, &0, &0, &p1);
+
+    let state_after = client.get_state();
+    assert_eq!(state_after.player_state.health, MAX_HEALTH - 1);
+    assert_eq!(state_after.player_state.score, 5);
+    assert_eq!(state_after.status, GameStatus::Active);
+}
+
+#[test]
+fn test_premium_hint_action_flow() {
+    let (env, client, player) = setup();
+    env.mock_all_auths();
+
+    let leaf = BytesN::from_array(&env, &[44u8; 32]);
+    let sibling = BytesN::from_array(&env, &[55u8; 32]);
+    let root = hash_pair(&env, &leaf, &sibling);
+
+    client.init_game(&player, &root, &4, &4);
+
+    let receipt = BytesN::from_array(&env, &[90u8; 32]);
+    client.credit_x402_payment(&player, &player, &3, &receipt);
+
+    client.purchase_hint(&player, &0);
+    client.purchase_hint(&player, &1);
+
+    let state = client.get_state();
+    assert_eq!(state.hint_usage.hints_used, 1);
+    assert_eq!(state.hint_usage.scans_used, 1);
+    assert_eq!(state.x402_credits, 0);
+}
+
+#[test]
+fn test_game_completion_condition() {
+    let (env, client, player) = setup();
+    env.mock_all_auths();
+
+    let leaf = BytesN::from_array(&env, &[101u8; 32]);
+    let sibling = BytesN::from_array(&env, &[102u8; 32]);
+    let root = hash_pair(&env, &leaf, &sibling);
+
+    client.init_game(&player, &root, &1, &1);
+
+    let p = proof_input(&env, &root, 0, 0, true, &leaf, &sibling, false, 10);
+    client.explore(&player, &0, &0, &p);
+
+    let state = client.get_state();
+    assert_eq!(state.status, GameStatus::Won);
+    assert!(client.is_finished());
+}
+
+#[test]
+fn test_failure_condition_on_health_depletion() {
+    let (env, client, player) = setup();
+    env.mock_all_auths();
+
+    let leaf = BytesN::from_array(&env, &[13u8; 32]);
+    let sibling = BytesN::from_array(&env, &[14u8; 32]);
+    let root = hash_pair(&env, &leaf, &sibling);
+
+    client.init_game(&player, &root, &2, &2);
+
+    let p1 = proof_input(&env, &root, 0, 0, false, &leaf, &sibling, false, 11);
+    client.explore(&player, &0, &0, &p1);
+
+    let p2 = proof_input(&env, &root, 1, 0, false, &leaf, &sibling, false, 12);
+    client.explore(&player, &1, &0, &p2);
+
+    let p3 = proof_input(&env, &root, 0, 1, false, &leaf, &sibling, false, 13);
+    client.explore(&player, &0, &1, &p3);
+
+    let state = client.get_state();
+    assert_eq!(state.player_state.health, 0);
+    assert_eq!(state.status, GameStatus::Lost);
+    assert!(client.is_finished());
+}


### PR DESCRIPTION
.Add standalone Soroban example at examples/proof_of_hunt
.Implement hidden-state exploration with committed off-chain map root
.Implement proof-oriented exploration verification using BN254 pairing flow aligned with stellar-zk verifier pattern
.Add x402-modeled premium hint/scan actions via credited payment units
.Add deterministic progression state (score, health, discoveries, active/won/lost)
.Add tests for init, valid/invalid proof flow, progression, premium actions, and completion/failure
.Add CI workflow for proof_of_hunt with fmt, clippy, tests, and stellar contract build command


clodse #78 