### PR TITLE
Use published cougr-core in AI dungeon and shadow draft examples

### DIFF
--- a/examples/ai_dungeon_master_arena/Cargo.toml
+++ b/examples/ai_dungeon_master_arena/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/shadow_draft_card_game/Cargo.toml
+++ b/examples/shadow_draft_card_game/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }


### PR DESCRIPTION
- Update ai_dungeon_master_arena/Cargo.toml to use cougr-core 1.0.0
- Update shadow_draft_card_game/Cargo.toml to use cougr-core 1.0.0
- Replace local path dependencies with published crate from crates.io
- Examples now reflect external developer experience using Cougr
- Fixes #118