### PR TITLE
Feature/issue 125 use published cougr-core in memory_match and minesweeper examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ examples/*/test_snapshots/
 *.so
 *.dylib
 *.dll
-examples/*/target/
+**/target/
 
 # Claude plans
 .claude/

--- a/examples/memory_match/Cargo.toml
+++ b/examples/memory_match/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/minesweeper/Cargo.toml
+++ b/examples/minesweeper/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }


### PR DESCRIPTION
# Tittle: use published cougr-core in memory_match and minesweeper examples

## Summary
This PR updates the `memory_match` and `minesweeper` examples to consume the published `cougr-core` crate (v1.0.0) from crates.io instead of using a repository-local path dependency. 

This change ensures that these examples serve as standalone, reliable references for developers integrating the Cougr framework into their own external projects.

## Changes
- Updated `examples/memory_match/Cargo.toml`: Changed `cougr-core` dependency from `{ path = "../../" }` to `"1.0.0"`.
- Updated `examples/minesweeper/Cargo.toml`: Changed `cougr-core` dependency from `{ path = "../../" }` to `"1.0.0"`.
- Updated .gitignore to use a more general pattern for target directories.

## Verification Results
Verified the changes by running `cargo check` in both example directories. The dependency was successfully resolved from the registry:
- `examples/memory_match`: Finished successfully (checked `cougr-core v1.0.0`).
- `examples/minesweeper`: Finished successfully (checked `cougr-core v1.0.0`).

## Fixes
Closes #125

Updated .gitignore to use a more general pattern for target directories.
<img width="535" height="110" alt="image" src="https://github.com/user-attachments/assets/4b5f0f73-0cda-48b3-b037-a0741623f0e3" />