### PR TITLE
Use published cougr-core in asteroids and bomberman examples

### DIFF
--- a/examples/asteroids/Cargo.toml
+++ b/examples/asteroids/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/bomberman/Cargo.toml
+++ b/examples/bomberman/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["rlib"]
 [dependencies]
 soroban-sdk = "25.1.0"
 num-derive = "0.4"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }


### PR DESCRIPTION
- Update asteroids/Cargo.toml to use cougr-core 1.0.0 from crates.io
- Update bomberman/Cargo.toml to use cougr-core 1.0.0 from crates.io
- Replace local path dependencies with published crate from crates.io
- Examples now demonstrate external project consumption of Cougr
- Fixes #120