### PR TITLE
chore: add crates.io publish workflow

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,101 @@
+name: Publish Crate
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'benches/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'README.md'
+      - 'LICENSE'
+      - 'CHANGELOG.md'
+      - 'docs/**'
+      - '.github/workflows/publish-crate.yml'
+      - '!.github/**/*.md'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish the current Cargo.toml version to crates.io'
+        required: true
+        type: boolean
+        default: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-crate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    name: Package crate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check package
+        run: cargo package
+
+  publish:
+    name: Publish to crates.io
+    needs: package
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Read crate metadata
+        id: crate
+        run: |
+          metadata="$(cargo metadata --no-deps --format-version 1)"
+          echo "name=$(echo "$metadata" | jq -r '.packages[0].name')" >> "$GITHUB_OUTPUT"
+          echo "version=$(echo "$metadata" | jq -r '.packages[0].version')" >> "$GITHUB_OUTPUT"
+
+      - name: Check crates.io version
+        id: crates
+        run: |
+          response="$(curl -fsSL "https://crates.io/api/v1/crates/${{ steps.crate.outputs.name }}" || true)"
+          published=false
+
+          if [ -n "$response" ] && echo "$response" | jq -e --arg version "${{ steps.crate.outputs.version }}" '.versions[]? | select(.num == $version)' >/dev/null; then
+            published=true
+          fi
+
+          echo "published=$published" >> "$GITHUB_OUTPUT"
+
+      - name: Publish crate
+        if: steps.crates.outputs.published != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: Skip already published version
+        if: steps.crates.outputs.published == 'true'
+        run: echo "${{ steps.crate.outputs.name }} ${{ steps.crate.outputs.version }} is already published on crates.io"


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to package the root crate when crate-related files change.
- Publish to crates.io using `CARGO_REGISTRY_TOKEN` when the current `Cargo.toml` version is not already published.
- Support tag-based and manual dispatch publishing.

## Verification
- `cargo package` passed locally for `cougr-core v1.0.0`.