### PR TITLE
Use published cougr-core in connect four and racing examples

### DIFF
--- a/examples/connect_four/Cargo.toml
+++ b/examples/connect_four/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/cross_asset_racing_league/Cargo.toml
+++ b/examples/cross_asset_racing_league/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
- Update connect_four/Cargo.toml to use cougr-core 1.0.0 from crates.io
- Update cross_asset_racing_league/Cargo.toml to use cougr-core 1.0.0 from crates.io
- Both examples now use published crate instead of local path dependency
- Examples reflect external developer experience using Cougr
- Fixes #122