### PR TITLE
Use published cougr-core in flappy bird and geometry dash examples

### DIFF
--- a/examples/flappy_bird/Cargo.toml
+++ b/examples/flappy_bird/Cargo.toml
@@ -10,7 +10,7 @@ description = "Flappy Bird on-chain game example using cougr-core ECS framework"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/geometry_dash/Cargo.toml
+++ b/examples/geometry_dash/Cargo.toml
@@ -10,7 +10,7 @@ description = "Geometry Dash on-chain game example using cougr-core ECS framewor
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
- Update flappy_bird/Cargo.toml to use cougr-core 1.0.0 from crates.io
- Update geometry_dash/Cargo.toml to use cougr-core 1.0.0 from crates.io
- Replace local path dependencies with published crate from crates.io
- Arcade-loop examples now aligned with public API for onboarding
- Fixes #123