### PR TITLE
[chore] add reusable standards layer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,8 +8,8 @@ High-level overview of how Cougr is organized. For usage, see [README.md](README
 ┌─────────────────────────────────────────────┐
 │              GameWorld                       │  Unified API: ECS + Auth + ZK
 ├───────────┬───────────────┬─────────────────┤
-│  ECS      │  Accounts     │  ZK Proofs      │
-├───────────┼───────────────┼─────────────────┤
+│  ECS      │  Accounts     │  Standards      │  ZK Proofs
+├───────────┼───────────────┼─────────────────┼─────────────────┤
 │  soroban-sdk 25.1.0  (no_std, WASM)         │
 └─────────────────────────────────────────────┘
 ```
@@ -71,6 +71,20 @@ CougrAccount (trait)
 Key traits: `CougrAccount`, `SessionKeyProvider`, `RecoveryProvider`, `MultiDeviceProvider`.
 
 `SessionBuilder` provides a fluent API for constructing scoped session keys. `authorize_with_fallback` handles graceful degradation from session keys to direct authorization.
+
+## Standards (`src/standards/`)
+
+Reusable contract standards for integrations that need explicit operational controls:
+
+- `Ownable` and `Ownable2Step` for owner-managed authority
+- `AccessControl` for role-based authorization with delegated admins
+- `Pausable` for emergency stops
+- `ExecutionGuard` for serialized critical sections
+- `RecoveryGuard` for blocking sensitive paths during recovery windows
+- `BatchExecutor` for bounded multi-operation flows
+- `DelayedExecutionPolicy` for time-delayed operation queues
+
+Each standard instance is keyed by a caller-supplied `Symbol`, which keeps storage deterministic and avoids collisions when a contract composes multiple modules.
 
 ## Feature Flags
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cougr-core"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "soroban-sdk",
  "wee_alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cougr-core"
-version = "0.3.0"
+version = "0.5.0"
 edition = "2021"
 description = "Cougr - A Soroban-compatible ECS framework for on-chain gaming on Stellar"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Current maturity baseline:
 |---|---|
 | ECS runtime and storage | Beta |
 | Accounts and smart-account patterns | Beta |
+| Standards layer (`standards`) | Beta |
 | Privacy primitives (`zk::stable`) | Stable |
 | Advanced ZK verification and confidential abstractions | Experimental |
 
@@ -38,6 +39,7 @@ Current maturity baseline:
 | ECS | Typed components, multiple world implementations, scheduling, deferred commands, hooks, observers, and change tracking |
 | Zero-knowledge tooling | Groth16 verification, curve helpers, commitments, Merkle structures, reusable circuits, and ECS-integrated proof flows |
 | Smart account patterns | Session keys, social recovery, multi-device authorization, and fallback authorization flows |
+| Contract standards | Ownable, Ownable2Step, AccessControl, Pausable, execution guards, recovery guards, delayed execution, and batch primitives |
 | Example contracts | 20+ example game projects and growing, each intended to show concrete patterns rather than isolated snippets |
 
 ## Quick Start
@@ -91,6 +93,16 @@ let pos: Position = world.get_typed(&env, player).unwrap();
 | Multi-device usage | Per-device policies and device-scoped access control |
 | Fallback authorization | Graceful degradation from advanced auth flows to direct authorization |
 
+### Standards Layer
+
+| Capability | Description |
+|---|---|
+| `Ownable` and `Ownable2Step` | Owner-based authority with direct and staged transfers |
+| `AccessControl` | Symbol-keyed roles with delegated role admins |
+| `Pausable` | Emergency stop primitive for mutating entrypoints |
+| `ExecutionGuard` and `RecoveryGuard` | Serialized critical sections and recovery-aware protection |
+| `BatchExecutor` and `DelayedExecutionPolicy` | Bounded multi-operation flows and timelocked execution queues |
+
 ## Example Projects
 
 The `examples/` directory contains 20+ standalone game contracts and is expected to keep growing. Examples are useful both as runnable references and as design patterns for structuring new projects on top of Cougr.
@@ -137,6 +149,7 @@ Some examples also include Soroban-specific build flows using `stellar contract 
 - [docs/API_CONTRACT.md](docs/API_CONTRACT.md) for the current public API contract and compatibility boundaries
 - [docs/ACCOUNT_KERNEL.md](docs/ACCOUNT_KERNEL.md) for the phase 1 account-kernel model, intents, signers, and replay protection
 - [docs/PRIVACY_MODEL.md](docs/PRIVACY_MODEL.md) for the phase 2 privacy split, maturity table, and proof-verification contract
+- [docs/STANDARDS_LAYER.md](docs/STANDARDS_LAYER.md) for the reusable standards layer, storage model, and failure semantics
 - [docs/PUBLIC_GAPS.md](docs/PUBLIC_GAPS.md) for public behaviors that remain outside the stable promise
 
 ## Compatibility

--- a/docs/MATURITY_MODEL.md
+++ b/docs/MATURITY_MODEL.md
@@ -60,6 +60,7 @@ Experimental is the default for features where:
 |---|---|---|
 | ECS runtime, worlds, storage, scheduling | Beta | Broadly usable, with a curated root facade and a smaller onboarding path |
 | Accounts and smart-account flows | Beta | Valuable direction, but auth kernel and session enforcement still need redesign |
+| Standards layer (`standards`) | Beta | Reusable and integration-tested, but still pre-`1.0` and not yet frozen |
 | Commitments, commit-reveal, hidden-state encoding, and Merkle utilities (`zk::stable`) | Stable | Explicitly separated from experimental proof-verification helpers |
 | Advanced ZK verification and confidential abstractions | Experimental | Do not treat as stable production primitives yet |
 | Testing helpers (`zk::testing`, `MockAccount`) | Non-stable support surface | Intended only for tests or explicit test utility consumers |

--- a/docs/PUBLIC_GAPS.md
+++ b/docs/PUBLIC_GAPS.md
@@ -37,6 +37,15 @@ Remaining gaps:
 - the crate still exports more modules than the eventual stable golden path is likely to keep
 - internals-heavy modules remain public in places where durable invariants are not yet fully documented
 
+### Standards Layer
+
+Status: Beta
+
+Remaining gaps:
+
+- reusable standards are now implemented, but their long-term SemVer-frozen surface is not promised before `1.0`
+- integrating contracts are still responsible for composing caller authentication around generic state-machine helpers such as `Pausable` and `RecoveryGuard`
+
 ## Removed or Downgraded During Phase 0
 
 - deprecated placeholder helpers were removed from `src/lib.rs` in favor of the curated root API

--- a/docs/STANDARDS_LAYER.md
+++ b/docs/STANDARDS_LAYER.md
@@ -1,0 +1,100 @@
+# Standards Layer
+
+## Purpose
+
+The standards layer introduces reusable, storage-aware contract primitives in the style of OpenZeppelin building blocks, but shaped for Cougr's Soroban-oriented single-crate model.
+
+These modules are meant to be composed into application contracts and account flows without depending on any example project.
+
+## Included Standards
+
+### `Ownable`
+
+- single-owner access primitive
+- explicit initialization
+- direct transfer and renounce flows
+- typed ownership transition events
+
+### `Ownable2Step`
+
+- staged ownership handoff
+- pending-owner tracking in storage
+- explicit acceptance requirement before ownership changes
+- cancellation support for abandoned handoffs
+
+### `AccessControl`
+
+- role-based authorization keyed by `Symbol`
+- per-role admin delegation
+- explicit grant, revoke, and renounce semantics
+- default admin role for bootstrapping new modules
+
+### `Pausable`
+
+- storage-backed emergency stop flag
+- explicit paused and unpaused transitions
+- guard methods for mutating entrypoints
+
+### `ExecutionGuard`
+
+- storage-backed execution lock
+- suited for reentrancy-like protection and mutation serialization
+- can be used as explicit enter/exit calls or as a scoped closure wrapper
+
+### `RecoveryGuard`
+
+- blocks sensitive flows while a recovery window is active
+- generic enough to compose with account recovery or application-defined incident response
+
+### `BatchExecutor`
+
+- reusable batch length validation
+- single-path execution semantics for collections of operations
+- explicit empty and oversize rejection
+
+### `DelayedExecutionPolicy`
+
+- storage-backed delayed operation queue
+- deterministic operation IDs
+- readiness and expiry checks
+- cancellation and execution events
+
+## Storage and Namespacing
+
+Each standards module is instantiated with a `Symbol` identifier.
+
+That identifier becomes part of the storage key, which allows a single contract to host multiple independent instances of the same standard without collisions.
+
+## Authorization Model
+
+These modules do not assume hidden caller semantics.
+
+Where authorization matters:
+
+- `Ownable` and `Ownable2Step` require an explicit caller address
+- `AccessControl` checks the caller against the relevant admin role
+- `Pausable`, `RecoveryGuard`, and similar state machines leave the surrounding authorization decision to the integrating contract
+
+This is intentional. Cougr keeps authorization visible at the integration boundary instead of burying it in generic helpers.
+
+## Error Semantics
+
+The standards layer uses `StandardsError` for consistent negative-path behavior across integrations.
+
+Important failure modes include:
+
+- unauthorized caller
+- duplicate initialization
+- missing or mismatched pending owner
+- duplicate role grant or missing role during revoke
+- paused versus not-paused guard failures
+- execution lock contention
+- recovery-active guard failure
+- empty or oversized batches
+- delayed operation not ready, expired, already executed, or missing
+
+## Maturity
+
+Status: Beta
+
+The standards are reusable and integration-tested, but still pre-`1.0`. Their API is intentionally designed and documented, yet still subject to refinement while Cougr finalizes its broader stable surface.

--- a/examples/space_invaders/Cargo.lock
+++ b/examples/space_invaders/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cougr-core"
-version = "0.0.1"
+version = "0.5.0"
 dependencies = [
  "soroban-sdk",
  "wee_alloc",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub mod query;
 pub mod resource;
 pub mod scheduler;
 pub mod simple_world;
+pub mod standards;
 pub mod system;
 pub mod world;
 pub mod zk;

--- a/src/standards/access_control.rs
+++ b/src/standards/access_control.rs
@@ -1,0 +1,213 @@
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+use super::error::StandardsError;
+
+const ROLE_MEMBER_PREFIX: &str = "std_role_m";
+const ROLE_ADMIN_PREFIX: &str = "std_role_a";
+
+pub const DEFAULT_ADMIN_ROLE_NAME: &str = "DEFAULT_ADMIN_ROLE";
+
+/// Role-based access control with per-role admin delegation.
+#[derive(Clone, Debug)]
+pub struct AccessControl {
+    id: Symbol,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleGrantedEvent {
+    pub role: Symbol,
+    pub account: Address,
+    pub sender: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleRevokedEvent {
+    pub role: Symbol,
+    pub account: Address,
+    pub sender: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleAdminChangedEvent {
+    pub role: Symbol,
+    pub previous_admin_role: Symbol,
+    pub new_admin_role: Symbol,
+    pub sender: Address,
+}
+
+impl AccessControl {
+    pub fn new(id: Symbol) -> Self {
+        Self { id }
+    }
+
+    pub fn initialize(
+        &self,
+        env: &Env,
+        admin: &Address,
+    ) -> Result<RoleGrantedEvent, StandardsError> {
+        let default_admin_role = self.default_admin_role(env);
+        let admin_key = self.role_admin_key(env, &default_admin_role);
+        if env.storage().persistent().has(&admin_key) {
+            return Err(StandardsError::AlreadyInitialized);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&admin_key, &default_admin_role);
+        self.grant_role_unchecked(env, &default_admin_role, admin);
+
+        Ok(RoleGrantedEvent {
+            role: default_admin_role,
+            account: admin.clone(),
+            sender: admin.clone(),
+        })
+    }
+
+    pub fn default_admin_role(&self, env: &Env) -> Symbol {
+        Symbol::new(env, DEFAULT_ADMIN_ROLE_NAME)
+    }
+
+    pub fn has_role(&self, env: &Env, role: &Symbol, account: &Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&self.role_member_key(env, role, account))
+    }
+
+    pub fn require_role(
+        &self,
+        env: &Env,
+        role: &Symbol,
+        account: &Address,
+    ) -> Result<(), StandardsError> {
+        if self.has_role(env, role, account) {
+            return Ok(());
+        }
+        Err(StandardsError::Unauthorized)
+    }
+
+    pub fn role_admin(&self, env: &Env, role: &Symbol) -> Symbol {
+        env.storage()
+            .persistent()
+            .get(&self.role_admin_key(env, role))
+            .unwrap_or_else(|| self.default_admin_role(env))
+    }
+
+    pub fn grant_role(
+        &self,
+        env: &Env,
+        caller: &Address,
+        role: &Symbol,
+        account: &Address,
+    ) -> Result<RoleGrantedEvent, StandardsError> {
+        let admin_role = self.role_admin(env, role);
+        self.require_role(env, &admin_role, caller)?;
+        if self.has_role(env, role, account) {
+            return Err(StandardsError::RoleAlreadyGranted);
+        }
+
+        self.grant_role_unchecked(env, role, account);
+        Ok(RoleGrantedEvent {
+            role: role.clone(),
+            account: account.clone(),
+            sender: caller.clone(),
+        })
+    }
+
+    pub fn revoke_role(
+        &self,
+        env: &Env,
+        caller: &Address,
+        role: &Symbol,
+        account: &Address,
+    ) -> Result<RoleRevokedEvent, StandardsError> {
+        let admin_role = self.role_admin(env, role);
+        self.require_role(env, &admin_role, caller)?;
+        if !self.has_role(env, role, account) {
+            return Err(StandardsError::RoleNotGranted);
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&self.role_member_key(env, role, account));
+
+        Ok(RoleRevokedEvent {
+            role: role.clone(),
+            account: account.clone(),
+            sender: caller.clone(),
+        })
+    }
+
+    pub fn renounce_role(
+        &self,
+        env: &Env,
+        role: &Symbol,
+        caller: &Address,
+    ) -> Result<RoleRevokedEvent, StandardsError> {
+        if !self.has_role(env, role, caller) {
+            return Err(StandardsError::RoleNotGranted);
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&self.role_member_key(env, role, caller));
+
+        Ok(RoleRevokedEvent {
+            role: role.clone(),
+            account: caller.clone(),
+            sender: caller.clone(),
+        })
+    }
+
+    pub fn set_role_admin(
+        &self,
+        env: &Env,
+        caller: &Address,
+        role: &Symbol,
+        new_admin_role: &Symbol,
+    ) -> Result<RoleAdminChangedEvent, StandardsError> {
+        let previous_admin_role = self.role_admin(env, role);
+        self.require_role(env, &previous_admin_role, caller)?;
+
+        env.storage()
+            .persistent()
+            .set(&self.role_admin_key(env, role), new_admin_role);
+
+        Ok(RoleAdminChangedEvent {
+            role: role.clone(),
+            previous_admin_role,
+            new_admin_role: new_admin_role.clone(),
+            sender: caller.clone(),
+        })
+    }
+
+    fn grant_role_unchecked(&self, env: &Env, role: &Symbol, account: &Address) {
+        env.storage()
+            .persistent()
+            .set(&self.role_member_key(env, role, account), &true);
+    }
+
+    fn role_member_key(
+        &self,
+        env: &Env,
+        role: &Symbol,
+        account: &Address,
+    ) -> (Symbol, Symbol, Symbol, Address) {
+        (
+            Symbol::new(env, ROLE_MEMBER_PREFIX),
+            self.id.clone(),
+            role.clone(),
+            account.clone(),
+        )
+    }
+
+    fn role_admin_key(&self, env: &Env, role: &Symbol) -> (Symbol, Symbol, Symbol) {
+        (
+            Symbol::new(env, ROLE_ADMIN_PREFIX),
+            self.id.clone(),
+            role.clone(),
+        )
+    }
+}

--- a/src/standards/batch.rs
+++ b/src/standards/batch.rs
@@ -1,0 +1,43 @@
+use alloc::vec::Vec;
+
+use super::error::StandardsError;
+
+/// Generic batch validator and executor for standards-layer flows.
+#[derive(Clone, Debug)]
+pub struct BatchExecutor {
+    max_size: usize,
+}
+
+impl BatchExecutor {
+    pub fn new(max_size: usize) -> Self {
+        Self { max_size }
+    }
+
+    pub fn max_size(&self) -> usize {
+        self.max_size
+    }
+
+    pub fn validate_len(&self, len: usize) -> Result<(), StandardsError> {
+        if len == 0 {
+            return Err(StandardsError::BatchEmpty);
+        }
+        if len > self.max_size {
+            return Err(StandardsError::BatchTooLarge);
+        }
+        Ok(())
+    }
+
+    pub fn execute<T, R>(
+        &self,
+        items: &[T],
+        mut executor: impl FnMut(&T) -> Result<R, StandardsError>,
+    ) -> Result<Vec<R>, StandardsError> {
+        self.validate_len(items.len())?;
+
+        let mut results = Vec::with_capacity(items.len());
+        for item in items {
+            results.push(executor(item)?);
+        }
+        Ok(results)
+    }
+}

--- a/src/standards/delayed_execution.rs
+++ b/src/standards/delayed_execution.rs
@@ -1,0 +1,221 @@
+use soroban_sdk::{contracttype, Bytes, Env, Symbol, Vec};
+
+use super::error::StandardsError;
+
+const OPERATION_PREFIX: &str = "std_delay";
+const OPERATION_IDS_PREFIX: &str = "std_delay_ids";
+const NONCE_PREFIX: &str = "std_delay_n";
+
+/// Storage-backed delayed execution queue.
+#[derive(Clone, Debug)]
+pub struct DelayedExecutionPolicy {
+    id: Symbol,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelayedOperation {
+    pub operation_id: u64,
+    pub action: Symbol,
+    pub payload: Bytes,
+    pub scheduled_at: u64,
+    pub not_before: u64,
+    pub expires_at: u64,
+    pub executed: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelayedExecutionScheduledEvent {
+    pub operation_id: u64,
+    pub action: Symbol,
+    pub not_before: u64,
+    pub expires_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelayedExecutionCancelledEvent {
+    pub operation_id: u64,
+    pub action: Symbol,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelayedExecutionExecutedEvent {
+    pub operation_id: u64,
+    pub action: Symbol,
+    pub executed_at: u64,
+}
+
+impl DelayedExecutionPolicy {
+    pub fn new(id: Symbol) -> Self {
+        Self { id }
+    }
+
+    pub fn schedule(
+        &self,
+        env: &Env,
+        action: Symbol,
+        payload: Bytes,
+        delay: u64,
+        ttl: u64,
+    ) -> Result<DelayedExecutionScheduledEvent, StandardsError> {
+        let now = env.ledger().timestamp();
+        let operation_id = self.next_operation_id(env);
+        let operation = DelayedOperation {
+            operation_id,
+            action: action.clone(),
+            payload,
+            scheduled_at: now,
+            not_before: now + delay,
+            expires_at: now + delay + ttl,
+            executed: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&self.operation_key(env, operation_id), &operation);
+
+        let mut ids = self.operation_ids(env);
+        ids.push_back(operation_id);
+        env.storage()
+            .persistent()
+            .set(&self.operation_ids_key(env), &ids);
+
+        Ok(DelayedExecutionScheduledEvent {
+            operation_id,
+            action,
+            not_before: operation.not_before,
+            expires_at: operation.expires_at,
+        })
+    }
+
+    pub fn operation(&self, env: &Env, operation_id: u64) -> Option<DelayedOperation> {
+        env.storage()
+            .persistent()
+            .get(&self.operation_key(env, operation_id))
+    }
+
+    pub fn pending_operations(&self, env: &Env) -> Vec<DelayedOperation> {
+        let ids = self.operation_ids(env);
+        let mut operations = Vec::new(env);
+
+        for i in 0..ids.len() {
+            if let Some(operation_id) = ids.get(i) {
+                if let Some(operation) = self.operation(env, operation_id) {
+                    if !operation.executed {
+                        operations.push_back(operation);
+                    }
+                }
+            }
+        }
+
+        operations
+    }
+
+    pub fn cancel(
+        &self,
+        env: &Env,
+        operation_id: u64,
+    ) -> Result<DelayedExecutionCancelledEvent, StandardsError> {
+        let operation = self
+            .operation(env, operation_id)
+            .ok_or(StandardsError::OperationNotFound)?;
+
+        self.remove_operation(env, operation_id);
+
+        Ok(DelayedExecutionCancelledEvent {
+            operation_id,
+            action: operation.action,
+        })
+    }
+
+    pub fn execute_ready(
+        &self,
+        env: &Env,
+        operation_id: u64,
+    ) -> Result<DelayedExecutionExecutedEvent, StandardsError> {
+        let mut operation = self
+            .operation(env, operation_id)
+            .ok_or(StandardsError::OperationNotFound)?;
+
+        if operation.executed {
+            return Err(StandardsError::OperationAlreadyExecuted);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < operation.not_before {
+            return Err(StandardsError::OperationNotReady);
+        }
+        if now > operation.expires_at {
+            return Err(StandardsError::OperationExpired);
+        }
+
+        operation.executed = true;
+        env.storage()
+            .persistent()
+            .set(&self.operation_key(env, operation_id), &operation);
+        self.remove_operation_id(env, operation_id);
+
+        Ok(DelayedExecutionExecutedEvent {
+            operation_id,
+            action: operation.action,
+            executed_at: now,
+        })
+    }
+
+    fn next_operation_id(&self, env: &Env) -> u64 {
+        let key = self.nonce_key(env);
+        let next = env.storage().persistent().get::<_, u64>(&key).unwrap_or(0) + 1;
+        env.storage().persistent().set(&key, &next);
+        next
+    }
+
+    fn remove_operation(&self, env: &Env, operation_id: u64) {
+        env.storage()
+            .persistent()
+            .remove(&self.operation_key(env, operation_id));
+        self.remove_operation_id(env, operation_id);
+    }
+
+    fn remove_operation_id(&self, env: &Env, operation_id: u64) {
+        let ids = self.operation_ids(env);
+        let mut retained = Vec::new(env);
+
+        for i in 0..ids.len() {
+            if let Some(candidate) = ids.get(i) {
+                if candidate != operation_id {
+                    retained.push_back(candidate);
+                }
+            }
+        }
+
+        env.storage()
+            .persistent()
+            .set(&self.operation_ids_key(env), &retained);
+    }
+
+    fn operation_ids(&self, env: &Env) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&self.operation_ids_key(env))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    fn operation_key(&self, env: &Env, operation_id: u64) -> (Symbol, Symbol, u64) {
+        (
+            Symbol::new(env, OPERATION_PREFIX),
+            self.id.clone(),
+            operation_id,
+        )
+    }
+
+    fn operation_ids_key(&self, env: &Env) -> (Symbol, Symbol) {
+        (Symbol::new(env, OPERATION_IDS_PREFIX), self.id.clone())
+    }
+
+    fn nonce_key(&self, env: &Env) -> (Symbol, Symbol) {
+        (Symbol::new(env, NONCE_PREFIX), self.id.clone())
+    }
+}

--- a/src/standards/error.rs
+++ b/src/standards/error.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::contracterror;
+
+/// Errors returned by the reusable standards layer.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum StandardsError {
+    Unauthorized = 60,
+    AlreadyInitialized = 61,
+    OwnerNotSet = 62,
+    PendingOwnerNotSet = 63,
+    PendingOwnerMismatch = 64,
+    RoleAlreadyGranted = 65,
+    RoleNotGranted = 66,
+    MissingRoleAdmin = 67,
+    Paused = 68,
+    NotPaused = 69,
+    ExecutionLocked = 70,
+    RecoveryActive = 71,
+    RecoveryInactive = 72,
+    BatchEmpty = 73,
+    BatchTooLarge = 74,
+    OperationNotReady = 75,
+    OperationExpired = 76,
+    OperationNotFound = 77,
+    OperationAlreadyExecuted = 78,
+    ExecutionNotLocked = 79,
+}

--- a/src/standards/execution_guard.rs
+++ b/src/standards/execution_guard.rs
@@ -1,0 +1,72 @@
+use soroban_sdk::{contracttype, Env, Symbol};
+
+use super::error::StandardsError;
+
+const EXECUTION_LOCK_PREFIX: &str = "std_exec";
+
+/// Storage-backed execution lock for sensitive state transitions.
+#[derive(Clone, Debug)]
+pub struct ExecutionGuard {
+    id: Symbol,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExecutionGuardEnteredEvent {
+    pub guard_id: Symbol,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExecutionGuardExitedEvent {
+    pub guard_id: Symbol,
+}
+
+impl ExecutionGuard {
+    pub fn new(id: Symbol) -> Self {
+        Self { id }
+    }
+
+    pub fn is_locked(&self, env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&self.lock_key(env))
+            .unwrap_or(false)
+    }
+
+    pub fn require_unlocked(&self, env: &Env) -> Result<(), StandardsError> {
+        if self.is_locked(env) {
+            return Err(StandardsError::ExecutionLocked);
+        }
+        Ok(())
+    }
+
+    pub fn enter(&self, env: &Env) -> Result<ExecutionGuardEnteredEvent, StandardsError> {
+        self.require_unlocked(env)?;
+        env.storage().persistent().set(&self.lock_key(env), &true);
+        Ok(ExecutionGuardEnteredEvent {
+            guard_id: self.id.clone(),
+        })
+    }
+
+    pub fn exit(&self, env: &Env) -> Result<ExecutionGuardExitedEvent, StandardsError> {
+        if !self.is_locked(env) {
+            return Err(StandardsError::ExecutionNotLocked);
+        }
+        env.storage().persistent().set(&self.lock_key(env), &false);
+        Ok(ExecutionGuardExitedEvent {
+            guard_id: self.id.clone(),
+        })
+    }
+
+    pub fn execute<T>(&self, env: &Env, f: impl FnOnce() -> T) -> Result<T, StandardsError> {
+        self.enter(env)?;
+        let result = f();
+        self.exit(env)?;
+        Ok(result)
+    }
+
+    fn lock_key(&self, env: &Env) -> (Symbol, Symbol) {
+        (Symbol::new(env, EXECUTION_LOCK_PREFIX), self.id.clone())
+    }
+}

--- a/src/standards/mod.rs
+++ b/src/standards/mod.rs
@@ -1,0 +1,33 @@
+//! Reusable contract standards for Cougr integrations.
+//!
+//! The standards layer is intentionally framework-oriented rather than
+//! example-specific. Each standard is storage-backed where persistence matters,
+//! exposes typed state-transition events, and keeps authorization checks
+//! explicit instead of hidden behind implicit caller assumptions.
+
+mod access_control;
+mod batch;
+mod delayed_execution;
+mod error;
+mod execution_guard;
+mod ownable;
+mod pausable;
+mod recovery_guard;
+
+pub use access_control::{
+    AccessControl, RoleAdminChangedEvent, RoleGrantedEvent, RoleRevokedEvent,
+    DEFAULT_ADMIN_ROLE_NAME,
+};
+pub use batch::BatchExecutor;
+pub use delayed_execution::{
+    DelayedExecutionCancelledEvent, DelayedExecutionExecutedEvent, DelayedExecutionPolicy,
+    DelayedExecutionScheduledEvent, DelayedOperation,
+};
+pub use error::StandardsError;
+pub use execution_guard::{ExecutionGuard, ExecutionGuardEnteredEvent, ExecutionGuardExitedEvent};
+pub use ownable::{
+    Ownable, Ownable2Step, OwnershipTransferCancelledEvent, OwnershipTransferStartedEvent,
+    OwnershipTransferredEvent,
+};
+pub use pausable::{Pausable, PausedEvent, UnpausedEvent};
+pub use recovery_guard::{RecoveryGuard, RecoveryGuardActivatedEvent, RecoveryGuardClearedEvent};

--- a/src/standards/ownable.rs
+++ b/src/standards/ownable.rs
@@ -1,0 +1,218 @@
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+use super::error::StandardsError;
+
+const OWNER_PREFIX: &str = "std_owner";
+const PENDING_OWNER_PREFIX: &str = "std_powner";
+
+/// OpenZeppelin-style single-owner control primitive.
+#[derive(Clone, Debug)]
+pub struct Ownable {
+    id: Symbol,
+}
+
+/// Two-step ownership handoff built on top of [`Ownable`].
+#[derive(Clone, Debug)]
+pub struct Ownable2Step {
+    inner: Ownable,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OwnershipTransferredEvent {
+    pub previous_owner: Option<Address>,
+    pub new_owner: Option<Address>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OwnershipTransferStartedEvent {
+    pub owner: Address,
+    pub pending_owner: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OwnershipTransferCancelledEvent {
+    pub owner: Address,
+    pub pending_owner: Address,
+}
+
+impl Ownable {
+    pub fn new(id: Symbol) -> Self {
+        Self { id }
+    }
+
+    pub fn initialize(
+        &self,
+        env: &Env,
+        owner: &Address,
+    ) -> Result<OwnershipTransferredEvent, StandardsError> {
+        if self.owner(env).is_some() {
+            return Err(StandardsError::AlreadyInitialized);
+        }
+
+        env.storage().persistent().set(&self.owner_key(env), owner);
+        env.storage()
+            .persistent()
+            .remove(&self.pending_owner_key(env));
+
+        Ok(OwnershipTransferredEvent {
+            previous_owner: None,
+            new_owner: Some(owner.clone()),
+        })
+    }
+
+    pub fn owner(&self, env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&self.owner_key(env))
+    }
+
+    pub fn pending_owner(&self, env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&self.pending_owner_key(env))
+    }
+
+    pub fn require_owner(&self, env: &Env, caller: &Address) -> Result<(), StandardsError> {
+        let owner = self.owner(env).ok_or(StandardsError::OwnerNotSet)?;
+        if owner != *caller {
+            return Err(StandardsError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    pub fn transfer_ownership(
+        &self,
+        env: &Env,
+        caller: &Address,
+        new_owner: &Address,
+    ) -> Result<OwnershipTransferredEvent, StandardsError> {
+        self.require_owner(env, caller)?;
+        let previous_owner = self.owner(env);
+        env.storage()
+            .persistent()
+            .set(&self.owner_key(env), new_owner);
+        env.storage()
+            .persistent()
+            .remove(&self.pending_owner_key(env));
+
+        Ok(OwnershipTransferredEvent {
+            previous_owner,
+            new_owner: Some(new_owner.clone()),
+        })
+    }
+
+    pub fn renounce_ownership(
+        &self,
+        env: &Env,
+        caller: &Address,
+    ) -> Result<OwnershipTransferredEvent, StandardsError> {
+        self.require_owner(env, caller)?;
+        let previous_owner = self.owner(env);
+        env.storage().persistent().remove(&self.owner_key(env));
+        env.storage()
+            .persistent()
+            .remove(&self.pending_owner_key(env));
+
+        Ok(OwnershipTransferredEvent {
+            previous_owner,
+            new_owner: None,
+        })
+    }
+
+    fn owner_key(&self, env: &Env) -> (Symbol, Symbol) {
+        (Symbol::new(env, OWNER_PREFIX), self.id.clone())
+    }
+
+    fn pending_owner_key(&self, env: &Env) -> (Symbol, Symbol) {
+        (Symbol::new(env, PENDING_OWNER_PREFIX), self.id.clone())
+    }
+}
+
+impl Ownable2Step {
+    pub fn new(id: Symbol) -> Self {
+        Self {
+            inner: Ownable::new(id),
+        }
+    }
+
+    pub fn initialize(
+        &self,
+        env: &Env,
+        owner: &Address,
+    ) -> Result<OwnershipTransferredEvent, StandardsError> {
+        self.inner.initialize(env, owner)
+    }
+
+    pub fn owner(&self, env: &Env) -> Option<Address> {
+        self.inner.owner(env)
+    }
+
+    pub fn pending_owner(&self, env: &Env) -> Option<Address> {
+        self.inner.pending_owner(env)
+    }
+
+    pub fn require_owner(&self, env: &Env, caller: &Address) -> Result<(), StandardsError> {
+        self.inner.require_owner(env, caller)
+    }
+
+    pub fn begin_transfer(
+        &self,
+        env: &Env,
+        caller: &Address,
+        pending_owner: &Address,
+    ) -> Result<OwnershipTransferStartedEvent, StandardsError> {
+        self.inner.require_owner(env, caller)?;
+        env.storage()
+            .persistent()
+            .set(&self.inner.pending_owner_key(env), pending_owner);
+
+        Ok(OwnershipTransferStartedEvent {
+            owner: caller.clone(),
+            pending_owner: pending_owner.clone(),
+        })
+    }
+
+    pub fn accept_transfer(
+        &self,
+        env: &Env,
+        caller: &Address,
+    ) -> Result<OwnershipTransferredEvent, StandardsError> {
+        let pending_owner = self
+            .pending_owner(env)
+            .ok_or(StandardsError::PendingOwnerNotSet)?;
+        if pending_owner != *caller {
+            return Err(StandardsError::PendingOwnerMismatch);
+        }
+
+        let previous_owner = self.owner(env);
+        env.storage()
+            .persistent()
+            .set(&self.inner.owner_key(env), caller);
+        env.storage()
+            .persistent()
+            .remove(&self.inner.pending_owner_key(env));
+
+        Ok(OwnershipTransferredEvent {
+            previous_owner,
+            new_owner: Some(caller.clone()),
+        })
+    }
+
+    pub fn cancel_transfer(
+        &self,
+        env: &Env,
+        caller: &Address,
+    ) -> Result<OwnershipTransferCancelledEvent, StandardsError> {
+        self.inner.require_owner(env, caller)?;
+        let pending_owner = self
+            .pending_owner(env)
+            .ok_or(StandardsError::PendingOwnerNotSet)?;
+        env.storage()
+            .persistent()
+            .remove(&self.inner.pending_owner_key(env));
+
+        Ok(OwnershipTransferCancelledEvent {
+            owner: caller.clone(),
+            pending_owner,
+        })
+    }
+}

--- a/src/standards/pausable.rs
+++ b/src/standards/pausable.rs
@@ -1,0 +1,76 @@
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+use super::error::StandardsError;
+
+const PAUSED_PREFIX: &str = "std_pause";
+
+/// Pause state primitive for emergency stops.
+#[derive(Clone, Debug)]
+pub struct Pausable {
+    id: Symbol,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PausedEvent {
+    pub account: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnpausedEvent {
+    pub account: Address,
+}
+
+impl Pausable {
+    pub fn new(id: Symbol) -> Self {
+        Self { id }
+    }
+
+    pub fn is_paused(&self, env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&self.paused_key(env))
+            .unwrap_or(false)
+    }
+
+    pub fn require_paused(&self, env: &Env) -> Result<(), StandardsError> {
+        if self.is_paused(env) {
+            return Ok(());
+        }
+        Err(StandardsError::NotPaused)
+    }
+
+    pub fn require_not_paused(&self, env: &Env) -> Result<(), StandardsError> {
+        if self.is_paused(env) {
+            return Err(StandardsError::Paused);
+        }
+        Ok(())
+    }
+
+    pub fn pause(&self, env: &Env, caller: &Address) -> Result<PausedEvent, StandardsError> {
+        if self.is_paused(env) {
+            return Err(StandardsError::Paused);
+        }
+        env.storage().persistent().set(&self.paused_key(env), &true);
+        Ok(PausedEvent {
+            account: caller.clone(),
+        })
+    }
+
+    pub fn unpause(&self, env: &Env, caller: &Address) -> Result<UnpausedEvent, StandardsError> {
+        if !self.is_paused(env) {
+            return Err(StandardsError::NotPaused);
+        }
+        env.storage()
+            .persistent()
+            .set(&self.paused_key(env), &false);
+        Ok(UnpausedEvent {
+            account: caller.clone(),
+        })
+    }
+
+    fn paused_key(&self, env: &Env) -> (Symbol, Symbol) {
+        (Symbol::new(env, PAUSED_PREFIX), self.id.clone())
+    }
+}

--- a/src/standards/recovery_guard.rs
+++ b/src/standards/recovery_guard.rs
@@ -1,0 +1,82 @@
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+use super::error::StandardsError;
+
+const RECOVERY_GUARD_PREFIX: &str = "std_recov";
+
+/// Guard used to block sensitive flows while recovery is active.
+#[derive(Clone, Debug)]
+pub struct RecoveryGuard {
+    id: Symbol,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecoveryGuardActivatedEvent {
+    pub account: Address,
+    pub activated_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecoveryGuardClearedEvent {
+    pub account: Address,
+    pub cleared_at: u64,
+}
+
+impl RecoveryGuard {
+    pub fn new(id: Symbol) -> Self {
+        Self { id }
+    }
+
+    pub fn is_active(&self, env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get::<_, bool>(&self.guard_key(env))
+            .unwrap_or(false)
+    }
+
+    pub fn require_active(&self, env: &Env) -> Result<(), StandardsError> {
+        if self.is_active(env) {
+            return Ok(());
+        }
+        Err(StandardsError::RecoveryInactive)
+    }
+
+    pub fn require_inactive(&self, env: &Env) -> Result<(), StandardsError> {
+        if self.is_active(env) {
+            return Err(StandardsError::RecoveryActive);
+        }
+        Ok(())
+    }
+
+    pub fn activate(
+        &self,
+        env: &Env,
+        caller: &Address,
+    ) -> Result<RecoveryGuardActivatedEvent, StandardsError> {
+        self.require_inactive(env)?;
+        env.storage().persistent().set(&self.guard_key(env), &true);
+        Ok(RecoveryGuardActivatedEvent {
+            account: caller.clone(),
+            activated_at: env.ledger().timestamp(),
+        })
+    }
+
+    pub fn clear(
+        &self,
+        env: &Env,
+        caller: &Address,
+    ) -> Result<RecoveryGuardClearedEvent, StandardsError> {
+        self.require_active(env)?;
+        env.storage().persistent().set(&self.guard_key(env), &false);
+        Ok(RecoveryGuardClearedEvent {
+            account: caller.clone(),
+            cleared_at: env.ledger().timestamp(),
+        })
+    }
+
+    fn guard_key(&self, env: &Env) -> (Symbol, Symbol) {
+        (Symbol::new(env, RECOVERY_GUARD_PREFIX), self.id.clone())
+    }
+}

--- a/tests/integration_standards.rs
+++ b/tests/integration_standards.rs
@@ -1,0 +1,232 @@
+//! Integration tests for the reusable standards layer.
+
+use cougr_core::standards::{
+    AccessControl, BatchExecutor, DelayedExecutionPolicy, ExecutionGuard, Ownable, Ownable2Step,
+    Pausable, RecoveryGuard, StandardsError, DEFAULT_ADMIN_ROLE_NAME,
+};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, testutils::Address as _, testutils::Ledger as _, Address,
+    Bytes, Env, Symbol,
+};
+
+#[contract]
+pub struct TestContract;
+
+#[contractimpl]
+impl TestContract {}
+
+#[test]
+fn ownable_supports_transfer_and_renounce() {
+    let env = Env::default();
+    let contract_id = env.register(TestContract, ());
+    let owner = Address::generate(&env);
+    let next_owner = Address::generate(&env);
+    let module = Ownable::new(symbol_short!("own"));
+
+    env.as_contract(&contract_id, || {
+        module.initialize(&env, &owner).unwrap();
+        assert_eq!(module.owner(&env), Some(owner.clone()));
+
+        module
+            .transfer_ownership(&env, &owner, &next_owner)
+            .unwrap();
+        assert_eq!(module.owner(&env), Some(next_owner.clone()));
+
+        module.renounce_ownership(&env, &next_owner).unwrap();
+        assert_eq!(module.owner(&env), None);
+    });
+}
+
+#[test]
+fn ownable_2step_requires_pending_owner_acceptance() {
+    let env = Env::default();
+    let contract_id = env.register(TestContract, ());
+    let owner = Address::generate(&env);
+    let pending_owner = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    let module = Ownable2Step::new(symbol_short!("own2"));
+
+    env.as_contract(&contract_id, || {
+        module.initialize(&env, &owner).unwrap();
+        module.begin_transfer(&env, &owner, &pending_owner).unwrap();
+
+        let unauthorized = module.accept_transfer(&env, &outsider);
+        assert_eq!(unauthorized, Err(StandardsError::PendingOwnerMismatch));
+
+        module.accept_transfer(&env, &pending_owner).unwrap();
+        assert_eq!(module.owner(&env), Some(pending_owner));
+        assert_eq!(module.pending_owner(&env), None);
+    });
+}
+
+#[test]
+fn access_control_enforces_admin_hierarchy() {
+    let env = Env::default();
+    let contract_id = env.register(TestContract, ());
+    let admin = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let grantee = Address::generate(&env);
+    let module = AccessControl::new(symbol_short!("acl"));
+    let ops_role = symbol_short!("OPS");
+    let ops_admin_role = symbol_short!("OPADM");
+
+    env.as_contract(&contract_id, || {
+        module.initialize(&env, &admin).unwrap();
+        module
+            .grant_role(&env, &admin, &ops_role, &operator)
+            .unwrap();
+        assert!(module.has_role(&env, &ops_role, &operator));
+
+        module
+            .set_role_admin(&env, &admin, &ops_role, &ops_admin_role)
+            .unwrap();
+        module
+            .grant_role(&env, &admin, &ops_admin_role, &operator)
+            .unwrap();
+        module
+            .grant_role(&env, &operator, &ops_role, &grantee)
+            .unwrap();
+        assert!(module.has_role(&env, &ops_role, &grantee));
+
+        let default_admin_role = Symbol::new(&env, DEFAULT_ADMIN_ROLE_NAME);
+        module
+            .revoke_role(&env, &admin, &default_admin_role, &admin)
+            .unwrap();
+        assert!(!module.has_role(&env, &default_admin_role, &admin));
+    });
+}
+
+#[test]
+fn pausable_blocks_execution_until_unpaused() {
+    let env = Env::default();
+    let contract_id = env.register(TestContract, ());
+    let caller = Address::generate(&env);
+    let module = Pausable::new(symbol_short!("pause"));
+
+    env.as_contract(&contract_id, || {
+        assert!(!module.is_paused(&env));
+        module.pause(&env, &caller).unwrap();
+        assert_eq!(module.require_not_paused(&env), Err(StandardsError::Paused));
+        module.unpause(&env, &caller).unwrap();
+        assert!(module.require_not_paused(&env).is_ok());
+    });
+}
+
+#[test]
+fn execution_guard_prevents_reentrancy_like_nesting() {
+    let env = Env::default();
+    let contract_id = env.register(TestContract, ());
+    let module = ExecutionGuard::new(symbol_short!("exec"));
+
+    env.as_contract(&contract_id, || {
+        module.enter(&env).unwrap();
+        assert_eq!(module.enter(&env), Err(StandardsError::ExecutionLocked));
+        module.exit(&env).unwrap();
+
+        let value = module.execute(&env, || 42u32).unwrap();
+        assert_eq!(value, 42);
+        assert!(!module.is_locked(&env));
+    });
+}
+
+#[test]
+fn recovery_guard_blocks_sensitive_paths_while_active() {
+    let env = Env::default();
+    let contract_id = env.register(TestContract, ());
+    let caller = Address::generate(&env);
+    let module = RecoveryGuard::new(symbol_short!("recov"));
+
+    env.as_contract(&contract_id, || {
+        module.activate(&env, &caller).unwrap();
+        assert_eq!(
+            module.require_inactive(&env),
+            Err(StandardsError::RecoveryActive)
+        );
+        module.clear(&env, &caller).unwrap();
+        assert!(module.require_inactive(&env).is_ok());
+    });
+}
+
+#[test]
+fn batch_executor_enforces_limits_and_executes_items() {
+    let batch = BatchExecutor::new(3);
+    let items = [1u32, 2, 3];
+
+    let results = batch.execute(&items, |item| Ok(item * 2)).unwrap();
+    assert_eq!(results, vec![2, 4, 6]);
+
+    assert_eq!(
+        batch.execute::<u32, u32>(&[], |_| Ok(0)),
+        Err(StandardsError::BatchEmpty)
+    );
+    assert_eq!(
+        batch.execute(&[1u32, 2, 3, 4], |item| Ok(*item)),
+        Err(StandardsError::BatchTooLarge)
+    );
+}
+
+#[test]
+fn delayed_execution_enforces_readiness_and_expiry() {
+    let env = Env::default();
+    let contract_id = env.register(TestContract, ());
+    let module = DelayedExecutionPolicy::new(symbol_short!("delay"));
+
+    env.as_contract(&contract_id, || {
+        env.ledger().with_mut(|li| {
+            li.timestamp = 100;
+        });
+
+        let scheduled = module
+            .schedule(
+                &env,
+                symbol_short!("UPGD"),
+                Bytes::from_array(&env, &[1, 2, 3]),
+                10,
+                20,
+            )
+            .unwrap();
+        assert_eq!(scheduled.operation_id, 1);
+        assert_eq!(module.pending_operations(&env).len(), 1);
+
+        let too_early = module.execute_ready(&env, scheduled.operation_id);
+        assert_eq!(too_early, Err(StandardsError::OperationNotReady));
+
+        env.ledger().with_mut(|li| {
+            li.timestamp = 111;
+        });
+        module.execute_ready(&env, scheduled.operation_id).unwrap();
+        assert_eq!(module.pending_operations(&env).len(), 0);
+
+        let second = module
+            .schedule(
+                &env,
+                symbol_short!("CANC"),
+                Bytes::from_array(&env, &[9]),
+                5,
+                5,
+            )
+            .unwrap();
+        module.cancel(&env, second.operation_id).unwrap();
+        assert_eq!(
+            module.execute_ready(&env, second.operation_id),
+            Err(StandardsError::OperationNotFound)
+        );
+
+        let third = module
+            .schedule(
+                &env,
+                symbol_short!("EXPR"),
+                Bytes::from_array(&env, &[8]),
+                1,
+                1,
+            )
+            .unwrap();
+        env.ledger().with_mut(|li| {
+            li.timestamp = 114;
+        });
+        assert_eq!(
+            module.execute_ready(&env, third.operation_id),
+            Err(StandardsError::OperationExpired)
+        );
+    });
+}

--- a/tests/public_api_surface.rs
+++ b/tests/public_api_surface.rs
@@ -7,6 +7,10 @@
 use cougr_core::accounts::{
     verify_secp256r1, ClassicAccount, GameAction, Secp256r1Key, Secp256r1Storage, SessionBuilder,
 };
+use cougr_core::standards::{
+    AccessControl, BatchExecutor, DelayedExecutionPolicy, ExecutionGuard, Ownable, Ownable2Step,
+    Pausable, RecoveryGuard, StandardsError,
+};
 use cougr_core::zk::experimental::{
     bytes32_to_scalar, open_state_channel, u32_to_scalar, CustomCircuit, FogOfWarSnapshot,
     GameCircuit, MovementCircuit, RecursiveProofLayout,
@@ -120,4 +124,22 @@ fn accounts_namespace_exposes_curated_beta_entrypoints() {
         &Bytes,
         &BytesN<64>,
     ) -> Result<(), cougr_core::accounts::AccountError> = verify_secp256r1;
+}
+
+#[test]
+fn standards_namespace_exposes_reusable_contract_primitives() {
+    let env = Env::default();
+    let account = Address::generate(&env);
+
+    let _ownable = Ownable::new(symbol_short!("own"));
+    let _ownable_2step = Ownable2Step::new(symbol_short!("own2"));
+    let _access = AccessControl::new(symbol_short!("acl"));
+    let _pausable = Pausable::new(symbol_short!("pause"));
+    let _guard = ExecutionGuard::new(symbol_short!("exec"));
+    let _recovery_guard = RecoveryGuard::new(symbol_short!("reco"));
+    let _delayed = DelayedExecutionPolicy::new(symbol_short!("delay"));
+    let _batch = BatchExecutor::new(8);
+
+    let _error_marker = StandardsError::Paused;
+    let _ = account;
 }


### PR DESCRIPTION
## Summary

This PR completes Phase 4 of the roadmap by introducing a reusable `standards` layer for common contract controls in Cougr.

It adds storage-backed, example-independent primitives for:

- `Ownable`
- `Ownable2Step`
- `AccessControl`
- `Pausable`
- `ExecutionGuard`
- `RecoveryGuard`
- `BatchExecutor`
- `DelayedExecutionPolicy`

## Why

Cougr already had useful ECS, account, and privacy building blocks, but it did not yet expose a cohesive standards layer for common contract ergonomics and operational controls.

This change closes that gap with explicit, composable primitives that:

- avoid game-specific assumptions
- keep storage schemas deterministic through namespaced `Symbol` identifiers
- define clear error semantics and typed transition events
- integrate cleanly with the existing crate structure instead of introducing a parallel architecture

## Impact

Developers building on Cougr now have a dedicated public standards surface for ownership, access control, pausability, guarded execution, recovery-aware protection, bounded batching, and delayed execution flows.

The documentation and maturity model were also updated so the new layer is described honestly as Beta and aligned with the roadmap and public API story.

## Validation

- `cargo fmt --check`
- `cargo test --test integration_standards -- --nocapture`
- `cargo test --test public_api_surface -- --nocapture`
- `cargo test --lib --tests`

Closes #101