### PR TITLE
fix: resolve compile error and DefBuff logic in rpg_arena (#72)

### DIFF
--- a/.github/workflows/rpg_arena.yml
+++ b/.github/workflows/rpg_arena.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: examples/rpg_arena
@@ -40,7 +40,7 @@ jobs:
         run: cargo test
 
       - name: Install Stellar CLI
-        run: cargo install --locked stellar-cli || echo "stellar-cli cached"
+        run: brew install stellar-cli
 
       - name: Stellar Contract Build
         run: stellar contract build

--- a/.github/workflows/rpg_arena.yml
+++ b/.github/workflows/rpg_arena.yml
@@ -1,0 +1,46 @@
+name: RPG Arena Validation
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'examples/rpg_arena/**'
+      - '.github/workflows/rpg_arena.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'examples/rpg_arena/**'
+      - '.github/workflows/rpg_arena.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/rpg_arena
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+          components: rustfmt, clippy
+
+      - name: Cache Cargo Registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check Formatting
+        run: cargo fmt --check
+
+      - name: Clippy Warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Cargo Test
+        run: cargo test
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli || echo "stellar-cli cached"
+
+      - name: Stellar Contract Build
+        run: stellar contract build

--- a/examples/rpg_arena/Cargo.toml
+++ b/examples/rpg_arena/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "rpg_arena"
+version = "0.1.0"
+edition = "2021"
+description = "Turn-Based RPG Arena on-chain game using Cougr-Core ECS framework on Stellar Soroban"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "25.1.0"
+cougr-core = { path = "../../" }
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/examples/rpg_arena/README.md
+++ b/examples/rpg_arena/README.md
@@ -1,0 +1,16 @@
+# Turn-Based RPG Arena
+
+Cougr smart contract example implementing a compact, deterministic turn-based combat loop with status effects and cooldowns.
+Built to demonstrate a deterministic two-combatant battle using clean Cougr-style structure.
+
+## Validation Commands
+
+To build and run tests natively or against standard architectures, be aware that Soroban projects target `wasm32v1-none`. The following commands utilize `wasm32v1-none`.
+
+```bash
+cd examples/rpg_arena
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+stellar contract build
+```

--- a/examples/rpg_arena/src/lib.rs
+++ b/examples/rpg_arena/src/lib.rs
@@ -314,85 +314,85 @@ impl RPGArenaContract {
     }
 
     fn damage_resolution_system(
-        env: &Env,
+        _env: &Env,
         world: &mut ECSWorldState,
         player: &Address,
         action: &Action,
     ) {
         let is_p1 = *player == world.player_one;
 
-        let (
-            attacker_stats,
-            defender_stats,
-            defender_statuses,
-            attacker_statuses,
-            attacker_cooldowns,
-        ) = if is_p1 {
-            (
-                &mut world.p1_combatant,
-                &mut world.p2_combatant,
-                &mut world.p2_statuses,
-                &mut world.p1_statuses,
-                &mut world.p1_cooldowns,
-            )
-        } else {
-            (
-                &mut world.p2_combatant,
-                &mut world.p1_combatant,
-                &mut world.p1_statuses,
-                &mut world.p2_statuses,
-                &mut world.p2_cooldowns,
-            )
-        };
-
-        // Determine effective defense (base + DefBuff)
-        let mut def = defender_stats.defense;
-        for i in 0..defender_statuses.len() {
-            let st = defender_statuses.get(i).unwrap();
-            if st.effect_kind == 2 {
-                // DefBuff
-                def += st.magnitude;
+        // Determine effective defense (base + active DefBuff on the defender).
+        // Reads are done before any mutable borrows to keep borrow scopes non-overlapping.
+        let effective_def = {
+            let base = if is_p1 {
+                world.p2_combatant.defense
+            } else {
+                world.p1_combatant.defense
+            };
+            let defender_statuses = if is_p1 {
+                &world.p2_statuses
+            } else {
+                &world.p1_statuses
+            };
+            let mut def = base;
+            for i in 0..defender_statuses.len() {
+                let st = defender_statuses.get(i).unwrap();
+                if st.effect_kind == 2 {
+                    def += st.magnitude;
+                }
             }
-        }
+            def
+        };
 
         match action {
             Action::Attack => {
-                let dmg = 15u32.saturating_sub(def);
-                defender_stats.hp = defender_stats.hp.saturating_sub(dmg);
+                let dmg = 15u32.saturating_sub(effective_def);
+                if is_p1 {
+                    world.p2_combatant.hp = world.p2_combatant.hp.saturating_sub(dmg);
+                } else {
+                    world.p1_combatant.hp = world.p1_combatant.hp.saturating_sub(dmg);
+                }
             }
             Action::Defend => {
-                // Apply a DefBuff for 1 turn
-                let mut buff_id = world.next_entity_id;
-                world.next_entity_id += 1;
-                attacker_statuses.push_back(StatusEffectComponent {
+                // duration: 2 so the buff survives the end-of-turn status tick and
+                // is still active when the opponent resolves their next attack.
+                let buff = StatusEffectComponent {
                     effect_kind: 2,
-                    duration: 1, // Will apply to incoming damage this turn / next turn
+                    duration: 2,
                     magnitude: 10,
-                    entity_id: buff_id,
-                });
+                    entity_id: world.next_entity_id,
+                };
+                world.next_entity_id += 1;
+                if is_p1 {
+                    world.p1_statuses.push_back(buff);
+                } else {
+                    world.p2_statuses.push_back(buff);
+                }
             }
             Action::Special => {
-                let dmg = 25u32.saturating_sub(def);
-                defender_stats.hp = defender_stats.hp.saturating_sub(dmg);
-
-                // Add poison status
-                let mut psn_id = world.next_entity_id;
-                world.next_entity_id += 1;
-                defender_statuses.push_back(StatusEffectComponent {
+                let dmg = 25u32.saturating_sub(effective_def);
+                let poison = StatusEffectComponent {
                     effect_kind: 1,
                     duration: 3,
                     magnitude: 5,
-                    entity_id: psn_id,
-                });
-
-                // Add cooldown
-                let mut cd_id = world.next_entity_id;
+                    entity_id: world.next_entity_id,
+                };
                 world.next_entity_id += 1;
-                attacker_cooldowns.push_back(CooldownComponent {
+                let cooldown = CooldownComponent {
                     action_kind: 1,
                     remaining_turns: 3,
-                    entity_id: cd_id,
-                });
+                    entity_id: world.next_entity_id,
+                };
+                world.next_entity_id += 1;
+                if is_p1 {
+                    world.p2_combatant.hp = world.p2_combatant.hp.saturating_sub(dmg);
+                    world.p2_statuses.push_back(poison);
+                    world.p1_cooldowns.push_back(cooldown);
+                } else {
+                    world.p1_combatant.hp = world.p1_combatant.hp.saturating_sub(dmg);
+                    world.p1_statuses.push_back(poison);
+                    world.p2_cooldowns.push_back(cooldown);
+                }
             }
         }
     }

--- a/examples/rpg_arena/src/lib.rs
+++ b/examples/rpg_arena/src/lib.rs
@@ -214,7 +214,15 @@ impl RPGArenaContract {
         // System 1: Action Validation System
         let val = Self::action_validation_system(&world, &player, &action);
         if !val.0 {
-            panic!("Invalid action: {:?}", val.1);
+            if val.1 == symbol_short!("notturn") {
+                panic!("notturn");
+            } else if val.1 == symbol_short!("cooldown") {
+                panic!("cooldown");
+            } else if val.1 == symbol_short!("gameover") {
+                panic!("gameover");
+            } else {
+                panic!("invalid");
+            }
         }
 
         // System 2 & 3: Damage Resolution & Status Application System

--- a/examples/rpg_arena/src/lib.rs
+++ b/examples/rpg_arena/src/lib.rs
@@ -1,0 +1,486 @@
+#![no_std]
+
+use cougr_core::component::ComponentTrait;
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Symbol, Vec,
+};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Action {
+    Attack,
+    Defend,
+    Special,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CombatantComponent {
+    pub hp: u32,
+    pub defense: u32,
+    pub speed: u32,
+    pub entity_id: u32,
+}
+
+impl ComponentTrait for CombatantComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("combnnt")
+    }
+    fn serialize(&self, env: &Env) -> Bytes {
+        Bytes::new(env)
+    }
+    fn deserialize(_env: &Env, _data: &Bytes) -> Option<Self> {
+        None
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StatusEffectComponent {
+    pub effect_kind: u32, // 1 = Poison, 2 = DefenseBuff
+    pub duration: u32,
+    pub magnitude: u32,
+    pub entity_id: u32,
+}
+
+impl ComponentTrait for StatusEffectComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("status")
+    }
+    fn serialize(&self, env: &Env) -> Bytes {
+        Bytes::new(env)
+    }
+    fn deserialize(_env: &Env, _data: &Bytes) -> Option<Self> {
+        None
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CooldownComponent {
+    pub action_kind: u32, // 1 = Special
+    pub remaining_turns: u32,
+    pub entity_id: u32,
+}
+
+impl ComponentTrait for CooldownComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("cooldown")
+    }
+    fn serialize(&self, env: &Env) -> Bytes {
+        Bytes::new(env)
+    }
+    fn deserialize(_env: &Env, _data: &Bytes) -> Option<Self> {
+        None
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TurnComponent {
+    pub current_actor: Address,
+    pub round: u32,
+    pub entity_id: u32,
+}
+
+impl ComponentTrait for TurnComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("turn")
+    }
+    fn serialize(&self, env: &Env) -> Bytes {
+        Bytes::new(env)
+    }
+    fn deserialize(_env: &Env, _data: &Bytes) -> Option<Self> {
+        None
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BattleStatusComponent {
+    pub status: u32, // 0 = Ongoing, 1 = PlayerOneWins, 2 = PlayerTwoWins, 3 = Draw
+    pub entity_id: u32,
+}
+
+impl ComponentTrait for BattleStatusComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("bstatus")
+    }
+    fn serialize(&self, env: &Env) -> Bytes {
+        Bytes::new(env)
+    }
+    fn deserialize(_env: &Env, _data: &Bytes) -> Option<Self> {
+        None
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ECSWorldState {
+    pub player_one: Address,
+    pub player_two: Address,
+
+    pub p1_combatant: CombatantComponent,
+    pub p2_combatant: CombatantComponent,
+
+    pub p1_statuses: Vec<StatusEffectComponent>,
+    pub p2_statuses: Vec<StatusEffectComponent>,
+
+    pub p1_cooldowns: Vec<CooldownComponent>,
+    pub p2_cooldowns: Vec<CooldownComponent>,
+
+    pub turn: TurnComponent,
+    pub battle_status: BattleStatusComponent,
+
+    pub next_entity_id: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BattleState {
+    pub p1_hp: u32,
+    pub p2_hp: u32,
+    pub current_turn: Address,
+    pub status: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CombatantState {
+    pub hp: u32,
+    pub defense: u32,
+    pub status_count: u32,
+    pub cooldown_count: u32,
+}
+
+const WORLD_KEY: Symbol = symbol_short!("WORLD");
+
+#[contract]
+pub struct RPGArenaContract;
+
+#[contractimpl]
+impl RPGArenaContract {
+    pub fn init_battle(env: Env, player_one: Address, player_two: Address) {
+        let mut next_entity_id = 0u32;
+
+        let p1_combatant = CombatantComponent {
+            hp: 100,
+            defense: 5,
+            speed: 10,
+            entity_id: next_entity_id,
+        };
+        next_entity_id += 1;
+        let p2_combatant = CombatantComponent {
+            hp: 100,
+            defense: 5,
+            speed: 10,
+            entity_id: next_entity_id,
+        };
+        next_entity_id += 1;
+
+        let turn = TurnComponent {
+            current_actor: player_one.clone(),
+            round: 1,
+            entity_id: next_entity_id,
+        };
+        next_entity_id += 1;
+
+        let battle_status = BattleStatusComponent {
+            status: 0,
+            entity_id: next_entity_id,
+        };
+        next_entity_id += 1;
+
+        let world_state = ECSWorldState {
+            player_one: player_one.clone(),
+            player_two: player_two.clone(),
+            p1_combatant,
+            p2_combatant,
+            p1_statuses: Vec::new(&env),
+            p2_statuses: Vec::new(&env),
+            p1_cooldowns: Vec::new(&env),
+            p2_cooldowns: Vec::new(&env),
+            turn,
+            battle_status,
+            next_entity_id,
+        };
+
+        env.storage().instance().set(&WORLD_KEY, &world_state);
+    }
+
+    pub fn submit_action(env: Env, player: Address, action: Action) {
+        let mut world: ECSWorldState = env.storage().instance().get(&WORLD_KEY).unwrap();
+
+        // System 1: Action Validation System
+        let val = Self::action_validation_system(&world, &player, &action);
+        if !val.0 {
+            panic!("Invalid action: {:?}", val.1);
+        }
+
+        // System 2 & 3: Damage Resolution & Status Application System
+        Self::damage_resolution_system(&env, &mut world, &player, &action);
+
+        // System 4: End Condition System (Check immediate impact)
+        Self::end_condition_system(&mut world);
+
+        if world.battle_status.status == 0 {
+            // System 5: Status Effect System (Apply poison, decrement status turns)
+            Self::status_effect_system(&env, &mut world);
+
+            // System 6: Cooldown System (Decrement cooldowns)
+            Self::cooldown_system(&env, &mut world);
+
+            // Turn Advance
+            Self::turn_advance_system(&mut world);
+
+            // Recheck End Condition after status effect (like poison damage)
+            Self::end_condition_system(&mut world);
+        }
+
+        env.storage().instance().set(&WORLD_KEY, &world);
+    }
+
+    pub fn get_state(env: Env) -> BattleState {
+        let world: ECSWorldState = env.storage().instance().get(&WORLD_KEY).unwrap();
+        Self::to_battle_state(&world)
+    }
+
+    pub fn get_combatant(env: Env, player: Address) -> CombatantState {
+        let world: ECSWorldState = env.storage().instance().get(&WORLD_KEY).unwrap();
+        if player == world.player_one {
+            CombatantState {
+                hp: world.p1_combatant.hp,
+                defense: world.p1_combatant.defense,
+                status_count: world.p1_statuses.len(),
+                cooldown_count: world.p1_cooldowns.len(),
+            }
+        } else if player == world.player_two {
+            CombatantState {
+                hp: world.p2_combatant.hp,
+                defense: world.p2_combatant.defense,
+                status_count: world.p2_statuses.len(),
+                cooldown_count: world.p2_cooldowns.len(),
+            }
+        } else {
+            panic!("Unknown player");
+        }
+    }
+
+    pub fn is_finished(env: Env) -> bool {
+        let world: ECSWorldState = env.storage().instance().get(&WORLD_KEY).unwrap();
+        world.battle_status.status != 0
+    }
+
+    // --- Systems ---
+
+    fn action_validation_system(
+        world: &ECSWorldState,
+        player: &Address,
+        action: &Action,
+    ) -> (bool, Symbol) {
+        if world.battle_status.status != 0 {
+            return (false, symbol_short!("gameover"));
+        }
+        if world.turn.current_actor != *player {
+            return (false, symbol_short!("notturn"));
+        }
+
+        // Check cooldowns
+        let is_p1 = *player == world.player_one;
+        let cooldowns = if is_p1 {
+            &world.p1_cooldowns
+        } else {
+            &world.p2_cooldowns
+        };
+
+        if *action == Action::Special {
+            for i in 0..cooldowns.len() {
+                let cd = cooldowns.get(i).unwrap();
+                if cd.action_kind == 1 && cd.remaining_turns > 0 {
+                    return (false, symbol_short!("cooldown"));
+                }
+            }
+        }
+
+        (true, symbol_short!("ok"))
+    }
+
+    fn damage_resolution_system(
+        env: &Env,
+        world: &mut ECSWorldState,
+        player: &Address,
+        action: &Action,
+    ) {
+        let is_p1 = *player == world.player_one;
+
+        let (
+            attacker_stats,
+            defender_stats,
+            defender_statuses,
+            attacker_statuses,
+            attacker_cooldowns,
+        ) = if is_p1 {
+            (
+                &mut world.p1_combatant,
+                &mut world.p2_combatant,
+                &mut world.p2_statuses,
+                &mut world.p1_statuses,
+                &mut world.p1_cooldowns,
+            )
+        } else {
+            (
+                &mut world.p2_combatant,
+                &mut world.p1_combatant,
+                &mut world.p1_statuses,
+                &mut world.p2_statuses,
+                &mut world.p2_cooldowns,
+            )
+        };
+
+        // Determine effective defense (base + DefBuff)
+        let mut def = defender_stats.defense;
+        for i in 0..defender_statuses.len() {
+            let st = defender_statuses.get(i).unwrap();
+            if st.effect_kind == 2 {
+                // DefBuff
+                def += st.magnitude;
+            }
+        }
+
+        match action {
+            Action::Attack => {
+                let dmg = 15u32.saturating_sub(def);
+                defender_stats.hp = defender_stats.hp.saturating_sub(dmg);
+            }
+            Action::Defend => {
+                // Apply a DefBuff for 1 turn
+                let mut buff_id = world.next_entity_id;
+                world.next_entity_id += 1;
+                attacker_statuses.push_back(StatusEffectComponent {
+                    effect_kind: 2,
+                    duration: 1, // Will apply to incoming damage this turn / next turn
+                    magnitude: 10,
+                    entity_id: buff_id,
+                });
+            }
+            Action::Special => {
+                let dmg = 25u32.saturating_sub(def);
+                defender_stats.hp = defender_stats.hp.saturating_sub(dmg);
+
+                // Add poison status
+                let mut psn_id = world.next_entity_id;
+                world.next_entity_id += 1;
+                defender_statuses.push_back(StatusEffectComponent {
+                    effect_kind: 1,
+                    duration: 3,
+                    magnitude: 5,
+                    entity_id: psn_id,
+                });
+
+                // Add cooldown
+                let mut cd_id = world.next_entity_id;
+                world.next_entity_id += 1;
+                attacker_cooldowns.push_back(CooldownComponent {
+                    action_kind: 1,
+                    remaining_turns: 3,
+                    entity_id: cd_id,
+                });
+            }
+        }
+    }
+
+    fn status_effect_system(env: &Env, world: &mut ECSWorldState) {
+        // Apply end-of-turn status impacts (e.g. Poison) to both players
+        // Actually, normally statuses are resolved exactly for the player whose turn it just ended,
+        // to not double-tick. Let's do it for the current actor.
+        let is_p1 = world.turn.current_actor == world.player_one;
+
+        let mut updated_statuses = Vec::new(env);
+
+        if is_p1 {
+            for i in 0..world.p1_statuses.len() {
+                let mut st = world.p1_statuses.get(i).unwrap();
+                if st.effect_kind == 1 {
+                    // Poison
+                    world.p1_combatant.hp = world.p1_combatant.hp.saturating_sub(st.magnitude);
+                }
+                if st.duration > 1 {
+                    st.duration -= 1;
+                    updated_statuses.push_back(st);
+                }
+            }
+            world.p1_statuses = updated_statuses;
+        } else {
+            for i in 0..world.p2_statuses.len() {
+                let mut st = world.p2_statuses.get(i).unwrap();
+                if st.effect_kind == 1 {
+                    // Poison
+                    world.p2_combatant.hp = world.p2_combatant.hp.saturating_sub(st.magnitude);
+                }
+                if st.duration > 1 {
+                    st.duration -= 1;
+                    updated_statuses.push_back(st);
+                }
+            }
+            world.p2_statuses = updated_statuses;
+        }
+    }
+
+    fn cooldown_system(env: &Env, world: &mut ECSWorldState) {
+        // Decrement cooldowns for current actor
+        let is_p1 = world.turn.current_actor == world.player_one;
+        let mut updated_cds = Vec::new(env);
+
+        if is_p1 {
+            for i in 0..world.p1_cooldowns.len() {
+                let mut cd = world.p1_cooldowns.get(i).unwrap();
+                if cd.remaining_turns > 1 {
+                    cd.remaining_turns -= 1;
+                    updated_cds.push_back(cd);
+                }
+            }
+            world.p1_cooldowns = updated_cds;
+        } else {
+            for i in 0..world.p2_cooldowns.len() {
+                let mut cd = world.p2_cooldowns.get(i).unwrap();
+                if cd.remaining_turns > 1 {
+                    cd.remaining_turns -= 1;
+                    updated_cds.push_back(cd);
+                }
+            }
+            world.p2_cooldowns = updated_cds;
+        }
+    }
+
+    fn end_condition_system(world: &mut ECSWorldState) {
+        if world.p1_combatant.hp == 0 && world.p2_combatant.hp == 0 {
+            world.battle_status.status = 3; // Draw
+        } else if world.p2_combatant.hp == 0 {
+            world.battle_status.status = 1; // P1 wins
+        } else if world.p1_combatant.hp == 0 {
+            world.battle_status.status = 2; // P2 wins
+        }
+    }
+
+    fn turn_advance_system(world: &mut ECSWorldState) {
+        if world.turn.current_actor == world.player_one {
+            world.turn.current_actor = world.player_two.clone();
+        } else {
+            world.turn.current_actor = world.player_one.clone();
+            world.turn.round += 1;
+        }
+    }
+
+    // --- Helpers ---
+    fn to_battle_state(world: &ECSWorldState) -> BattleState {
+        BattleState {
+            p1_hp: world.p1_combatant.hp,
+            p2_hp: world.p2_combatant.hp,
+            current_turn: world.turn.current_actor.clone(),
+            status: world.battle_status.status,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/examples/rpg_arena/src/test.rs
+++ b/examples/rpg_arena/src/test.rs
@@ -1,13 +1,13 @@
 #![cfg(test)]
 
-use crate::{Action, BattleState, CombatantState, RPGArenaContract, RPGArenaContractClient};
+use crate::{Action, RPGArenaContract, RPGArenaContractClient};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
-fn setup_game(env: &Env) -> (RPGArenaContractClient, Address, Address) {
-    let contract_id = env.register_contract(None, RPGArenaContract);
-    let client = RPGArenaContractClient::new(&env, &contract_id);
-    let p1 = Address::generate(&env);
-    let p2 = Address::generate(&env);
+fn setup_game(env: &Env) -> (RPGArenaContractClient<'_>, Address, Address) {
+    let contract_id = env.register(RPGArenaContract, ());
+    let client = RPGArenaContractClient::new(env, &contract_id);
+    let p1 = Address::generate(env);
+    let p2 = Address::generate(env);
     (client, p1, p2)
 }
 
@@ -23,7 +23,7 @@ fn test_initialization() {
     assert_eq!(state.p2_hp, 100);
     assert_eq!(state.current_turn, p1);
     assert_eq!(state.status, 0); // Ongoing
-    assert_eq!(client.is_finished(), false);
+    assert!(!client.is_finished());
 
     let p1_state = client.get_combatant(&p1);
     assert_eq!(p1_state.hp, 100);
@@ -161,7 +161,7 @@ fn test_battle_completion() {
     let state = client.get_state();
     assert_eq!(state.p2_hp, 0);
     assert_eq!(state.status, 1); // P1 wins
-    assert_eq!(client.is_finished(), true);
+    assert!(client.is_finished());
 
     // Further actions should be rejected with panic
     client.submit_action(&p1, &Action::Attack);

--- a/examples/rpg_arena/src/test.rs
+++ b/examples/rpg_arena/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
-use crate::{RPGArenaContract, RPGArenaContractClient, Action, BattleState, CombatantState};
-use soroban_sdk::{Env, Address, testutils::Address as _};
+use crate::{Action, BattleState, CombatantState, RPGArenaContract, RPGArenaContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
 
 fn setup_game(env: &Env) -> (RPGArenaContractClient, Address, Address) {
     let contract_id = env.register_contract(None, RPGArenaContract);
@@ -18,7 +18,7 @@ fn test_initialization() {
 
     client.init_battle(&p1, &p2);
     let state = client.get_state();
-    
+
     assert_eq!(state.p1_hp, 100);
     assert_eq!(state.p2_hp, 100);
     assert_eq!(state.current_turn, p1);
@@ -55,7 +55,7 @@ fn test_defend_interaction() {
 
     // P1 defends
     client.submit_action(&p1, &Action::Defend);
-    
+
     // P2 attacks P1
     client.submit_action(&p2, &Action::Attack);
 
@@ -75,9 +75,9 @@ fn test_special_ability_and_cooldown() {
 
     // P1 uses Special
     client.submit_action(&p1, &Action::Special);
-    
+
     let state = client.get_state();
-    assert_eq!(state.p2_hp, 80); 
+    assert_eq!(state.p2_hp, 80);
 
     // P2 attacks normally
     client.submit_action(&p2, &Action::Attack);
@@ -94,7 +94,7 @@ fn test_status_effect_application_and_expiration() {
 
     client.submit_action(&p1, &Action::Special);
     // P2 HP = 80 now
-    
+
     // P2 attacks (P2's turn, status_effect_system runs for P2 at the end of their turn)
     client.submit_action(&p2, &Action::Attack);
     // P2 was poisoned. Damage is 5. So P2 HP = 80 - 5 = 75.
@@ -157,7 +157,7 @@ fn test_battle_completion() {
         // P2 attacks
         client.submit_action(&p2, &Action::Attack);
     }
-    
+
     let state = client.get_state();
     assert_eq!(state.p2_hp, 0);
     assert_eq!(state.status, 1); // P1 wins

--- a/examples/rpg_arena/src/test.rs
+++ b/examples/rpg_arena/src/test.rs
@@ -1,0 +1,168 @@
+#![cfg(test)]
+
+use crate::{RPGArenaContract, RPGArenaContractClient, Action, BattleState, CombatantState};
+use soroban_sdk::{Env, Address, testutils::Address as _};
+
+fn setup_game(env: &Env) -> (RPGArenaContractClient, Address, Address) {
+    let contract_id = env.register_contract(None, RPGArenaContract);
+    let client = RPGArenaContractClient::new(&env, &contract_id);
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+    (client, p1, p2)
+}
+
+#[test]
+fn test_initialization() {
+    let env = Env::default();
+    let (client, p1, p2) = setup_game(&env);
+
+    client.init_battle(&p1, &p2);
+    let state = client.get_state();
+    
+    assert_eq!(state.p1_hp, 100);
+    assert_eq!(state.p2_hp, 100);
+    assert_eq!(state.current_turn, p1);
+    assert_eq!(state.status, 0); // Ongoing
+    assert_eq!(client.is_finished(), false);
+
+    let p1_state = client.get_combatant(&p1);
+    assert_eq!(p1_state.hp, 100);
+    assert_eq!(p1_state.defense, 5);
+    assert_eq!(p1_state.status_count, 0);
+    assert_eq!(p1_state.cooldown_count, 0);
+}
+
+#[test]
+fn test_basic_attack() {
+    let env = Env::default();
+    let (client, p1, p2) = setup_game(&env);
+    client.init_battle(&p1, &p2);
+
+    client.submit_action(&p1, &Action::Attack);
+
+    let state = client.get_state();
+    assert_eq!(state.p1_hp, 100);
+    // Base attack is 15 dmg - 5 def = 10 damage
+    assert_eq!(state.p2_hp, 90);
+    assert_eq!(state.current_turn, p2);
+}
+
+#[test]
+fn test_defend_interaction() {
+    let env = Env::default();
+    let (client, p1, p2) = setup_game(&env);
+    client.init_battle(&p1, &p2);
+
+    // P1 defends
+    client.submit_action(&p1, &Action::Defend);
+    
+    // P2 attacks P1
+    client.submit_action(&p2, &Action::Attack);
+
+    let state = client.get_state();
+    // P1 took 0 damage
+    assert_eq!(state.p1_hp, 100);
+    assert_eq!(state.p2_hp, 100);
+    assert_eq!(state.current_turn, p1);
+}
+
+#[test]
+#[should_panic(expected = "cooldown")]
+fn test_special_ability_and_cooldown() {
+    let env = Env::default();
+    let (client, p1, p2) = setup_game(&env);
+    client.init_battle(&p1, &p2);
+
+    // P1 uses Special
+    client.submit_action(&p1, &Action::Special);
+    
+    let state = client.get_state();
+    assert_eq!(state.p2_hp, 80); 
+
+    // P2 attacks normally
+    client.submit_action(&p2, &Action::Attack);
+
+    // P1 tries to Special again, should fail with panic
+    client.submit_action(&p1, &Action::Special);
+}
+
+#[test]
+fn test_status_effect_application_and_expiration() {
+    let env = Env::default();
+    let (client, p1, p2) = setup_game(&env);
+    client.init_battle(&p1, &p2);
+
+    client.submit_action(&p1, &Action::Special);
+    // P2 HP = 80 now
+    
+    // P2 attacks (P2's turn, status_effect_system runs for P2 at the end of their turn)
+    client.submit_action(&p2, &Action::Attack);
+    // P2 was poisoned. Damage is 5. So P2 HP = 80 - 5 = 75.
+    let state = client.get_state();
+    assert_eq!(state.p2_hp, 75);
+
+    // P1 attacks
+    client.submit_action(&p1, &Action::Attack);
+    // P2 HP = 75 - 10 = 65
+
+    // P2 attacks
+    client.submit_action(&p2, &Action::Attack);
+    // P2 takes poison damage again (2nd tick) -> 65 - 5 = 60
+    assert_eq!(client.get_state().p2_hp, 60);
+
+    // P1 attacks
+    client.submit_action(&p1, &Action::Attack);
+    // P2 HP = 60 - 10 = 50
+
+    // P2 attacks
+    client.submit_action(&p2, &Action::Attack);
+    // P2 takes poison damage again (3rd tick) -> 50 - 5 = 45
+    assert_eq!(client.get_state().p2_hp, 45);
+
+    // P1 attacks
+    client.submit_action(&p1, &Action::Attack);
+    // P2 HP = 45 - 10 = 35
+
+    // P2 attacks
+    client.submit_action(&p2, &Action::Attack);
+    // Poison expired! No damage. Check HP:
+    assert_eq!(client.get_state().p2_hp, 35);
+}
+
+#[test]
+#[should_panic(expected = "notturn")]
+fn test_wrong_turn_rejection() {
+    let env = Env::default();
+    let (client, p1, p2) = setup_game(&env);
+    client.init_battle(&p1, &p2);
+
+    // Should panic since it's P1's turn
+    client.submit_action(&p2, &Action::Attack);
+}
+
+#[test]
+#[should_panic(expected = "gameover")]
+fn test_battle_completion() {
+    let env = Env::default();
+    let (client, p1, p2) = setup_game(&env);
+    client.init_battle(&p1, &p2);
+
+    // Bring P2 to 0 hp
+    for _ in 0..10 {
+        // P1 attacks
+        client.submit_action(&p1, &Action::Attack);
+        if client.is_finished() {
+            break;
+        }
+        // P2 attacks
+        client.submit_action(&p2, &Action::Attack);
+    }
+    
+    let state = client.get_state();
+    assert_eq!(state.p2_hp, 0);
+    assert_eq!(state.status, 1); // P1 wins
+    assert_eq!(client.is_finished(), true);
+
+    // Further actions should be rejected with panic
+    client.submit_action(&p1, &Action::Attack);
+}


### PR DESCRIPTION
## Summary

- Removes conditional split borrow pattern in `damage_resolution_system` that caused
  a borrow checker compile error. The original code took mutable references to five
  `world` fields via an `if/else` expression, then accessed `world.next_entity_id`
  while those borrows were still live. Rust cannot prove a conditional borrow does not
  alias an unrelated field and rejects the access. Fixed by routing each field access
  individually using the `is_p1` flag, keeping every borrow strictly scoped and
  non-overlapping.

- Fixes DefBuff duration from `1` to `2`. With `duration: 1` the buff was added during
  the defender's Defend action and immediately dropped by `status_effect_system` at the
  end of the same turn (`if st.duration > 1` fails for duration=1), leaving no
  protection when the opponent attacked next. Changing to `duration: 2` lets the buff
  survive one end-of-turn tick (2→1), remain active when the opponent resolves damage,
  and expire on the defender's following turn. This makes `test_defend_interaction` pass.

- Removes unnecessary `mut` on `buff_id`, `psn_id`, and `cd_id` locals. These
  variables were declared `mut` but never modified after assignment. With
  `cargo clippy -- -D warnings` (the CI command) the `unused_mut` lint is promoted to
  an error, causing CI failure. These intermediate variables are eliminated entirely in
  the restructured function.

## Test Plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test` passes — all 7 tests: `test_initialization`, `test_basic_attack`,
      `test_defend_interaction`, `test_special_ability_and_cooldown`,
      `test_status_effect_application_and_expiration`, `test_wrong_turn_rejection`,
      `test_battle_completion`
- [ ] `stellar contract build` passes

Closes #72
```