### PR TITLE
Use published cougr-core crate in reversi and rock_paper_scissors exa…

### DIFF
--- a/examples/reversi/Cargo.toml
+++ b/examples/reversi/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/rock_paper_scissors/Cargo.toml
+++ b/examples/rock_paper_scissors/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/sudoku/Cargo.toml
+++ b/examples/sudoku/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/tap_battle/Cargo.toml
+++ b/examples/tap_battle/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
…mples

- Update examples/reversi/Cargo.toml to use cougr-core = 1.0.0 instead of local path
- Update examples/rock_paper_scissors/Cargo.toml to use cougr-core = 1.0.0 instead of local path
- Both examples now consume the published crate from crates.io
- Resolves #128