### PR TITLE
#130 Use published Cougr in sudoku and tap battle examples

### DIFF
--- a/examples/sudoku/Cargo.toml
+++ b/examples/sudoku/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/tap_battle/Cargo.toml
+++ b/examples/tap_battle/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Closes #130

---

- Update examples/sudoku/Cargo.toml to use cougr-core version 1.0.0 instead of local path
- Update examples/tap_battle/Cargo.toml to use cougr-core version 1.0.0 instead of local path
- Both examples now consume the published cougr-core crate
- Validated: cargo test and stellar contract build pass for both examples
- sudoku: 15 tests passed, WASM built successfully (23089 bytes)
- tap_battle: 17 tests passed, WASM built successfully (39505 bytes)