### PR TITLE
Refactored bomberman and trading card examples

### DIFF
--- a/examples/bomberman/src/components.rs
+++ b/examples/bomberman/src/components.rs
@@ -1,0 +1,522 @@
+use cougr_core::component::ComponentTrait;
+use soroban_sdk::{contracttype, symbol_short, Bytes, Env, Symbol, Vec};
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+pub(crate) const GRID_WIDTH: usize = 15;
+pub(crate) const GRID_HEIGHT: usize = 13;
+pub(crate) const INITIAL_LIVES: u32 = 3;
+pub(crate) const BOMB_TIMER: u32 = 3;
+pub(crate) const EXPLOSION_DURATION: u32 = 1;
+
+// ── PlayerComponent ──────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PlayerComponent {
+    pub id: u32,
+    pub x: i32,
+    pub y: i32,
+    pub lives: u32,
+    pub bomb_capacity: u32,
+    pub score: u32,
+    pub bomb_power: u32,
+    pub speed: u32,
+}
+
+impl PlayerComponent {
+    pub fn new(id: u32, x: i32, y: i32) -> Self {
+        Self {
+            id,
+            x,
+            y,
+            lives: INITIAL_LIVES,
+            bomb_capacity: 1,
+            score: 0,
+            bomb_power: 1,
+            speed: 1,
+        }
+    }
+}
+
+impl ComponentTrait for PlayerComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("player")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.append(&Bytes::from_array(env, &self.id.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.x.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.y.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.lives.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.bomb_capacity.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.score.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.bomb_power.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.speed.to_be_bytes()));
+        bytes
+    }
+
+    #[allow(unused_variables)]
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() != 32 {
+            return None;
+        }
+        let id = u32::from_be_bytes([
+            data.get(0).unwrap(),
+            data.get(1).unwrap(),
+            data.get(2).unwrap(),
+            data.get(3).unwrap(),
+        ]);
+        let x = i32::from_be_bytes([
+            data.get(4).unwrap(),
+            data.get(5).unwrap(),
+            data.get(6).unwrap(),
+            data.get(7).unwrap(),
+        ]);
+        let y = i32::from_be_bytes([
+            data.get(8).unwrap(),
+            data.get(9).unwrap(),
+            data.get(10).unwrap(),
+            data.get(11).unwrap(),
+        ]);
+        let lives = u32::from_be_bytes([
+            data.get(12).unwrap(),
+            data.get(13).unwrap(),
+            data.get(14).unwrap(),
+            data.get(15).unwrap(),
+        ]);
+        let bomb_capacity = u32::from_be_bytes([
+            data.get(16).unwrap(),
+            data.get(17).unwrap(),
+            data.get(18).unwrap(),
+            data.get(19).unwrap(),
+        ]);
+        let score = u32::from_be_bytes([
+            data.get(20).unwrap(),
+            data.get(21).unwrap(),
+            data.get(22).unwrap(),
+            data.get(23).unwrap(),
+        ]);
+        let bomb_power = u32::from_be_bytes([
+            data.get(24).unwrap(),
+            data.get(25).unwrap(),
+            data.get(26).unwrap(),
+            data.get(27).unwrap(),
+        ]);
+        let speed = u32::from_be_bytes([
+            data.get(28).unwrap(),
+            data.get(29).unwrap(),
+            data.get(30).unwrap(),
+            data.get(31).unwrap(),
+        ]);
+        Some(Self {
+            id,
+            x,
+            y,
+            lives,
+            bomb_capacity,
+            score,
+            bomb_power,
+            speed,
+        })
+    }
+}
+
+// ── BombComponent ────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct BombComponent {
+    pub x: i32,
+    pub y: i32,
+    pub timer: u32,
+    pub power: u32,
+    pub owner_id: u32,
+}
+
+impl BombComponent {
+    pub fn new(x: i32, y: i32, owner_id: u32) -> Self {
+        Self {
+            x,
+            y,
+            timer: BOMB_TIMER,
+            power: 1,
+            owner_id,
+        }
+    }
+}
+
+impl ComponentTrait for BombComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("bomb")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.append(&Bytes::from_array(env, &self.x.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.y.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.timer.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.power.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.owner_id.to_be_bytes()));
+        bytes
+    }
+
+    #[allow(unused_variables)]
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() != 20 {
+            return None;
+        }
+        let x = i32::from_be_bytes([
+            data.get(0).unwrap(),
+            data.get(1).unwrap(),
+            data.get(2).unwrap(),
+            data.get(3).unwrap(),
+        ]);
+        let y = i32::from_be_bytes([
+            data.get(4).unwrap(),
+            data.get(5).unwrap(),
+            data.get(6).unwrap(),
+            data.get(7).unwrap(),
+        ]);
+        let timer = u32::from_be_bytes([
+            data.get(8).unwrap(),
+            data.get(9).unwrap(),
+            data.get(10).unwrap(),
+            data.get(11).unwrap(),
+        ]);
+        let power = u32::from_be_bytes([
+            data.get(12).unwrap(),
+            data.get(13).unwrap(),
+            data.get(14).unwrap(),
+            data.get(15).unwrap(),
+        ]);
+        let owner_id = u32::from_be_bytes([
+            data.get(16).unwrap(),
+            data.get(17).unwrap(),
+            data.get(18).unwrap(),
+            data.get(19).unwrap(),
+        ]);
+        Some(Self {
+            x,
+            y,
+            timer,
+            power,
+            owner_id,
+        })
+    }
+}
+
+// ── ExplosionComponent ───────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct ExplosionComponent {
+    pub x: i32,
+    pub y: i32,
+    pub timer: u32,
+}
+
+impl ExplosionComponent {
+    pub fn new(x: i32, y: i32) -> Self {
+        Self {
+            x,
+            y,
+            timer: EXPLOSION_DURATION,
+        }
+    }
+}
+
+impl ComponentTrait for ExplosionComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("explosion")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.append(&Bytes::from_array(env, &self.x.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.y.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.timer.to_be_bytes()));
+        bytes
+    }
+
+    #[allow(unused_variables)]
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() != 12 {
+            return None;
+        }
+        let x = i32::from_be_bytes([
+            data.get(0).unwrap(),
+            data.get(1).unwrap(),
+            data.get(2).unwrap(),
+            data.get(3).unwrap(),
+        ]);
+        let y = i32::from_be_bytes([
+            data.get(4).unwrap(),
+            data.get(5).unwrap(),
+            data.get(6).unwrap(),
+            data.get(7).unwrap(),
+        ]);
+        let timer = u32::from_be_bytes([
+            data.get(8).unwrap(),
+            data.get(9).unwrap(),
+            data.get(10).unwrap(),
+            data.get(11).unwrap(),
+        ]);
+        Some(Self { x, y, timer })
+    }
+}
+
+// ── PowerUpType / PowerUpComponent ───────────────────────────────────────────
+
+#[contracttype]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PowerUpType {
+    Capacity = 0,
+    Power = 1,
+    Speed = 2,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PowerUpComponent {
+    pub x: i32,
+    pub y: i32,
+    pub power_up_type: PowerUpType,
+}
+
+impl PowerUpComponent {
+    pub fn new(x: i32, y: i32, power_up_type: PowerUpType) -> Self {
+        Self {
+            x,
+            y,
+            power_up_type,
+        }
+    }
+}
+
+impl ComponentTrait for PowerUpComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("powerup")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.append(&Bytes::from_array(env, &self.x.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.y.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &[self.power_up_type as u8]));
+        bytes
+    }
+
+    #[allow(unused_variables)]
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() != 9 {
+            return None;
+        }
+        let x = i32::from_be_bytes([
+            data.get(0).unwrap(),
+            data.get(1).unwrap(),
+            data.get(2).unwrap(),
+            data.get(3).unwrap(),
+        ]);
+        let y = i32::from_be_bytes([
+            data.get(4).unwrap(),
+            data.get(5).unwrap(),
+            data.get(6).unwrap(),
+            data.get(7).unwrap(),
+        ]);
+        let power_up_type = match data.get(8).unwrap() {
+            0 => PowerUpType::Capacity,
+            1 => PowerUpType::Power,
+            2 => PowerUpType::Speed,
+            _ => return None,
+        };
+        Some(Self {
+            x,
+            y,
+            power_up_type,
+        })
+    }
+}
+
+// ── CellType / GridComponent ─────────────────────────────────────────────────
+
+#[contracttype]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CellType {
+    Empty = 0,
+    Wall = 1,
+    Destructible = 2,
+    PowerUp = 3,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct GridComponent {
+    pub cells: Vec<CellType>,
+}
+
+impl GridComponent {
+    #[allow(clippy::if_same_then_else)]
+    pub fn new(env: &Env) -> Self {
+        let mut cells = Vec::new(env);
+        for _ in 0..(GRID_WIDTH * GRID_HEIGHT) {
+            cells.push_back(CellType::Empty);
+        }
+        for x in 0..GRID_WIDTH {
+            for y in 0..GRID_HEIGHT {
+                let index = y * GRID_WIDTH + x;
+                if x == 0 || x == GRID_WIDTH - 1 || y == 0 || y == GRID_HEIGHT - 1 {
+                    cells.set(index as u32, CellType::Wall);
+                } else if x % 2 == 0 && y % 2 == 0 {
+                    cells.set(index as u32, CellType::Wall);
+                }
+            }
+        }
+        for x in 1..GRID_WIDTH - 1 {
+            for y in 1..GRID_HEIGHT - 1 {
+                let index = y * GRID_WIDTH + x;
+                if (x + y) % 3 == 0 && cells.get(index as u32).unwrap() == CellType::Empty {
+                    cells.set(index as u32, CellType::Destructible);
+                }
+            }
+        }
+        Self { cells }
+    }
+
+    pub fn get_cell(&self, x: usize, y: usize) -> CellType {
+        if x < GRID_WIDTH && y < GRID_HEIGHT {
+            self.cells
+                .get((y * GRID_WIDTH + x) as u32)
+                .unwrap_or(CellType::Wall)
+        } else {
+            CellType::Wall
+        }
+    }
+
+    pub fn set_cell(&mut self, x: usize, y: usize, cell_type: CellType) {
+        if x < GRID_WIDTH && y < GRID_HEIGHT {
+            self.cells.set((y * GRID_WIDTH + x) as u32, cell_type);
+        }
+    }
+
+    pub fn is_walkable(&self, x: i32, y: i32) -> bool {
+        if x < 0 || y < 0 || x >= GRID_WIDTH as i32 || y >= GRID_HEIGHT as i32 {
+            return false;
+        }
+        matches!(
+            self.get_cell(x as usize, y as usize),
+            CellType::Empty | CellType::PowerUp
+        )
+    }
+}
+
+impl ComponentTrait for GridComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("grid")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        for cell in self.cells.iter() {
+            bytes.append(&Bytes::from_array(env, &[cell as u8]));
+        }
+        bytes
+    }
+
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() != (GRID_WIDTH * GRID_HEIGHT) as u32 {
+            return None;
+        }
+        let mut cells = Vec::new(env);
+        for i in 0..GRID_WIDTH * GRID_HEIGHT {
+            let cell = match data.get(i as u32).unwrap() {
+                0 => CellType::Empty,
+                1 => CellType::Wall,
+                2 => CellType::Destructible,
+                3 => CellType::PowerUp,
+                _ => return None,
+            };
+            cells.push_back(cell);
+        }
+        Some(Self { cells })
+    }
+}
+
+// ── GameStateComponent ───────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct GameStateComponent {
+    pub current_tick: u32,
+    pub game_over: bool,
+    pub winner_id: Option<u32>,
+}
+
+impl GameStateComponent {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            current_tick: 0,
+            game_over: false,
+            winner_id: None,
+        }
+    }
+}
+
+impl ComponentTrait for GameStateComponent {
+    fn component_type() -> Symbol {
+        symbol_short!("gstate")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.append(&Bytes::from_array(env, &self.current_tick.to_be_bytes()));
+        bytes.append(&Bytes::from_array(
+            env,
+            &[if self.game_over { 1 } else { 0 }],
+        ));
+        match self.winner_id {
+            Some(id) => {
+                bytes.append(&Bytes::from_array(env, &[1]));
+                bytes.append(&Bytes::from_array(env, &id.to_be_bytes()));
+            }
+            None => {
+                bytes.append(&Bytes::from_array(env, &[0]));
+            }
+        }
+        bytes
+    }
+
+    #[allow(unused_variables)]
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() < 6 {
+            return None;
+        }
+        let current_tick = u32::from_be_bytes([
+            data.get(0).unwrap(),
+            data.get(1).unwrap(),
+            data.get(2).unwrap(),
+            data.get(3).unwrap(),
+        ]);
+        let game_over = data.get(4).unwrap() != 0;
+        let has_winner = data.get(5).unwrap() != 0;
+        let winner_id = if has_winner && data.len() >= 10 {
+            Some(u32::from_be_bytes([
+                data.get(6).unwrap(),
+                data.get(7).unwrap(),
+                data.get(8).unwrap(),
+                data.get(9).unwrap(),
+            ]))
+        } else {
+            None
+        };
+        Some(Self {
+            current_tick,
+            game_over,
+            winner_id,
+        })
+    }
+}

--- a/examples/bomberman/src/components.rs
+++ b/examples/bomberman/src/components.rs
@@ -3,11 +3,11 @@ use soroban_sdk::{contracttype, symbol_short, Bytes, Env, Symbol, Vec};
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-pub(crate) const GRID_WIDTH: usize = 15;
-pub(crate) const GRID_HEIGHT: usize = 13;
-pub(crate) const INITIAL_LIVES: u32 = 3;
-pub(crate) const BOMB_TIMER: u32 = 3;
-pub(crate) const EXPLOSION_DURATION: u32 = 1;
+pub const GRID_WIDTH: usize = 15;
+pub const GRID_HEIGHT: usize = 13;
+pub const INITIAL_LIVES: u32 = 3;
+pub const BOMB_TIMER: u32 = 3;
+pub const EXPLOSION_DURATION: u32 = 1;
 
 // ── PlayerComponent ──────────────────────────────────────────────────────────
 

--- a/examples/bomberman/src/lib.rs
+++ b/examples/bomberman/src/lib.rs
@@ -8,7 +8,7 @@ mod systems;
 #[cfg(test)]
 mod test;
 
-use components::{
+pub use components::{
     BombComponent, CellType, ExplosionComponent, GameStateComponent, GridComponent,
     PlayerComponent, PowerUpComponent, PowerUpType, BOMB_TIMER, GRID_HEIGHT, GRID_WIDTH,
     INITIAL_LIVES,
@@ -16,13 +16,6 @@ use components::{
 use systems::{
     bomb_timer_and_chain_system, direction_delta, explosion_timer_system, pickup_system,
     player_death_system, win_condition_system,
-};
-
-// Re-export types needed by tests and external consumers
-pub use components::{
-    BombComponent, CellType, ExplosionComponent, GameStateComponent, GridComponent,
-    PlayerComponent, PowerUpComponent, PowerUpType, BOMB_TIMER, GRID_HEIGHT, GRID_WIDTH,
-    INITIAL_LIVES,
 };
 
 #[contracttype]

--- a/examples/bomberman/src/lib.rs
+++ b/examples/bomberman/src/lib.rs
@@ -132,10 +132,8 @@ impl BombermanContract {
             world.get_entities_with_component(&ExplosionComponent::component_type(), &env);
         for e_id in explosion_entities.iter() {
             if let Some(explosion) = world.get_typed::<ExplosionComponent>(&env, e_id) {
-                if explosion.x == next_x && explosion.y == next_y {
-                    if player.lives > 0 {
-                        player.lives -= 1;
-                    }
+                if explosion.x == next_x && explosion.y == next_y && player.lives > 0 {
+                    player.lives -= 1;
                 }
             }
         }

--- a/examples/bomberman/src/lib.rs
+++ b/examples/bomberman/src/lib.rs
@@ -1,529 +1,34 @@
 #![no_std]
 use cougr_core::component::ComponentTrait;
 use cougr_core::*;
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Bytes, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, Symbol};
 
+mod components;
+mod systems;
+#[cfg(test)]
 mod test;
 
-// Game constants
-const GRID_WIDTH: usize = 15;
-const GRID_HEIGHT: usize = 13;
-const INITIAL_LIVES: u32 = 3;
-const BOMB_TIMER: u32 = 3;
-const EXPLOSION_DURATION: u32 = 1;
+use components::{
+    BombComponent, CellType, ExplosionComponent, GameStateComponent, GridComponent,
+    PlayerComponent, PowerUpComponent, PowerUpType, BOMB_TIMER, GRID_HEIGHT, GRID_WIDTH,
+    INITIAL_LIVES,
+};
+use systems::{
+    bomb_timer_and_chain_system, direction_delta, explosion_timer_system, pickup_system,
+    player_death_system, win_condition_system,
+};
+
+// Re-export types needed by tests and external consumers
+pub use components::{
+    BombComponent, CellType, ExplosionComponent, GameStateComponent, GridComponent,
+    PlayerComponent, PowerUpComponent, PowerUpType, BOMB_TIMER, GRID_HEIGHT, GRID_WIDTH,
+    INITIAL_LIVES,
+};
 
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     World,
-}
-
-// Component definitions for Bomberman game
-#[contracttype]
-#[derive(Clone)]
-pub struct PlayerComponent {
-    pub id: u32,
-    pub x: i32,
-    pub y: i32,
-    pub lives: u32,
-    pub bomb_capacity: u32,
-    pub score: u32,
-    pub bomb_power: u32,
-    pub speed: u32,
-}
-
-impl PlayerComponent {
-    pub fn new(id: u32, x: i32, y: i32) -> Self {
-        Self {
-            id,
-            x,
-            y,
-            lives: INITIAL_LIVES,
-            bomb_capacity: 1,
-            score: 0,
-            bomb_power: 1,
-            speed: 1,
-        }
-    }
-}
-
-impl ComponentTrait for PlayerComponent {
-    fn component_type() -> Symbol {
-        symbol_short!("player")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        bytes.append(&Bytes::from_array(env, &self.id.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.x.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.y.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.lives.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.bomb_capacity.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.score.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.bomb_power.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.speed.to_be_bytes()));
-        bytes
-    }
-
-    #[allow(unused_variables)]
-    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() != 32 {
-            return None;
-        }
-        let id = u32::from_be_bytes([
-            data.get(0).unwrap(),
-            data.get(1).unwrap(),
-            data.get(2).unwrap(),
-            data.get(3).unwrap(),
-        ]);
-        let x = i32::from_be_bytes([
-            data.get(4).unwrap(),
-            data.get(5).unwrap(),
-            data.get(6).unwrap(),
-            data.get(7).unwrap(),
-        ]);
-        let y = i32::from_be_bytes([
-            data.get(8).unwrap(),
-            data.get(9).unwrap(),
-            data.get(10).unwrap(),
-            data.get(11).unwrap(),
-        ]);
-        let lives = u32::from_be_bytes([
-            data.get(12).unwrap(),
-            data.get(13).unwrap(),
-            data.get(14).unwrap(),
-            data.get(15).unwrap(),
-        ]);
-        let bomb_capacity = u32::from_be_bytes([
-            data.get(16).unwrap(),
-            data.get(17).unwrap(),
-            data.get(18).unwrap(),
-            data.get(19).unwrap(),
-        ]);
-        let score = u32::from_be_bytes([
-            data.get(20).unwrap(),
-            data.get(21).unwrap(),
-            data.get(22).unwrap(),
-            data.get(23).unwrap(),
-        ]);
-        let bomb_power = u32::from_be_bytes([
-            data.get(24).unwrap(),
-            data.get(25).unwrap(),
-            data.get(26).unwrap(),
-            data.get(27).unwrap(),
-        ]);
-        let speed = u32::from_be_bytes([
-            data.get(28).unwrap(),
-            data.get(29).unwrap(),
-            data.get(30).unwrap(),
-            data.get(31).unwrap(),
-        ]);
-        Some(Self {
-            id,
-            x,
-            y,
-            lives,
-            bomb_capacity,
-            score,
-            bomb_power,
-            speed,
-        })
-    }
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct BombComponent {
-    pub x: i32,
-    pub y: i32,
-    pub timer: u32,
-    pub power: u32,
-    pub owner_id: u32,
-}
-
-impl BombComponent {
-    pub fn new(x: i32, y: i32, owner_id: u32) -> Self {
-        Self {
-            x,
-            y,
-            timer: BOMB_TIMER,
-            power: 1,
-            owner_id,
-        }
-    }
-}
-
-impl ComponentTrait for BombComponent {
-    fn component_type() -> Symbol {
-        symbol_short!("bomb")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        bytes.append(&Bytes::from_array(env, &self.x.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.y.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.timer.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.power.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.owner_id.to_be_bytes()));
-        bytes
-    }
-
-    #[allow(unused_variables)]
-    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() != 20 {
-            return None;
-        }
-        let x = i32::from_be_bytes([
-            data.get(0).unwrap(),
-            data.get(1).unwrap(),
-            data.get(2).unwrap(),
-            data.get(3).unwrap(),
-        ]);
-        let y = i32::from_be_bytes([
-            data.get(4).unwrap(),
-            data.get(5).unwrap(),
-            data.get(6).unwrap(),
-            data.get(7).unwrap(),
-        ]);
-        let timer = u32::from_be_bytes([
-            data.get(8).unwrap(),
-            data.get(9).unwrap(),
-            data.get(10).unwrap(),
-            data.get(11).unwrap(),
-        ]);
-        let power = u32::from_be_bytes([
-            data.get(12).unwrap(),
-            data.get(13).unwrap(),
-            data.get(14).unwrap(),
-            data.get(15).unwrap(),
-        ]);
-        let owner_id = u32::from_be_bytes([
-            data.get(16).unwrap(),
-            data.get(17).unwrap(),
-            data.get(18).unwrap(),
-            data.get(19).unwrap(),
-        ]);
-        Some(Self {
-            x,
-            y,
-            timer,
-            power,
-            owner_id,
-        })
-    }
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct ExplosionComponent {
-    pub x: i32,
-    pub y: i32,
-    pub timer: u32,
-}
-
-impl ExplosionComponent {
-    pub fn new(x: i32, y: i32) -> Self {
-        Self {
-            x,
-            y,
-            timer: EXPLOSION_DURATION,
-        }
-    }
-}
-
-impl ComponentTrait for ExplosionComponent {
-    fn component_type() -> Symbol {
-        symbol_short!("explosion")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        bytes.append(&Bytes::from_array(env, &self.x.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.y.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.timer.to_be_bytes()));
-        bytes
-    }
-
-    #[allow(unused_variables)]
-    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() != 12 {
-            return None;
-        }
-        let x = i32::from_be_bytes([
-            data.get(0).unwrap(),
-            data.get(1).unwrap(),
-            data.get(2).unwrap(),
-            data.get(3).unwrap(),
-        ]);
-        let y = i32::from_be_bytes([
-            data.get(4).unwrap(),
-            data.get(5).unwrap(),
-            data.get(6).unwrap(),
-            data.get(7).unwrap(),
-        ]);
-        let timer = u32::from_be_bytes([
-            data.get(8).unwrap(),
-            data.get(9).unwrap(),
-            data.get(10).unwrap(),
-            data.get(11).unwrap(),
-        ]);
-        Some(Self { x, y, timer })
-    }
-}
-
-#[contracttype]
-#[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum PowerUpType {
-    Capacity = 0,
-    Power = 1,
-    Speed = 2,
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct PowerUpComponent {
-    pub x: i32,
-    pub y: i32,
-    pub power_up_type: PowerUpType,
-}
-
-impl PowerUpComponent {
-    pub fn new(x: i32, y: i32, power_up_type: PowerUpType) -> Self {
-        Self {
-            x,
-            y,
-            power_up_type,
-        }
-    }
-}
-
-impl ComponentTrait for PowerUpComponent {
-    fn component_type() -> Symbol {
-        symbol_short!("powerup")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        bytes.append(&Bytes::from_array(env, &self.x.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.y.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &[self.power_up_type as u8]));
-        bytes
-    }
-
-    #[allow(unused_variables)]
-    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() != 9 {
-            return None;
-        }
-        let x = i32::from_be_bytes([
-            data.get(0).unwrap(),
-            data.get(1).unwrap(),
-            data.get(2).unwrap(),
-            data.get(3).unwrap(),
-        ]);
-        let y = i32::from_be_bytes([
-            data.get(4).unwrap(),
-            data.get(5).unwrap(),
-            data.get(6).unwrap(),
-            data.get(7).unwrap(),
-        ]);
-        let power_up_type = match data.get(8).unwrap() {
-            0 => PowerUpType::Capacity,
-            1 => PowerUpType::Power,
-            2 => PowerUpType::Speed,
-            _ => return None,
-        };
-        Some(Self {
-            x,
-            y,
-            power_up_type,
-        })
-    }
-}
-
-// Grid cell types
-#[contracttype]
-#[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum CellType {
-    Empty = 0,
-    Wall = 1,
-    Destructible = 2,
-    PowerUp = 3,
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct GridComponent {
-    pub cells: Vec<CellType>,
-}
-
-impl GridComponent {
-    #[allow(clippy::if_same_then_else)]
-    pub fn new(env: &Env) -> Self {
-        let mut cells = Vec::new(env);
-
-        for _ in 0..(GRID_WIDTH * GRID_HEIGHT) {
-            cells.push_back(CellType::Empty);
-        }
-
-        // Initialize walls around the perimeter
-        for x in 0..GRID_WIDTH {
-            for y in 0..GRID_HEIGHT {
-                let index = y * GRID_WIDTH + x;
-                if x == 0 || x == GRID_WIDTH - 1 || y == 0 || y == GRID_HEIGHT - 1 {
-                    cells.set(index as u32, CellType::Wall);
-                } else if x % 2 == 0 && y % 2 == 0 {
-                    cells.set(index as u32, CellType::Wall);
-                }
-            }
-        }
-
-        // Add some destructible blocks
-        for x in 1..GRID_WIDTH - 1 {
-            for y in 1..GRID_HEIGHT - 1 {
-                let index = y * GRID_WIDTH + x;
-                if (x + y) % 3 == 0 && cells.get(index as u32).unwrap() == CellType::Empty {
-                    cells.set(index as u32, CellType::Destructible);
-                }
-            }
-        }
-
-        Self { cells }
-    }
-
-    pub fn get_cell(&self, x: usize, y: usize) -> CellType {
-        if x < GRID_WIDTH && y < GRID_HEIGHT {
-            self.cells
-                .get((y * GRID_WIDTH + x) as u32)
-                .unwrap_or(CellType::Wall)
-        } else {
-            CellType::Wall
-        }
-    }
-
-    pub fn set_cell(&mut self, x: usize, y: usize, cell_type: CellType) {
-        if x < GRID_WIDTH && y < GRID_HEIGHT {
-            self.cells.set((y * GRID_WIDTH + x) as u32, cell_type);
-        }
-    }
-
-    pub fn is_walkable(&self, x: i32, y: i32) -> bool {
-        if x < 0 || y < 0 || x >= GRID_WIDTH as i32 || y >= GRID_HEIGHT as i32 {
-            return false;
-        }
-        matches!(
-            self.get_cell(x as usize, y as usize),
-            CellType::Empty | CellType::PowerUp
-        )
-    }
-}
-
-impl ComponentTrait for GridComponent {
-    fn component_type() -> Symbol {
-        symbol_short!("grid")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        for cell in self.cells.iter() {
-            bytes.append(&Bytes::from_array(env, &[cell as u8]));
-        }
-        bytes
-    }
-
-    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() != (GRID_WIDTH * GRID_HEIGHT) as u32 {
-            return None;
-        }
-        let mut cells = Vec::new(env);
-        for i in 0..GRID_WIDTH * GRID_HEIGHT {
-            let cell = match data.get(i as u32).unwrap() {
-                0 => CellType::Empty,
-                1 => CellType::Wall,
-                2 => CellType::Destructible,
-                3 => CellType::PowerUp,
-                _ => return None,
-            };
-            cells.push_back(cell);
-        }
-        Some(Self { cells })
-    }
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct GameStateComponent {
-    pub current_tick: u32,
-    pub game_over: bool,
-    pub winner_id: Option<u32>,
-}
-
-impl GameStateComponent {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self {
-            current_tick: 0,
-            game_over: false,
-            winner_id: None,
-        }
-    }
-}
-
-impl ComponentTrait for GameStateComponent {
-    fn component_type() -> Symbol {
-        symbol_short!("gstate")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        bytes.append(&Bytes::from_array(env, &self.current_tick.to_be_bytes()));
-        bytes.append(&Bytes::from_array(
-            env,
-            &[if self.game_over { 1 } else { 0 }],
-        ));
-        match self.winner_id {
-            Some(id) => {
-                bytes.append(&Bytes::from_array(env, &[1]));
-                bytes.append(&Bytes::from_array(env, &id.to_be_bytes()));
-            }
-            None => {
-                bytes.append(&Bytes::from_array(env, &[0]));
-            }
-        }
-        bytes
-    }
-
-    #[allow(unused_variables)]
-    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() < 6 {
-            return None;
-        }
-        let current_tick = u32::from_be_bytes([
-            data.get(0).unwrap(),
-            data.get(1).unwrap(),
-            data.get(2).unwrap(),
-            data.get(3).unwrap(),
-        ]);
-        let game_over = data.get(4).unwrap() != 0;
-        let has_winner = data.get(5).unwrap() != 0;
-        let winner_id = if has_winner && data.len() >= 10 {
-            Some(u32::from_be_bytes([
-                data.get(6).unwrap(),
-                data.get(7).unwrap(),
-                data.get(8).unwrap(),
-                data.get(9).unwrap(),
-            ]))
-        } else {
-            None
-        };
-        Some(Self {
-            current_tick,
-            game_over,
-            winner_id,
-        })
-    }
 }
 
 #[contract]
@@ -532,30 +37,19 @@ pub struct BombermanContract;
 #[allow(unused_variables)]
 #[contractimpl]
 impl BombermanContract {
-    /// Initialize the game world using cougr-core ECS
-    /// This demonstrates how cougr-core simplifies persistent game state management
-    /// compared to vanilla Soroban where you'd manually handle storage keys and serialization
-    ///
-    /// Benefits of using cougr-core:
-    /// - Declarative component-based architecture
-    /// - Automatic serialization/deserialization through ComponentTrait
-    /// - Entity-Component queries for efficient game logic
-    /// - Clean separation of game state concerns
+    /// Initialize the game world.
     pub fn init_game(env: Env) -> Symbol {
         let mut world = SimpleWorld::new(&env);
 
-        // Spawn grid entity
         let grid = GridComponent::new(&env);
         let grid_entity = world.spawn_entity();
         world.set_typed(&env, grid_entity, &grid);
 
-        // Spawn game state entity
         let game_state = GameStateComponent::new();
         let game_state_entity = world.spawn_entity();
         world.set_typed(&env, game_state_entity, &game_state);
 
         // PowerUpSpawnSystem (init): place power-up entities at deterministic positions.
-        // Using (x+y) % 7 == 0 on empty cells — mirrors the old grid pattern but as ECS entities.
         for x in 1..GRID_WIDTH - 1 {
             for y in 1..GRID_HEIGHT - 1 {
                 if (x + y) % 7 == 0 && grid.get_cell(x, y) == CellType::Empty {
@@ -571,17 +65,14 @@ impl BombermanContract {
             }
         }
 
-        // Persist world
         env.storage().instance().set(&DataKey::World, &world);
-
         symbol_short!("init")
     }
 
-    /// Spawn a new player at a given position
+    /// Spawn a new player at a given position.
     pub fn spawn_player(env: Env, player_id: u32, x: i32, y: i32) -> Symbol {
         let mut world = Self::get_world(&env);
 
-        // Check if player ID already exists
         let player_entities =
             world.get_entities_with_component(&PlayerComponent::component_type(), &env);
         for entity_id in player_entities.iter() {
@@ -600,8 +91,7 @@ impl BombermanContract {
         symbol_short!("spawned")
     }
 
-    /// Move a player in the specified direction
-    /// Directions: 0=up, 1=right, 2=down, 3=left
+    /// Move a player in the specified direction (0=up, 1=right, 2=down, 3=left).
     pub fn move_player(env: Env, player_id: u32, direction: u32) -> Symbol {
         let mut world = Self::get_world(&env);
 
@@ -633,16 +123,13 @@ impl BombermanContract {
         let grid = world.get_typed::<GridComponent>(&env, grid_entity).unwrap();
 
         // Calculate new position
-        let (mut next_x, mut next_y) = (player.x, player.y);
-        match direction {
-            0 => next_y -= 1, // Up
-            1 => next_x += 1, // Right
-            2 => next_y += 1, // Down
-            3 => next_x -= 1, // Left
-            _ => return symbol_short!("inv_dir"),
-        }
+        let (dx, dy) = match direction_delta(direction) {
+            Some(d) => d,
+            None => return symbol_short!("inv_dir"),
+        };
+        let next_x = player.x + dx;
+        let next_y = player.y + dy;
 
-        // Validate move
         if !grid.is_walkable(next_x, next_y) {
             return symbol_short!("blocked");
         }
@@ -653,12 +140,9 @@ impl BombermanContract {
         for e_id in explosion_entities.iter() {
             if let Some(explosion) = world.get_typed::<ExplosionComponent>(&env, e_id) {
                 if explosion.x == next_x && explosion.y == next_y {
-                    // Player died
                     if player.lives > 0 {
                         player.lives -= 1;
                     }
-                    // Reset position to safe spot (optional, but requested logic is "death")
-                    // For now, let's just decrement lives and stay put or move and lose life
                 }
             }
         }
@@ -666,49 +150,18 @@ impl BombermanContract {
         player.x = next_x;
         player.y = next_y;
 
-        // PickupSystem: check for a power-up at the new position
-        let powerup_entities =
-            world.get_entities_with_component(&PowerUpComponent::component_type(), &env);
-        let mut pickup_id_opt = None;
-        let mut pickup_type_opt = None;
-        for pu_id in powerup_entities.iter() {
-            if let Some(pu) = world.get_typed::<PowerUpComponent>(&env, pu_id) {
-                if pu.x == next_x && pu.y == next_y {
-                    pickup_id_opt = Some(pu_id);
-                    pickup_type_opt = Some(pu.power_up_type);
-                    break;
-                }
-            }
-        }
-        if let (Some(pu_id), Some(pu_type)) = (pickup_id_opt, pickup_type_opt) {
-            match pu_type {
-                PowerUpType::Capacity => player.bomb_capacity += 1,
-                PowerUpType::Power => player.bomb_power += 1,
-                PowerUpType::Speed => player.speed += 1,
-            }
-            world.despawn_entity(pu_id);
-        }
+        // PickupSystem
+        pickup_system(&env, &mut world, &mut player, next_x, next_y);
 
         world.set_typed(&env, player_entity, &player);
-
-        // Save world
         env.storage().instance().set(&DataKey::World, &world);
-
         symbol_short!("moved")
     }
 
-    fn get_world(env: &Env) -> SimpleWorld {
-        env.storage()
-            .instance()
-            .get(&DataKey::World)
-            .expect("Game not initialized")
-    }
-
-    /// Place a bomb at the player's current position
+    /// Place a bomb at the player's current position.
     pub fn place_bomb(env: Env, player_id: u32) -> Symbol {
         let mut world = Self::get_world(&env);
 
-        // Find player position
         let player_entities =
             world.get_entities_with_component(&PlayerComponent::component_type(), &env);
         let mut player_opt = None;
@@ -726,7 +179,6 @@ impl BombermanContract {
             None => return symbol_short!("no_player"),
         };
 
-        // Check current bomb count for this player
         let bomb_entities =
             world.get_entities_with_component(&BombComponent::component_type(), &env);
         let mut owned_bombs = 0;
@@ -742,7 +194,6 @@ impl BombermanContract {
             return symbol_short!("cap_full");
         }
 
-        // Check if a bomb already exists at this position
         for b_id in bomb_entities.iter() {
             if let Some(bomb) = world.get_typed::<BombComponent>(&env, b_id) {
                 if bomb.x == player.x && bomb.y == player.y {
@@ -751,24 +202,19 @@ impl BombermanContract {
             }
         }
 
-        // Create bomb entity, using player's current power stat
         let mut bomb = BombComponent::new(player.x, player.y, player_id);
         bomb.power = player.bomb_power;
         let bomb_entity = world.spawn_entity();
         world.set_typed(&env, bomb_entity, &bomb);
 
-        // Save world
         env.storage().instance().set(&DataKey::World, &world);
-
         symbol_short!("bomb_plc")
     }
 
-    /// Advance the game tick - handle timers, explosions, collisions
-    /// This is where cougr-core's ECS shines for complex game logic
+    /// Advance the game tick — handle timers, explosions, and collisions.
     pub fn update_tick(env: Env) -> Symbol {
         let mut world = Self::get_world(&env);
 
-        // Update game state tick
         let state_entities =
             world.get_entities_with_component(&GameStateComponent::component_type(), &env);
         let state_entity = state_entities.get(0).expect("No game state");
@@ -782,214 +228,36 @@ impl BombermanContract {
 
         game_state.current_tick += 1;
 
-        // Find grid
         let grid_entities =
             world.get_entities_with_component(&GridComponent::component_type(), &env);
         let grid_entity = grid_entities.get(0).expect("No grid");
         let mut grid = world.get_typed::<GridComponent>(&env, grid_entity).unwrap();
 
-        // 1. Process explosion timers
-        let explosion_entities =
-            world.get_entities_with_component(&ExplosionComponent::component_type(), &env);
-        for e_id in explosion_entities.iter() {
-            if let Some(mut explosion) = world.get_typed::<ExplosionComponent>(&env, e_id) {
-                if explosion.timer > 0 {
-                    explosion.timer -= 1;
-                }
-                if explosion.timer == 0 {
-                    world.despawn_entity(e_id);
-                } else {
-                    world.set_typed(&env, e_id, &explosion);
-                }
-            }
-        }
+        // 1. ExplosionTimerSystem
+        explosion_timer_system(&env, &mut world);
 
-        // 2. BombTimerSystem: decrement timers and collect bombs that expire this tick.
-        // ChainReactionSystem: after each detonation, any bomb overlapping an explosion
-        // is immediately queued for detonation in the same tick.
-        {
-            // First pass: decrement timers and collect naturally-expiring bombs
-            let bomb_entities =
-                world.get_entities_with_component(&BombComponent::component_type(), &env);
-            let mut detonation_queue: Vec<BombComponent> = Vec::new(&env);
+        // 2. BombTimerSystem + ChainReactionSystem
+        bomb_timer_and_chain_system(&env, &mut world, &mut grid);
 
-            for b_id in bomb_entities.iter() {
-                if let Some(mut bomb) = world.get_typed::<BombComponent>(&env, b_id) {
-                    if bomb.timer > 0 {
-                        bomb.timer -= 1;
-                    }
-                    if bomb.timer == 0 {
-                        detonation_queue.push_back(bomb);
-                        world.despawn_entity(b_id);
-                    } else {
-                        world.set_typed(&env, b_id, &bomb);
-                    }
-                }
-            }
+        // 3. PlayerDeathSystem
+        player_death_system(&env, &mut world);
 
-            // Iterative chain-reaction resolution: detonate a bomb, then check if
-            // its new explosions overlap any remaining live bombs.  Repeat until
-            // the queue is empty.  This models cascading detonations within one tick.
-            let mut head = 0u32;
-            while head < detonation_queue.len() {
-                let bomb = detonation_queue.get(head).unwrap();
-                head += 1;
-
-                Self::detonate_bomb(&env, &mut world, &mut grid, &bomb);
-
-                // Scan remaining live bombs for chain-reaction overlap
-                let remaining =
-                    world.get_entities_with_component(&BombComponent::component_type(), &env);
-                let active_expl =
-                    world.get_entities_with_component(&ExplosionComponent::component_type(), &env);
-
-                for r_id in remaining.iter() {
-                    if let Some(remaining_bomb) = world.get_typed::<BombComponent>(&env, r_id) {
-                        // Check if any explosion cell hits this bomb's position
-                        let mut chain = false;
-                        for e_id in active_expl.iter() {
-                            if let Some(expl) = world.get_typed::<ExplosionComponent>(&env, e_id) {
-                                if expl.x == remaining_bomb.x && expl.y == remaining_bomb.y {
-                                    chain = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if chain {
-                            detonation_queue.push_back(remaining_bomb);
-                            world.despawn_entity(r_id);
-                        }
-                    }
-                }
-            }
-        }
-
-        // 3. Check for player deaths (collision with explosions)
-        let player_entities =
-            world.get_entities_with_component(&PlayerComponent::component_type(), &env);
-        let active_explosions =
-            world.get_entities_with_component(&ExplosionComponent::component_type(), &env);
-
-        for p_id in player_entities.iter() {
-            if let Some(mut player) = world.get_typed::<PlayerComponent>(&env, p_id) {
-                if player.lives == 0 {
-                    continue;
-                }
-
-                let mut hit = false;
-                for e_id in active_explosions.iter() {
-                    if let Some(explosion) = world.get_typed::<ExplosionComponent>(&env, e_id) {
-                        if explosion.x == player.x && explosion.y == player.y {
-                            hit = true;
-                            break;
-                        }
-                    }
-                }
-
-                if hit {
-                    player.lives -= 1;
-                    world.set_typed(&env, p_id, &player);
-                }
-            }
-        }
-
-        // 4. Update Grid and GameState
+        // 4. Persist updated grid
         world.set_typed(&env, grid_entity, &grid);
 
-        // Win/loss detection
-        let mut alive_players = 0;
-        let mut last_alive_id = 0;
-        for p_id in player_entities.iter() {
-            if let Some(player) = world.get_typed::<PlayerComponent>(&env, p_id) {
-                if player.lives > 0 {
-                    alive_players += 1;
-                    last_alive_id = player.id;
-                }
-            }
-        }
-
-        if alive_players <= 1 {
-            game_state.game_over = true;
-            if alive_players == 1 {
-                game_state.winner_id = Some(last_alive_id);
-            }
-        }
+        // 5. WinConditionSystem
+        win_condition_system(&env, &mut world, &mut game_state);
 
         world.set_typed(&env, state_entity, &game_state);
-
-        // Save world
         env.storage().instance().set(&DataKey::World, &world);
-
         symbol_short!("tick_upd")
     }
 
-    fn detonate_bomb(
-        env: &Env,
-        world: &mut SimpleWorld,
-        grid: &mut GridComponent,
-        bomb: &BombComponent,
-    ) {
-        // Spawn center explosion
-        let center_exp = ExplosionComponent::new(bomb.x, bomb.y);
-        let center_id = world.spawn_entity();
-        world.set_typed(env, center_id, &center_exp);
-
-        // Propagate in 4 directions
-        let dirs = [(0, -1), (1, 0), (0, 1), (-1, 0)];
-        for (dx, dy) in dirs {
-            for dist in 1..=bomb.power {
-                let x = bomb.x + dx * dist as i32;
-                let y = bomb.y + dy * dist as i32;
-
-                if x < 0 || y < 0 || x >= GRID_WIDTH as i32 || y >= GRID_HEIGHT as i32 {
-                    break;
-                }
-
-                let cell = grid.get_cell(x as usize, y as usize);
-                if cell == CellType::Wall {
-                    break;
-                }
-
-                // Spawn explosion
-                let exp = ExplosionComponent::new(x, y);
-                let exp_id = world.spawn_entity();
-                world.set_typed(env, exp_id, &exp);
-
-                if cell == CellType::Destructible {
-                    grid.set_cell(x as usize, y as usize, CellType::Empty);
-
-                    // PowerUpSpawnSystem: deterministically drop a power-up from
-                    // destroyed blocks.  Using (x+y)%4==0 keeps ~25% drop rate.
-                    if (x + y) % 4 == 0 {
-                        let pu_type = match (x + y) % 3 {
-                            0 => PowerUpType::Capacity,
-                            1 => PowerUpType::Power,
-                            _ => PowerUpType::Speed,
-                        };
-                        let pu = PowerUpComponent::new(x, y, pu_type);
-                        let pu_entity = world.spawn_entity();
-                        world.set_typed(env, pu_entity, &pu);
-                    }
-
-                    break; // Blocked by destructible but destroys it
-                }
-
-                if cell == CellType::PowerUp {
-                    // Legacy grid cell destroyed — already migrated to ECS entities.
-                    // The PowerUpComponent entity at this tile (if any) will be
-                    // despawned by the PickupSystem or explosion overlap checks.
-                    grid.set_cell(x as usize, y as usize, CellType::Empty);
-                }
-            }
-        }
-    }
-
-    /// Get the current score for a player
+    /// Get the current score for a player.
     pub fn get_score(env: Env, player_id: u32) -> u32 {
         let world = Self::get_world(&env);
         let player_entities =
             world.get_entities_with_component(&PlayerComponent::component_type(), &env);
-
         for entity_id in player_entities.iter() {
             if let Some(player) = world.get_typed::<PlayerComponent>(&env, entity_id) {
                 if player.id == player_id {
@@ -1000,12 +268,11 @@ impl BombermanContract {
         0
     }
 
-    /// Get the current lives for a player
+    /// Get the current lives for a player.
     pub fn get_lives(env: Env, player_id: u32) -> u32 {
         let world = Self::get_world(&env);
         let player_entities =
             world.get_entities_with_component(&PlayerComponent::component_type(), &env);
-
         for entity_id in player_entities.iter() {
             if let Some(player) = world.get_typed::<PlayerComponent>(&env, entity_id) {
                 if player.id == player_id {
@@ -1016,7 +283,7 @@ impl BombermanContract {
         0
     }
 
-    /// Check if the game is over and return winner if any
+    /// Check if the game is over and return winner status.
     pub fn check_game_over(env: Env) -> Symbol {
         let world = Self::get_world(&env);
         let state_entities =
@@ -1039,7 +306,16 @@ impl BombermanContract {
         }
     }
 
-    pub fn hello(env: Env, to: Symbol) -> Symbol {
+    pub fn hello(_env: Env, to: Symbol) -> Symbol {
         to
+    }
+
+    // ── Storage helper ────────────────────────────────────────────────────────
+
+    fn get_world(env: &Env) -> SimpleWorld {
+        env.storage()
+            .instance()
+            .get(&DataKey::World)
+            .expect("Game not initialized")
     }
 }

--- a/examples/bomberman/src/systems.rs
+++ b/examples/bomberman/src/systems.rs
@@ -12,10 +12,10 @@ use crate::components::{
 /// Returns `None` for invalid direction codes.
 pub(crate) fn direction_delta(direction: u32) -> Option<(i32, i32)> {
     match direction {
-        0 => Some((0, -1)),  // Up
-        1 => Some((1, 0)),   // Right
-        2 => Some((0, 1)),   // Down
-        3 => Some((-1, 0)),  // Left
+        0 => Some((0, -1)), // Up
+        1 => Some((1, 0)),  // Right
+        2 => Some((0, 1)),  // Down
+        3 => Some((-1, 0)), // Left
         _ => None,
     }
 }

--- a/examples/bomberman/src/systems.rs
+++ b/examples/bomberman/src/systems.rs
@@ -1,3 +1,4 @@
+use cougr_core::component::ComponentTrait;
 use cougr_core::SimpleWorld;
 use soroban_sdk::{Env, Vec};
 

--- a/examples/bomberman/src/systems.rs
+++ b/examples/bomberman/src/systems.rs
@@ -1,0 +1,259 @@
+use cougr_core::SimpleWorld;
+use soroban_sdk::{Env, Vec};
+
+use crate::components::{
+    BombComponent, CellType, ExplosionComponent, GameStateComponent, GridComponent,
+    PlayerComponent, PowerUpComponent, PowerUpType, GRID_HEIGHT, GRID_WIDTH,
+};
+
+// ── MovementSystem ────────────────────────────────────────────────────────────
+
+/// Translates a direction code into a (dx, dy) delta.
+/// Returns `None` for invalid direction codes.
+pub(crate) fn direction_delta(direction: u32) -> Option<(i32, i32)> {
+    match direction {
+        0 => Some((0, -1)),  // Up
+        1 => Some((1, 0)),   // Right
+        2 => Some((0, 1)),   // Down
+        3 => Some((-1, 0)),  // Left
+        _ => None,
+    }
+}
+
+// ── PickupSystem ──────────────────────────────────────────────────────────────
+
+/// Checks whether a power-up entity exists at `(x, y)`.  If so, applies the
+/// buff to `player`, despawns the entity, and returns `true`.
+pub(crate) fn pickup_system(
+    env: &Env,
+    world: &mut SimpleWorld,
+    player: &mut PlayerComponent,
+    x: i32,
+    y: i32,
+) {
+    let powerup_entities =
+        world.get_entities_with_component(&PowerUpComponent::component_type(), env);
+    let mut pickup_id_opt = None;
+    let mut pickup_type_opt = None;
+    for pu_id in powerup_entities.iter() {
+        if let Some(pu) = world.get_typed::<PowerUpComponent>(env, pu_id) {
+            if pu.x == x && pu.y == y {
+                pickup_id_opt = Some(pu_id);
+                pickup_type_opt = Some(pu.power_up_type);
+                break;
+            }
+        }
+    }
+    if let (Some(pu_id), Some(pu_type)) = (pickup_id_opt, pickup_type_opt) {
+        match pu_type {
+            PowerUpType::Capacity => player.bomb_capacity += 1,
+            PowerUpType::Power => player.bomb_power += 1,
+            PowerUpType::Speed => player.speed += 1,
+        }
+        world.despawn_entity(pu_id);
+    }
+}
+
+// ── ExplosionPropagationSystem ────────────────────────────────────────────────
+
+/// Detonates a bomb: spawns explosion entities at the bomb's position and in
+/// all four cardinal directions up to `bomb.power` cells, stopping at walls
+/// and destroying destructible blocks.  Also runs `PowerUpSpawnSystem` on
+/// destroyed blocks.
+pub(crate) fn detonate_bomb(
+    env: &Env,
+    world: &mut SimpleWorld,
+    grid: &mut GridComponent,
+    bomb: &BombComponent,
+) {
+    // Spawn center explosion
+    let center_exp = ExplosionComponent::new(bomb.x, bomb.y);
+    let center_id = world.spawn_entity();
+    world.set_typed(env, center_id, &center_exp);
+
+    let dirs = [(0i32, -1i32), (1, 0), (0, 1), (-1, 0)];
+    for (dx, dy) in dirs {
+        for dist in 1..=bomb.power {
+            let x = bomb.x + dx * dist as i32;
+            let y = bomb.y + dy * dist as i32;
+
+            if x < 0 || y < 0 || x >= GRID_WIDTH as i32 || y >= GRID_HEIGHT as i32 {
+                break;
+            }
+
+            let cell = grid.get_cell(x as usize, y as usize);
+            if cell == CellType::Wall {
+                break;
+            }
+
+            let exp = ExplosionComponent::new(x, y);
+            let exp_id = world.spawn_entity();
+            world.set_typed(env, exp_id, &exp);
+
+            if cell == CellType::Destructible {
+                grid.set_cell(x as usize, y as usize, CellType::Empty);
+                // PowerUpSpawnSystem: ~25% drop rate on destroyed blocks
+                powerup_spawn_system(env, world, x, y);
+                break;
+            }
+
+            if cell == CellType::PowerUp {
+                grid.set_cell(x as usize, y as usize, CellType::Empty);
+            }
+        }
+    }
+}
+
+// ── PowerUpSpawnSystem ────────────────────────────────────────────────────────
+
+/// Deterministically spawns a power-up entity at `(x, y)` when `(x+y)%4==0`.
+pub(crate) fn powerup_spawn_system(env: &Env, world: &mut SimpleWorld, x: i32, y: i32) {
+    if (x + y) % 4 == 0 {
+        let pu_type = match (x + y) % 3 {
+            0 => PowerUpType::Capacity,
+            1 => PowerUpType::Power,
+            _ => PowerUpType::Speed,
+        };
+        let pu = PowerUpComponent::new(x, y, pu_type);
+        let pu_entity = world.spawn_entity();
+        world.set_typed(env, pu_entity, &pu);
+    }
+}
+
+// ── BombTimerSystem + ChainReactionSystem ─────────────────────────────────────
+
+/// Decrements all bomb timers.  Bombs that reach zero are detonated.
+/// After each detonation, any remaining live bomb overlapping a fresh explosion
+/// is immediately queued for chain detonation in the same tick.
+pub(crate) fn bomb_timer_and_chain_system(
+    env: &Env,
+    world: &mut SimpleWorld,
+    grid: &mut GridComponent,
+) {
+    let bomb_entities = world.get_entities_with_component(&BombComponent::component_type(), env);
+    let mut detonation_queue: Vec<BombComponent> = Vec::new(env);
+
+    for b_id in bomb_entities.iter() {
+        if let Some(mut bomb) = world.get_typed::<BombComponent>(env, b_id) {
+            if bomb.timer > 0 {
+                bomb.timer -= 1;
+            }
+            if bomb.timer == 0 {
+                detonation_queue.push_back(bomb);
+                world.despawn_entity(b_id);
+            } else {
+                world.set_typed(env, b_id, &bomb);
+            }
+        }
+    }
+
+    let mut head = 0u32;
+    while head < detonation_queue.len() {
+        let bomb = detonation_queue.get(head).unwrap();
+        head += 1;
+
+        detonate_bomb(env, world, grid, &bomb);
+
+        // ChainReactionSystem: check remaining live bombs for overlap with new explosions
+        let remaining = world.get_entities_with_component(&BombComponent::component_type(), env);
+        let active_expl =
+            world.get_entities_with_component(&ExplosionComponent::component_type(), env);
+
+        for r_id in remaining.iter() {
+            if let Some(remaining_bomb) = world.get_typed::<BombComponent>(env, r_id) {
+                let mut chain = false;
+                for e_id in active_expl.iter() {
+                    if let Some(expl) = world.get_typed::<ExplosionComponent>(env, e_id) {
+                        if expl.x == remaining_bomb.x && expl.y == remaining_bomb.y {
+                            chain = true;
+                            break;
+                        }
+                    }
+                }
+                if chain {
+                    detonation_queue.push_back(remaining_bomb);
+                    world.despawn_entity(r_id);
+                }
+            }
+        }
+    }
+}
+
+// ── ExplosionTimerSystem ──────────────────────────────────────────────────────
+
+/// Decrements explosion timers and despawns expired explosions.
+pub(crate) fn explosion_timer_system(env: &Env, world: &mut SimpleWorld) {
+    let explosion_entities =
+        world.get_entities_with_component(&ExplosionComponent::component_type(), env);
+    for e_id in explosion_entities.iter() {
+        if let Some(mut explosion) = world.get_typed::<ExplosionComponent>(env, e_id) {
+            if explosion.timer > 0 {
+                explosion.timer -= 1;
+            }
+            if explosion.timer == 0 {
+                world.despawn_entity(e_id);
+            } else {
+                world.set_typed(env, e_id, &explosion);
+            }
+        }
+    }
+}
+
+// ── PlayerDeathSystem ─────────────────────────────────────────────────────────
+
+/// Checks each player against active explosions and decrements lives on hit.
+pub(crate) fn player_death_system(env: &Env, world: &mut SimpleWorld) {
+    let player_entities =
+        world.get_entities_with_component(&PlayerComponent::component_type(), env);
+    let active_explosions =
+        world.get_entities_with_component(&ExplosionComponent::component_type(), env);
+
+    for p_id in player_entities.iter() {
+        if let Some(mut player) = world.get_typed::<PlayerComponent>(env, p_id) {
+            if player.lives == 0 {
+                continue;
+            }
+            let mut hit = false;
+            for e_id in active_explosions.iter() {
+                if let Some(explosion) = world.get_typed::<ExplosionComponent>(env, e_id) {
+                    if explosion.x == player.x && explosion.y == player.y {
+                        hit = true;
+                        break;
+                    }
+                }
+            }
+            if hit {
+                player.lives -= 1;
+                world.set_typed(env, p_id, &player);
+            }
+        }
+    }
+}
+
+// ── WinConditionSystem ────────────────────────────────────────────────────────
+
+/// Checks alive player count and updates `GameStateComponent` accordingly.
+pub(crate) fn win_condition_system(
+    env: &Env,
+    world: &mut SimpleWorld,
+    game_state: &mut GameStateComponent,
+) {
+    let player_entities =
+        world.get_entities_with_component(&PlayerComponent::component_type(), env);
+    let mut alive_players = 0u32;
+    let mut last_alive_id = 0u32;
+    for p_id in player_entities.iter() {
+        if let Some(player) = world.get_typed::<PlayerComponent>(env, p_id) {
+            if player.lives > 0 {
+                alive_players += 1;
+                last_alive_id = player.id;
+            }
+        }
+    }
+    if alive_players <= 1 {
+        game_state.game_over = true;
+        if alive_players == 1 {
+            game_state.winner_id = Some(last_alive_id);
+        }
+    }
+}

--- a/examples/trading_card_game/src/components.rs
+++ b/examples/trading_card_game/src/components.rs
@@ -1,0 +1,420 @@
+use cougr_core::component::ComponentTrait;
+use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Symbol, Vec};
+
+// ── Error codes ──────────────────────────────────────────────────────────────
+
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum GameError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    NotYourTurn = 3,
+    NotAPlayer = 4,
+    InvalidCard = 5,
+    InsufficientMana = 6,
+    CardNotInHand = 7,
+    FieldFull = 8,
+    InvalidTarget = 9,
+    WrongPhase = 10,
+    GameOver = 11,
+    BatchEmpty = 12,
+    InvalidAction = 13,
+    InvalidPosition = 14,
+    SessionExpired = 15,
+}
+
+// ── Card kinds ───────────────────────────────────────────────────────────────
+
+pub const KIND_CREATURE: u32 = 0;
+pub const KIND_SPELL: u32 = 1;
+
+// ── Match phases ─────────────────────────────────────────────────────────────
+
+pub const PHASE_DRAW: u32 = 0;
+pub const PHASE_MAIN: u32 = 1;
+pub const PHASE_COMBAT: u32 = 2;
+pub const PHASE_END: u32 = 3;
+
+// ── Match status ─────────────────────────────────────────────────────────────
+
+pub const STATUS_IN_PROGRESS: u32 = 0;
+pub const STATUS_A_WINS: u32 = 1;
+pub const STATUS_B_WINS: u32 = 2;
+pub const STATUS_CONCEDED: u32 = 3;
+
+// ── Field / hand limits ──────────────────────────────────────────────────────
+
+pub const MAX_HAND: u32 = 7;
+pub const MAX_FIELD: u32 = 5;
+pub const MAX_MANA: u32 = 10;
+pub const STARTING_HEALTH: u32 = 20;
+pub const STARTING_HAND_SIZE: u32 = 4;
+
+// ── Action symbols ───────────────────────────────────────────────────────────
+
+pub const SYM_PLAY: Symbol = symbol_short!("play");
+pub const SYM_SPELL: Symbol = symbol_short!("spell");
+pub const SYM_ATTACK: Symbol = symbol_short!("attack");
+pub const SYM_CONCEDE: Symbol = symbol_short!("concede");
+
+// ── Card definition ──────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Card {
+    pub id: u32,
+    pub kind: u32,
+    pub cost: u32,
+    pub power: u32,
+    pub toughness: u32,
+}
+
+impl Card {
+    pub fn new(id: u32, kind: u32, cost: u32, power: u32, toughness: u32) -> Self {
+        Self {
+            id,
+            kind,
+            cost,
+            power,
+            toughness,
+        }
+    }
+}
+
+// ── CreatureState ────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CreatureState {
+    pub card_id: u32,
+    pub power: u32,
+    pub toughness: u32,
+    pub current_toughness: u32,
+}
+
+impl CreatureState {
+    pub fn new(card_id: u32, power: u32, toughness: u32) -> Self {
+        Self {
+            card_id,
+            power,
+            toughness,
+            current_toughness: toughness,
+        }
+    }
+}
+
+// ── PlayerHand ───────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PlayerHand {
+    pub cards: Vec<u32>,
+    pub entity_id: u32,
+}
+
+impl PlayerHand {
+    pub fn new(env: &Env, entity_id: u32) -> Self {
+        Self {
+            cards: Vec::new(env),
+            entity_id,
+        }
+    }
+}
+
+impl ComponentTrait for PlayerHand {
+    fn component_type() -> Symbol {
+        symbol_short!("hand")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.append(&Bytes::from_array(env, &self.entity_id.to_be_bytes()));
+        let len = self.cards.len();
+        bytes.append(&Bytes::from_array(env, &len.to_be_bytes()));
+        for i in 0..len {
+            let card_id = self.cards.get(i).unwrap_or(0);
+            bytes.append(&Bytes::from_array(env, &card_id.to_be_bytes()));
+        }
+        bytes
+    }
+
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() < 8 {
+            return None;
+        }
+        let entity_id = u32::from_be_bytes([
+            data.get(0).unwrap(),
+            data.get(1).unwrap(),
+            data.get(2).unwrap(),
+            data.get(3).unwrap(),
+        ]);
+        let len = u32::from_be_bytes([
+            data.get(4).unwrap(),
+            data.get(5).unwrap(),
+            data.get(6).unwrap(),
+            data.get(7).unwrap(),
+        ]);
+        let mut cards = Vec::new(env);
+        for i in 0..len {
+            let offset = 8 + (i * 4);
+            let card_id = u32::from_be_bytes([
+                data.get(offset).unwrap(),
+                data.get(offset + 1).unwrap(),
+                data.get(offset + 2).unwrap(),
+                data.get(offset + 3).unwrap(),
+            ]);
+            cards.push_back(card_id);
+        }
+        Some(Self { cards, entity_id })
+    }
+}
+
+// ── PlayerField ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PlayerField {
+    pub creatures: Vec<CreatureState>,
+    pub entity_id: u32,
+}
+
+impl PlayerField {
+    pub fn new(env: &Env, entity_id: u32) -> Self {
+        Self {
+            creatures: Vec::new(env),
+            entity_id,
+        }
+    }
+}
+
+impl ComponentTrait for PlayerField {
+    fn component_type() -> Symbol {
+        symbol_short!("field")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.append(&Bytes::from_array(env, &self.entity_id.to_be_bytes()));
+        let len = self.creatures.len();
+        bytes.append(&Bytes::from_array(env, &len.to_be_bytes()));
+        for i in 0..len {
+            let c = self.creatures.get(i).unwrap();
+            bytes.append(&Bytes::from_array(env, &c.card_id.to_be_bytes()));
+            bytes.append(&Bytes::from_array(env, &c.power.to_be_bytes()));
+            bytes.append(&Bytes::from_array(env, &c.toughness.to_be_bytes()));
+            bytes.append(&Bytes::from_array(env, &c.current_toughness.to_be_bytes()));
+        }
+        bytes
+    }
+
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() < 8 {
+            return None;
+        }
+        let entity_id = u32::from_be_bytes([
+            data.get(0).unwrap(),
+            data.get(1).unwrap(),
+            data.get(2).unwrap(),
+            data.get(3).unwrap(),
+        ]);
+        let len = u32::from_be_bytes([
+            data.get(4).unwrap(),
+            data.get(5).unwrap(),
+            data.get(6).unwrap(),
+            data.get(7).unwrap(),
+        ]);
+        let mut creatures = Vec::new(env);
+        for i in 0..len {
+            let base = 8 + (i * 16);
+            let card_id = u32::from_be_bytes([
+                data.get(base).unwrap(),
+                data.get(base + 1).unwrap(),
+                data.get(base + 2).unwrap(),
+                data.get(base + 3).unwrap(),
+            ]);
+            let power = u32::from_be_bytes([
+                data.get(base + 4).unwrap(),
+                data.get(base + 5).unwrap(),
+                data.get(base + 6).unwrap(),
+                data.get(base + 7).unwrap(),
+            ]);
+            let toughness = u32::from_be_bytes([
+                data.get(base + 8).unwrap(),
+                data.get(base + 9).unwrap(),
+                data.get(base + 10).unwrap(),
+                data.get(base + 11).unwrap(),
+            ]);
+            let current_toughness = u32::from_be_bytes([
+                data.get(base + 12).unwrap(),
+                data.get(base + 13).unwrap(),
+                data.get(base + 14).unwrap(),
+                data.get(base + 15).unwrap(),
+            ]);
+            creatures.push_back(CreatureState {
+                card_id,
+                power,
+                toughness,
+                current_toughness,
+            });
+        }
+        Some(Self {
+            creatures,
+            entity_id,
+        })
+    }
+}
+
+// ── PlayerStats ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PlayerStats {
+    pub health: u32,
+    pub mana: u32,
+    pub max_mana: u32,
+    pub entity_id: u32,
+}
+
+impl PlayerStats {
+    pub fn new(entity_id: u32) -> Self {
+        Self {
+            health: STARTING_HEALTH,
+            mana: 1,
+            max_mana: 1,
+            entity_id,
+        }
+    }
+}
+
+impl ComponentTrait for PlayerStats {
+    fn component_type() -> Symbol {
+        symbol_short!("pstats")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.append(&Bytes::from_array(env, &self.entity_id.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.health.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.mana.to_be_bytes()));
+        bytes.append(&Bytes::from_array(env, &self.max_mana.to_be_bytes()));
+        bytes
+    }
+
+    fn deserialize(_env: &Env, data: &Bytes) -> Option<Self> {
+        if data.len() != 16 {
+            return None;
+        }
+        let entity_id = u32::from_be_bytes([
+            data.get(0).unwrap(),
+            data.get(1).unwrap(),
+            data.get(2).unwrap(),
+            data.get(3).unwrap(),
+        ]);
+        let health = u32::from_be_bytes([
+            data.get(4).unwrap(),
+            data.get(5).unwrap(),
+            data.get(6).unwrap(),
+            data.get(7).unwrap(),
+        ]);
+        let mana = u32::from_be_bytes([
+            data.get(8).unwrap(),
+            data.get(9).unwrap(),
+            data.get(10).unwrap(),
+            data.get(11).unwrap(),
+        ]);
+        let max_mana = u32::from_be_bytes([
+            data.get(12).unwrap(),
+            data.get(13).unwrap(),
+            data.get(14).unwrap(),
+            data.get(15).unwrap(),
+        ]);
+        Some(Self {
+            health,
+            mana,
+            max_mana,
+            entity_id,
+        })
+    }
+}
+
+// ── MatchState ───────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MatchState {
+    pub turn: u32,
+    pub active_player: Address,
+    pub phase: u32,
+    pub status: u32,
+    pub entity_id: u32,
+}
+
+impl MatchState {
+    pub fn new(active_player: Address, entity_id: u32) -> Self {
+        Self {
+            turn: 1,
+            active_player,
+            phase: PHASE_DRAW,
+            status: STATUS_IN_PROGRESS,
+            entity_id,
+        }
+    }
+}
+
+// ── ECSWorldState ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ECSWorldState {
+    pub player_a: Address,
+    pub player_b: Address,
+    pub deck_a: Vec<u32>,
+    pub deck_b: Vec<u32>,
+    pub hand_a: PlayerHand,
+    pub hand_b: PlayerHand,
+    pub field_a: PlayerField,
+    pub field_b: PlayerField,
+    pub stats_a: PlayerStats,
+    pub stats_b: PlayerStats,
+    pub match_state: MatchState,
+    pub session_a_expires: u64,
+    pub session_b_expires: u64,
+    pub next_entity_id: u32,
+}
+
+// ── Action enum ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub enum Action {
+    PlayCreature(u32),
+    CastSpell(u32),
+    DeclareAttack(u32, u32),
+}
+
+// ── TurnResult ────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TurnResult {
+    pub success: bool,
+    pub actions_executed: u32,
+    pub match_status: u32,
+    pub message: Symbol,
+}
+
+// ── FieldState (external view) ────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FieldState {
+    pub field_a: Vec<CreatureState>,
+    pub field_b: Vec<CreatureState>,
+}
+
+// ── Storage key ──────────────────────────────────────────────────────────────
+
+pub const WORLD_KEY: Symbol = symbol_short!("WORLD");

--- a/examples/trading_card_game/src/lib.rs
+++ b/examples/trading_card_game/src/lib.rs
@@ -6,7 +6,7 @@ mod systems;
 mod test;
 
 use components::{
-    Action, Card, ECSWorldState, FieldState, GameError, MatchState, PlayerHand, PlayerField,
+    Action, Card, ECSWorldState, FieldState, GameError, MatchState, PlayerField, PlayerHand,
     PlayerStats, TurnResult, PHASE_DRAW, STARTING_HAND_SIZE, STATUS_CONCEDED, STATUS_IN_PROGRESS,
     SYM_ATTACK, SYM_PLAY, SYM_SPELL, WORLD_KEY,
 };

--- a/examples/trading_card_game/src/lib.rs
+++ b/examples/trading_card_game/src/lib.rs
@@ -18,7 +18,9 @@ use systems::{
 };
 
 use cougr_core::auth::{BatchBuilder, GameAction, SessionBuilder};
-use soroban_sdk::{contract, contractimpl, panic_with_error, symbol_short, Address, Bytes, Env, Vec};
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, symbol_short, Address, Bytes, Env, Vec,
+};
 
 #[contract]
 pub struct TradingCardGame;

--- a/examples/trading_card_game/src/lib.rs
+++ b/examples/trading_card_game/src/lib.rs
@@ -1,459 +1,33 @@
 #![no_std]
 
-use cougr_core::auth::{BatchBuilder, GameAction, SessionBuilder};
-use cougr_core::component::ComponentTrait;
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
-    Bytes, Env, Symbol, Vec,
+mod components;
+mod systems;
+#[cfg(test)]
+mod test;
+
+use components::{
+    Action, Card, ECSWorldState, FieldState, GameError, MatchState, PlayerHand, PlayerField,
+    PlayerStats, TurnResult, PHASE_DRAW, STARTING_HAND_SIZE, STATUS_CONCEDED, STATUS_IN_PROGRESS,
+    SYM_ATTACK, SYM_PLAY, SYM_SPELL, WORLD_KEY,
+};
+use systems::{
+    card_definition, cast_spell_system, combat_system, draw_system, mana_system, play_card_system,
+    win_condition_system,
 };
 
-// ─── Error codes ────────────────────────────────────────────────────────────
+use cougr_core::auth::{BatchBuilder, GameAction, SessionBuilder};
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, symbol_short, Address, Bytes, Env, Vec,
+};
 
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum GameError {
-    NotInitialized = 1,
-    AlreadyInitialized = 2,
-    NotYourTurn = 3,
-    NotAPlayer = 4,
-    InvalidCard = 5,
-    InsufficientMana = 6,
-    CardNotInHand = 7,
-    FieldFull = 8,
-    InvalidTarget = 9,
-    WrongPhase = 10,
-    GameOver = 11,
-    BatchEmpty = 12,
-    InvalidAction = 13,
-    InvalidPosition = 14,
-    SessionExpired = 15,
-}
-
-// ─── Card kinds ─────────────────────────────────────────────────────────────
-
-/// 0 = Creature, 1 = Spell
-pub const KIND_CREATURE: u32 = 0;
-pub const KIND_SPELL: u32 = 1;
-
-// ─── Match phases ────────────────────────────────────────────────────────────
-
-/// 0 = Draw, 1 = Main, 2 = Combat, 3 = End
-pub const PHASE_DRAW: u32 = 0;
-pub const PHASE_MAIN: u32 = 1;
-pub const PHASE_COMBAT: u32 = 2;
-pub const PHASE_END: u32 = 3;
-
-// ─── Match status ────────────────────────────────────────────────────────────
-
-/// 0 = InProgress, 1 = PlayerAWins, 2 = PlayerBWins, 3 = Conceded
-pub const STATUS_IN_PROGRESS: u32 = 0;
-pub const STATUS_A_WINS: u32 = 1;
-pub const STATUS_B_WINS: u32 = 2;
-pub const STATUS_CONCEDED: u32 = 3;
-
-// ─── Field capacity ─────────────────────────────────────────────────────────
-
-pub const MAX_HAND: u32 = 7;
-pub const MAX_FIELD: u32 = 5;
-pub const MAX_MANA: u32 = 10;
-pub const STARTING_HEALTH: u32 = 20;
-pub const STARTING_HAND_SIZE: u32 = 4;
-
-// ─── Action symbols ─────────────────────────────────────────────────────────
-
-pub const SYM_PLAY: Symbol = symbol_short!("play");
-pub const SYM_SPELL: Symbol = symbol_short!("spell");
-pub const SYM_ATTACK: Symbol = symbol_short!("attack");
-pub const SYM_CONCEDE: Symbol = symbol_short!("concede");
-
-// ─── Components ─────────────────────────────────────────────────────────────
-
-/// A single card definition.
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct Card {
-    pub id: u32,
-    pub kind: u32, // KIND_CREATURE | KIND_SPELL
-    pub cost: u32,
-    pub power: u32,
-    pub toughness: u32,
-}
-
-impl Card {
-    pub fn new(id: u32, kind: u32, cost: u32, power: u32, toughness: u32) -> Self {
-        Self {
-            id,
-            kind,
-            cost,
-            power,
-            toughness,
-        }
-    }
-}
-
-/// A creature currently on the battlefield.
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct CreatureState {
-    pub card_id: u32,
-    pub power: u32,
-    pub toughness: u32,
-    pub current_toughness: u32,
-}
-
-impl CreatureState {
-    pub fn new(card_id: u32, power: u32, toughness: u32) -> Self {
-        Self {
-            card_id,
-            power,
-            toughness,
-            current_toughness: toughness,
-        }
-    }
-}
-
-/// Represents the hand for one player.
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct PlayerHand {
-    pub cards: Vec<u32>, // Card IDs
-    pub entity_id: u32,
-}
-
-impl PlayerHand {
-    pub fn new(env: &Env, entity_id: u32) -> Self {
-        Self {
-            cards: Vec::new(env),
-            entity_id,
-        }
-    }
-}
-
-impl ComponentTrait for PlayerHand {
-    fn component_type() -> Symbol {
-        symbol_short!("hand")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        bytes.append(&Bytes::from_array(env, &self.entity_id.to_be_bytes()));
-        let len = self.cards.len();
-        bytes.append(&Bytes::from_array(env, &len.to_be_bytes()));
-        for i in 0..len {
-            let card_id = self.cards.get(i).unwrap_or(0);
-            bytes.append(&Bytes::from_array(env, &card_id.to_be_bytes()));
-        }
-        bytes
-    }
-
-    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() < 8 {
-            return None;
-        }
-        let entity_id = u32::from_be_bytes([
-            data.get(0).unwrap(),
-            data.get(1).unwrap(),
-            data.get(2).unwrap(),
-            data.get(3).unwrap(),
-        ]);
-        let len = u32::from_be_bytes([
-            data.get(4).unwrap(),
-            data.get(5).unwrap(),
-            data.get(6).unwrap(),
-            data.get(7).unwrap(),
-        ]);
-        let mut cards = Vec::new(env);
-        for i in 0..len {
-            let offset = 8 + (i * 4);
-            let card_id = u32::from_be_bytes([
-                data.get(offset).unwrap(),
-                data.get(offset + 1).unwrap(),
-                data.get(offset + 2).unwrap(),
-                data.get(offset + 3).unwrap(),
-            ]);
-            cards.push_back(card_id);
-        }
-        Some(Self { cards, entity_id })
-    }
-}
-
-/// Creatures on the battlefield for one player.
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct PlayerField {
-    pub creatures: Vec<CreatureState>,
-    pub entity_id: u32,
-}
-
-impl PlayerField {
-    pub fn new(env: &Env, entity_id: u32) -> Self {
-        Self {
-            creatures: Vec::new(env),
-            entity_id,
-        }
-    }
-}
-
-impl ComponentTrait for PlayerField {
-    fn component_type() -> Symbol {
-        symbol_short!("field")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        bytes.append(&Bytes::from_array(env, &self.entity_id.to_be_bytes()));
-        let len = self.creatures.len();
-        bytes.append(&Bytes::from_array(env, &len.to_be_bytes()));
-        for i in 0..len {
-            let c = self.creatures.get(i).unwrap();
-            bytes.append(&Bytes::from_array(env, &c.card_id.to_be_bytes()));
-            bytes.append(&Bytes::from_array(env, &c.power.to_be_bytes()));
-            bytes.append(&Bytes::from_array(env, &c.toughness.to_be_bytes()));
-            bytes.append(&Bytes::from_array(env, &c.current_toughness.to_be_bytes()));
-        }
-        bytes
-    }
-
-    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() < 8 {
-            return None;
-        }
-        let entity_id = u32::from_be_bytes([
-            data.get(0).unwrap(),
-            data.get(1).unwrap(),
-            data.get(2).unwrap(),
-            data.get(3).unwrap(),
-        ]);
-        let len = u32::from_be_bytes([
-            data.get(4).unwrap(),
-            data.get(5).unwrap(),
-            data.get(6).unwrap(),
-            data.get(7).unwrap(),
-        ]);
-        let mut creatures = Vec::new(env);
-        for i in 0..len {
-            let base = 8 + (i * 16);
-            let card_id = u32::from_be_bytes([
-                data.get(base).unwrap(),
-                data.get(base + 1).unwrap(),
-                data.get(base + 2).unwrap(),
-                data.get(base + 3).unwrap(),
-            ]);
-            let power = u32::from_be_bytes([
-                data.get(base + 4).unwrap(),
-                data.get(base + 5).unwrap(),
-                data.get(base + 6).unwrap(),
-                data.get(base + 7).unwrap(),
-            ]);
-            let toughness = u32::from_be_bytes([
-                data.get(base + 8).unwrap(),
-                data.get(base + 9).unwrap(),
-                data.get(base + 10).unwrap(),
-                data.get(base + 11).unwrap(),
-            ]);
-            let current_toughness = u32::from_be_bytes([
-                data.get(base + 12).unwrap(),
-                data.get(base + 13).unwrap(),
-                data.get(base + 14).unwrap(),
-                data.get(base + 15).unwrap(),
-            ]);
-            creatures.push_back(CreatureState {
-                card_id,
-                power,
-                toughness,
-                current_toughness,
-            });
-        }
-        Some(Self {
-            creatures,
-            entity_id,
-        })
-    }
-}
-
-/// Stats (health, mana) for one player.
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct PlayerStats {
-    pub health: u32,
-    pub mana: u32,
-    pub max_mana: u32,
-    pub entity_id: u32,
-}
-
-impl PlayerStats {
-    pub fn new(entity_id: u32) -> Self {
-        Self {
-            health: STARTING_HEALTH,
-            mana: 1,
-            max_mana: 1,
-            entity_id,
-        }
-    }
-}
-
-impl ComponentTrait for PlayerStats {
-    fn component_type() -> Symbol {
-        symbol_short!("pstats")
-    }
-
-    fn serialize(&self, env: &Env) -> Bytes {
-        let mut bytes = Bytes::new(env);
-        bytes.append(&Bytes::from_array(env, &self.entity_id.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.health.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.mana.to_be_bytes()));
-        bytes.append(&Bytes::from_array(env, &self.max_mana.to_be_bytes()));
-        bytes
-    }
-
-    fn deserialize(_env: &Env, data: &Bytes) -> Option<Self> {
-        if data.len() != 16 {
-            return None;
-        }
-        let entity_id = u32::from_be_bytes([
-            data.get(0).unwrap(),
-            data.get(1).unwrap(),
-            data.get(2).unwrap(),
-            data.get(3).unwrap(),
-        ]);
-        let health = u32::from_be_bytes([
-            data.get(4).unwrap(),
-            data.get(5).unwrap(),
-            data.get(6).unwrap(),
-            data.get(7).unwrap(),
-        ]);
-        let mana = u32::from_be_bytes([
-            data.get(8).unwrap(),
-            data.get(9).unwrap(),
-            data.get(10).unwrap(),
-            data.get(11).unwrap(),
-        ]);
-        let max_mana = u32::from_be_bytes([
-            data.get(12).unwrap(),
-            data.get(13).unwrap(),
-            data.get(14).unwrap(),
-            data.get(15).unwrap(),
-        ]);
-        Some(Self {
-            health,
-            mana,
-            max_mana,
-            entity_id,
-        })
-    }
-}
-
-/// Top-level match state.
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct MatchState {
-    pub turn: u32,
-    pub active_player: Address,
-    pub phase: u32,
-    pub status: u32,
-    pub entity_id: u32,
-}
-
-impl MatchState {
-    pub fn new(active_player: Address, entity_id: u32) -> Self {
-        Self {
-            turn: 1,
-            active_player,
-            phase: PHASE_DRAW,
-            status: STATUS_IN_PROGRESS,
-            entity_id,
-        }
-    }
-}
-
-// ─── World state (all ECS data for the match) ────────────────────────────────
-
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct ECSWorldState {
-    // Players
-    pub player_a: Address,
-    pub player_b: Address,
-    // Decks (remaining card IDs in draw order)
-    pub deck_a: Vec<u32>,
-    pub deck_b: Vec<u32>,
-    // Hands
-    pub hand_a: PlayerHand,
-    pub hand_b: PlayerHand,
-    // Fields
-    pub field_a: PlayerField,
-    pub field_b: PlayerField,
-    // Stats
-    pub stats_a: PlayerStats,
-    pub stats_b: PlayerStats,
-    // Match metadata
-    pub match_state: MatchState,
-    // Session key tracking (ledger timestamp-based TTL)
-    pub session_a_expires: u64,
-    pub session_b_expires: u64,
-    pub next_entity_id: u32,
-}
-
-// ─── Card library (deterministic card definitions) ───────────────────────────
-
-/// Returns the canonical card definition for a given card id.
-/// Cards 1-5: cheap creatures; 6-8: powerful creatures; 9-10: spells.
-fn card_definition(card_id: u32) -> Option<Card> {
-    match card_id {
-        1 => Some(Card::new(1, KIND_CREATURE, 1, 1, 2)), // 1-cost 1/2 creature
-        2 => Some(Card::new(2, KIND_CREATURE, 2, 2, 2)), // 2-cost 2/2 creature
-        3 => Some(Card::new(3, KIND_CREATURE, 2, 1, 3)), // 2-cost 1/3 creature
-        4 => Some(Card::new(4, KIND_CREATURE, 3, 3, 2)), // 3-cost 3/2 creature
-        5 => Some(Card::new(5, KIND_CREATURE, 3, 2, 4)), // 3-cost 2/4 creature
-        6 => Some(Card::new(6, KIND_CREATURE, 4, 4, 4)), // 4-cost 4/4 creature
-        7 => Some(Card::new(7, KIND_CREATURE, 5, 5, 5)), // 5-cost 5/5 creature
-        8 => Some(Card::new(8, KIND_CREATURE, 6, 6, 6)), // 6-cost 6/6 creature
-        9 => Some(Card::new(9, KIND_SPELL, 2, 3, 0)),    // 2-cost spell: deal 3 damage
-        10 => Some(Card::new(10, KIND_SPELL, 4, 5, 0)),  // 4-cost spell: deal 5 damage
-        _ => None,
-    }
-}
-
-// ─── Action enum ────────────────────────────────────────────────────────────
-
-/// Represents one action in a player's turn batch.
-#[contracttype]
-#[derive(Clone, Debug)]
-pub enum Action {
-    /// Play a creature from hand to the field.
-    PlayCreature(u32), // card_id
-    /// Cast a spell from hand, dealing damage to the opponent.
-    CastSpell(u32), // card_id
-    /// Declare an attack: attacker index on field vs target index on opponent field (u32::MAX = face).
-    DeclareAttack(u32, u32), // attacker_idx, target_idx (MAX = direct)
-}
-
-// ─── Turn result ─────────────────────────────────────────────────────────────
-
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct TurnResult {
-    pub success: bool,
-    pub actions_executed: u32,
-    pub match_status: u32,
-    pub message: Symbol,
-}
-
-// ─── External view types ────────────────────────────────────────────────────
-
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct FieldState {
-    pub field_a: Vec<CreatureState>,
-    pub field_b: Vec<CreatureState>,
-}
-
-// ─── Storage key ─────────────────────────────────────────────────────────────
-
-const WORLD_KEY: Symbol = symbol_short!("WORLD");
-
-// ─── Contract ────────────────────────────────────────────────────────────────
+// Re-export public API types for tests and external consumers
+pub use components::{
+    Action, Card, CreatureState, ECSWorldState, FieldState, GameError, MatchState, PlayerField,
+    PlayerHand, PlayerStats, TurnResult, KIND_CREATURE, KIND_SPELL, MAX_FIELD, MAX_HAND, MAX_MANA,
+    PHASE_COMBAT, PHASE_DRAW, PHASE_END, PHASE_MAIN, STARTING_HAND_SIZE, STARTING_HEALTH,
+    STATUS_A_WINS, STATUS_B_WINS, STATUS_CONCEDED, STATUS_IN_PROGRESS, SYM_ATTACK, SYM_CONCEDE,
+    SYM_PLAY, SYM_SPELL, WORLD_KEY,
+};
 
 #[contract]
 pub struct TradingCardGame;
@@ -491,7 +65,7 @@ impl TradingCardGame {
         let match_state = MatchState::new(player_a.clone(), eid);
         eid += 1;
 
-        // Draw starting hand from the front of the deck.
+        // Draw starting hands from the front of each deck.
         let mut remaining_a = Vec::new(&env);
         let draw_a = STARTING_HAND_SIZE.min(deck_a.len());
         for i in 0..deck_a.len() {
@@ -548,8 +122,7 @@ impl TradingCardGame {
             panic_with_error!(&env, GameError::NotAPlayer);
         }
 
-        // Build a session scope scoped to the three game actions.
-        let expires_at = env.ledger().timestamp() + 7200; // 2-hour TTL
+        let expires_at = env.ledger().timestamp() + 7200;
         let _scope = SessionBuilder::new(&env)
             .allow_action(SYM_PLAY)
             .allow_action(SYM_SPELL)
@@ -571,9 +144,6 @@ impl TradingCardGame {
     // ── Turn Submission ──────────────────────────────────────────────────────
 
     /// Submit a full turn as an atomic batch of actions.
-    ///
-    /// The caller must be the active player.  Actions are composed via `BatchBuilder`
-    /// and either ALL succeed or NONE are applied (the function panics, reverting all state).
     pub fn submit_turn(env: Env, player: Address, actions: Vec<Action>) -> TurnResult {
         let mut world: ECSWorldState = env
             .storage()
@@ -581,19 +151,16 @@ impl TradingCardGame {
             .get(&WORLD_KEY)
             .unwrap_or_else(|| panic_with_error!(&env, GameError::NotInitialized));
 
-        // ── Guard: match must be in progress ────────────────────────────────
         if world.match_state.status != STATUS_IN_PROGRESS {
             panic_with_error!(&env, GameError::GameOver);
         }
 
-        // ── Guard: it must be the player's turn ─────────────────────────────
         if player != world.match_state.active_player {
             panic_with_error!(&env, GameError::NotYourTurn);
         }
 
         let is_a = player == world.player_a;
 
-        // ── Guard: session must be valid ─────────────────────────────────────
         let session_expires = if is_a {
             world.session_a_expires
         } else {
@@ -603,21 +170,15 @@ impl TradingCardGame {
             panic_with_error!(&env, GameError::SessionExpired);
         }
 
-        // ── Guard: actions list must not be empty ────────────────────────────
         if actions.is_empty() {
             panic_with_error!(&env, GameError::BatchEmpty);
         }
 
-        // ── Run DrawSystem first (beginning of turn) ─────────────────────────
-        Self::draw_system(&env, &mut world, is_a);
+        // DrawSystem and ManaSystem run at the start of each turn.
+        draw_system(&env, &mut world, is_a);
+        mana_system(&mut world, is_a);
 
-        // ── Run ManaSystem ───────────────────────────────────────────────────
-        Self::mana_system(&mut world, is_a);
-
-        // ── Build BatchBuilder and validate each action ──────────────────────
-        // We compose every action into a BatchBuilder (proving atomicity intent),
-        // then execute the batch.  If authorization fails for any action the
-        // panic reverts all state changes made so far.
+        // Compose BatchBuilder manifest (proves atomicity intent).
         let mut batch = BatchBuilder::new();
         for i in 0..actions.len() {
             let action = actions.get(i).unwrap();
@@ -632,37 +193,30 @@ impl TradingCardGame {
             });
         }
 
-        // Validate batch is non-empty (already checked above, but BatchBuilder
-        // enforces it as well — we use a mock-style inline check here since we
-        // don't have a full CougrAccount in test context).
         if batch.is_empty() {
             panic_with_error!(&env, GameError::BatchEmpty);
         }
 
-        // ── Execute each action atomically ────────────────────────────────────
-        // The entire function runs within a single Soroban host invocation,
-        // so any panic below reverts ALL storage writes, achieving true atomicity.
+        // Execute each action atomically — any panic reverts all storage writes.
         let mut executed = 0u32;
         for i in 0..actions.len() {
             let action = actions.get(i).unwrap();
             match action {
                 Action::PlayCreature(card_id) => {
-                    Self::play_card_system(&env, &mut world, is_a, card_id);
+                    play_card_system(&env, &mut world, is_a, card_id);
                 }
                 Action::CastSpell(card_id) => {
-                    Self::cast_spell_system(&env, &mut world, is_a, card_id);
+                    cast_spell_system(&env, &mut world, is_a, card_id);
                 }
                 Action::DeclareAttack(attacker_idx, target_idx) => {
-                    Self::combat_system(&env, &mut world, is_a, attacker_idx, target_idx);
+                    combat_system(&env, &mut world, is_a, attacker_idx, target_idx);
                 }
             }
             executed += 1;
         }
 
-        // ── WinConditionSystem ───────────────────────────────────────────────
-        Self::win_condition_system(&mut world);
+        win_condition_system(&mut world);
 
-        // ── Advance turn ─────────────────────────────────────────────────────
         if world.match_state.status == STATUS_IN_PROGRESS {
             world.match_state.turn += 1;
             world.match_state.active_player = if is_a {
@@ -763,224 +317,4 @@ impl TradingCardGame {
         world.match_state.status = STATUS_CONCEDED;
         env.storage().instance().set(&WORLD_KEY, &world);
     }
-
-    // ── ECS Systems ──────────────────────────────────────────────────────────
-
-    /// DrawSystem — draws one card from the player's deck into their hand.
-    fn draw_system(env: &Env, world: &mut ECSWorldState, is_a: bool) {
-        let (hand, deck) = if is_a {
-            (&mut world.hand_a, &mut world.deck_a)
-        } else {
-            (&mut world.hand_b, &mut world.deck_b)
-        };
-
-        if deck.is_empty() || hand.cards.len() >= MAX_HAND {
-            return;
-        }
-
-        // Draw from the front of the deck.
-        let card_id = deck.get(0).unwrap();
-        let mut new_deck = Vec::new(env);
-        for i in 1..deck.len() {
-            new_deck.push_back(deck.get(i).unwrap());
-        }
-        *deck = new_deck;
-        hand.cards.push_back(card_id);
-    }
-
-    /// ManaSystem — increments max mana (capped at MAX_MANA) and refills current mana.
-    fn mana_system(world: &mut ECSWorldState, is_a: bool) {
-        let stats = if is_a {
-            &mut world.stats_a
-        } else {
-            &mut world.stats_b
-        };
-        if stats.max_mana < MAX_MANA {
-            stats.max_mana += 1;
-        }
-        stats.mana = stats.max_mana;
-    }
-
-    /// PlayCardSystem — validates and moves a creature card from hand to field.
-    fn play_card_system(env: &Env, world: &mut ECSWorldState, is_a: bool, card_id: u32) {
-        let card = match card_definition(card_id) {
-            Some(c) => c,
-            None => panic_with_error!(env, GameError::InvalidCard),
-        };
-
-        if card.kind != KIND_CREATURE {
-            panic_with_error!(env, GameError::InvalidCard);
-        }
-
-        let (hand, field, stats) = if is_a {
-            (&mut world.hand_a, &mut world.field_a, &mut world.stats_a)
-        } else {
-            (&mut world.hand_b, &mut world.field_b, &mut world.stats_b)
-        };
-
-        // Check mana
-        if stats.mana < card.cost {
-            panic_with_error!(env, GameError::InsufficientMana);
-        }
-
-        // Check field capacity
-        if field.creatures.len() >= MAX_FIELD {
-            panic_with_error!(env, GameError::FieldFull);
-        }
-
-        // Remove from hand
-        let pos = Self::find_card_in_hand(hand, card_id);
-        if pos >= hand.cards.len() {
-            panic_with_error!(env, GameError::CardNotInHand);
-        }
-        let mut new_hand = Vec::new(env);
-        for i in 0..hand.cards.len() {
-            if i != pos {
-                new_hand.push_back(hand.cards.get(i).unwrap());
-            }
-        }
-        hand.cards = new_hand;
-
-        // Deduct mana and place on field
-        stats.mana -= card.cost;
-        field
-            .creatures
-            .push_back(CreatureState::new(card_id, card.power, card.toughness));
-    }
-
-    /// CastSpellSystem — validates and casts a spell, dealing direct damage to opponent.
-    fn cast_spell_system(env: &Env, world: &mut ECSWorldState, is_a: bool, card_id: u32) {
-        let card = match card_definition(card_id) {
-            Some(c) => c,
-            None => panic_with_error!(env, GameError::InvalidCard),
-        };
-
-        if card.kind != KIND_SPELL {
-            panic_with_error!(env, GameError::InvalidCard);
-        }
-
-        let (hand, stats, opp_stats) = if is_a {
-            (&mut world.hand_a, &mut world.stats_a, &mut world.stats_b)
-        } else {
-            (&mut world.hand_b, &mut world.stats_b, &mut world.stats_a)
-        };
-
-        if stats.mana < card.cost {
-            panic_with_error!(env, GameError::InsufficientMana);
-        }
-
-        let pos = Self::find_card_in_hand(hand, card_id);
-        if pos >= hand.cards.len() {
-            panic_with_error!(env, GameError::CardNotInHand);
-        }
-        let mut new_hand = Vec::new(env);
-        for i in 0..hand.cards.len() {
-            if i != pos {
-                new_hand.push_back(hand.cards.get(i).unwrap());
-            }
-        }
-        hand.cards = new_hand;
-
-        stats.mana -= card.cost;
-
-        // Deal damage: spell's power value is the damage amount.
-        opp_stats.health = opp_stats.health.saturating_sub(card.power);
-    }
-
-    /// CombatSystem — resolves one attack declaration.
-    ///
-    /// `target_idx == u32::MAX` means direct attack (face damage).
-    fn combat_system(
-        env: &Env,
-        world: &mut ECSWorldState,
-        is_a: bool,
-        attacker_idx: u32,
-        target_idx: u32,
-    ) {
-        let (my_field, opp_field, opp_stats) = if is_a {
-            (&mut world.field_a, &mut world.field_b, &mut world.stats_b)
-        } else {
-            (&mut world.field_b, &mut world.field_a, &mut world.stats_a)
-        };
-
-        if attacker_idx >= my_field.creatures.len() {
-            panic_with_error!(env, GameError::InvalidTarget);
-        }
-
-        let attacker_power = my_field.creatures.get(attacker_idx).unwrap().power;
-
-        if target_idx == u32::MAX {
-            // Direct face attack
-            opp_stats.health = opp_stats.health.saturating_sub(attacker_power);
-        } else {
-            // Attack a creature
-            if target_idx >= opp_field.creatures.len() {
-                panic_with_error!(env, GameError::InvalidTarget);
-            }
-
-            let blocker_power = opp_field.creatures.get(target_idx).unwrap().power;
-            let blocker_toughness = opp_field
-                .creatures
-                .get(target_idx)
-                .unwrap()
-                .current_toughness;
-            let attacker_toughness = my_field
-                .creatures
-                .get(attacker_idx)
-                .unwrap()
-                .current_toughness;
-
-            // Apply damage both ways
-            let new_blocker_toughness = blocker_toughness.saturating_sub(attacker_power);
-            let new_attacker_toughness = attacker_toughness.saturating_sub(blocker_power);
-
-            // Update attacker
-            let mut attacker = my_field.creatures.get(attacker_idx).unwrap();
-            attacker.current_toughness = new_attacker_toughness;
-            my_field.creatures.set(attacker_idx, attacker);
-
-            // Update blocker
-            let mut blocker = opp_field.creatures.get(target_idx).unwrap();
-            blocker.current_toughness = new_blocker_toughness;
-            opp_field.creatures.set(target_idx, blocker);
-
-            // Remove dead creatures (toughness == 0)
-            Self::remove_dead(env, my_field);
-            Self::remove_dead(env, opp_field);
-        }
-    }
-
-    /// WinConditionSystem — marks the match over if any player's health reaches 0.
-    fn win_condition_system(world: &mut ECSWorldState) {
-        if world.stats_a.health == 0 {
-            world.match_state.status = STATUS_B_WINS;
-        } else if world.stats_b.health == 0 {
-            world.match_state.status = STATUS_A_WINS;
-        }
-    }
-
-    // ── Helpers ───────────────────────────────────────────────────────────────
-
-    fn find_card_in_hand(hand: &PlayerHand, card_id: u32) -> u32 {
-        for i in 0..hand.cards.len() {
-            if hand.cards.get(i).unwrap() == card_id {
-                return i;
-            }
-        }
-        u32::MAX
-    }
-
-    fn remove_dead(env: &Env, field: &mut PlayerField) {
-        let mut survivors = Vec::new(env);
-        for i in 0..field.creatures.len() {
-            let c = field.creatures.get(i).unwrap();
-            if c.current_toughness > 0 {
-                survivors.push_back(c);
-            }
-        }
-        field.creatures = survivors;
-    }
 }
-
-#[cfg(test)]
-mod test;

--- a/examples/trading_card_game/src/lib.rs
+++ b/examples/trading_card_game/src/lib.rs
@@ -5,22 +5,6 @@ mod systems;
 #[cfg(test)]
 mod test;
 
-use components::{
-    Action, Card, ECSWorldState, FieldState, GameError, MatchState, PlayerField, PlayerHand,
-    PlayerStats, TurnResult, PHASE_DRAW, STARTING_HAND_SIZE, STATUS_CONCEDED, STATUS_IN_PROGRESS,
-    SYM_ATTACK, SYM_PLAY, SYM_SPELL, WORLD_KEY,
-};
-use systems::{
-    card_definition, cast_spell_system, combat_system, draw_system, mana_system, play_card_system,
-    win_condition_system,
-};
-
-use cougr_core::auth::{BatchBuilder, GameAction, SessionBuilder};
-use soroban_sdk::{
-    contract, contractimpl, panic_with_error, symbol_short, Address, Bytes, Env, Vec,
-};
-
-// Re-export public API types for tests and external consumers
 pub use components::{
     Action, Card, CreatureState, ECSWorldState, FieldState, GameError, MatchState, PlayerField,
     PlayerHand, PlayerStats, TurnResult, KIND_CREATURE, KIND_SPELL, MAX_FIELD, MAX_HAND, MAX_MANA,
@@ -28,6 +12,13 @@ pub use components::{
     STATUS_A_WINS, STATUS_B_WINS, STATUS_CONCEDED, STATUS_IN_PROGRESS, SYM_ATTACK, SYM_CONCEDE,
     SYM_PLAY, SYM_SPELL, WORLD_KEY,
 };
+use systems::{
+    card_definition, cast_spell_system, combat_system, draw_system, mana_system, play_card_system,
+    win_condition_system,
+};
+
+use cougr_core::auth::{BatchBuilder, GameAction, SessionBuilder};
+use soroban_sdk::{contract, contractimpl, panic_with_error, symbol_short, Address, Bytes, Env, Vec};
 
 #[contract]
 pub struct TradingCardGame;

--- a/examples/trading_card_game/src/systems.rs
+++ b/examples/trading_card_game/src/systems.rs
@@ -1,0 +1,240 @@
+use soroban_sdk::{Env, Vec};
+
+use crate::components::{
+    Card, CreatureState, ECSWorldState, GameError, KIND_CREATURE, KIND_SPELL, MAX_FIELD, MAX_HAND,
+    MAX_MANA, PlayerField, PlayerHand,
+};
+
+// ── Card library ──────────────────────────────────────────────────────────────
+
+/// Returns the canonical card definition for a given card id.
+/// Cards 1-5: cheap creatures; 6-8: powerful creatures; 9-10: spells.
+pub(crate) fn card_definition(card_id: u32) -> Option<Card> {
+    match card_id {
+        1 => Some(Card::new(1, KIND_CREATURE, 1, 1, 2)),
+        2 => Some(Card::new(2, KIND_CREATURE, 2, 2, 2)),
+        3 => Some(Card::new(3, KIND_CREATURE, 2, 1, 3)),
+        4 => Some(Card::new(4, KIND_CREATURE, 3, 3, 2)),
+        5 => Some(Card::new(5, KIND_CREATURE, 3, 2, 4)),
+        6 => Some(Card::new(6, KIND_CREATURE, 4, 4, 4)),
+        7 => Some(Card::new(7, KIND_CREATURE, 5, 5, 5)),
+        8 => Some(Card::new(8, KIND_CREATURE, 6, 6, 6)),
+        9 => Some(Card::new(9, KIND_SPELL, 2, 3, 0)),
+        10 => Some(Card::new(10, KIND_SPELL, 4, 5, 0)),
+        _ => None,
+    }
+}
+
+// ── DrawSystem ────────────────────────────────────────────────────────────────
+
+/// Draws one card from the player's deck into their hand.
+pub(crate) fn draw_system(env: &Env, world: &mut ECSWorldState, is_a: bool) {
+    let (hand, deck) = if is_a {
+        (&mut world.hand_a, &mut world.deck_a)
+    } else {
+        (&mut world.hand_b, &mut world.deck_b)
+    };
+
+    if deck.is_empty() || hand.cards.len() >= MAX_HAND {
+        return;
+    }
+
+    let card_id = deck.get(0).unwrap();
+    let mut new_deck = Vec::new(env);
+    for i in 1..deck.len() {
+        new_deck.push_back(deck.get(i).unwrap());
+    }
+    *deck = new_deck;
+    hand.cards.push_back(card_id);
+}
+
+// ── ManaSystem ────────────────────────────────────────────────────────────────
+
+/// Increments max mana (capped at MAX_MANA) and refills current mana.
+pub(crate) fn mana_system(world: &mut ECSWorldState, is_a: bool) {
+    let stats = if is_a {
+        &mut world.stats_a
+    } else {
+        &mut world.stats_b
+    };
+    if stats.max_mana < MAX_MANA {
+        stats.max_mana += 1;
+    }
+    stats.mana = stats.max_mana;
+}
+
+// ── PlayCardSystem ────────────────────────────────────────────────────────────
+
+/// Validates and moves a creature card from hand to field.
+pub(crate) fn play_card_system(env: &Env, world: &mut ECSWorldState, is_a: bool, card_id: u32) {
+    let card = match card_definition(card_id) {
+        Some(c) => c,
+        None => soroban_sdk::panic_with_error!(env, GameError::InvalidCard),
+    };
+
+    if card.kind != KIND_CREATURE {
+        soroban_sdk::panic_with_error!(env, GameError::InvalidCard);
+    }
+
+    let (hand, field, stats) = if is_a {
+        (&mut world.hand_a, &mut world.field_a, &mut world.stats_a)
+    } else {
+        (&mut world.hand_b, &mut world.field_b, &mut world.stats_b)
+    };
+
+    if stats.mana < card.cost {
+        soroban_sdk::panic_with_error!(env, GameError::InsufficientMana);
+    }
+
+    if field.creatures.len() >= MAX_FIELD {
+        soroban_sdk::panic_with_error!(env, GameError::FieldFull);
+    }
+
+    let pos = find_card_in_hand(hand, card_id);
+    if pos >= hand.cards.len() {
+        soroban_sdk::panic_with_error!(env, GameError::CardNotInHand);
+    }
+    let mut new_hand = Vec::new(env);
+    for i in 0..hand.cards.len() {
+        if i != pos {
+            new_hand.push_back(hand.cards.get(i).unwrap());
+        }
+    }
+    hand.cards = new_hand;
+
+    stats.mana -= card.cost;
+    field
+        .creatures
+        .push_back(CreatureState::new(card_id, card.power, card.toughness));
+}
+
+// ── CastSpellSystem ───────────────────────────────────────────────────────────
+
+/// Validates and casts a spell, dealing direct damage to the opponent.
+pub(crate) fn cast_spell_system(env: &Env, world: &mut ECSWorldState, is_a: bool, card_id: u32) {
+    let card = match card_definition(card_id) {
+        Some(c) => c,
+        None => soroban_sdk::panic_with_error!(env, GameError::InvalidCard),
+    };
+
+    if card.kind != KIND_SPELL {
+        soroban_sdk::panic_with_error!(env, GameError::InvalidCard);
+    }
+
+    let (hand, stats, opp_stats) = if is_a {
+        (&mut world.hand_a, &mut world.stats_a, &mut world.stats_b)
+    } else {
+        (&mut world.hand_b, &mut world.stats_b, &mut world.stats_a)
+    };
+
+    if stats.mana < card.cost {
+        soroban_sdk::panic_with_error!(env, GameError::InsufficientMana);
+    }
+
+    let pos = find_card_in_hand(hand, card_id);
+    if pos >= hand.cards.len() {
+        soroban_sdk::panic_with_error!(env, GameError::CardNotInHand);
+    }
+    let mut new_hand = Vec::new(env);
+    for i in 0..hand.cards.len() {
+        if i != pos {
+            new_hand.push_back(hand.cards.get(i).unwrap());
+        }
+    }
+    hand.cards = new_hand;
+
+    stats.mana -= card.cost;
+    opp_stats.health = opp_stats.health.saturating_sub(card.power);
+}
+
+// ── CombatSystem ──────────────────────────────────────────────────────────────
+
+/// Resolves one attack declaration.
+/// `target_idx == u32::MAX` means a direct face attack.
+pub(crate) fn combat_system(
+    env: &Env,
+    world: &mut ECSWorldState,
+    is_a: bool,
+    attacker_idx: u32,
+    target_idx: u32,
+) {
+    let (my_field, opp_field, opp_stats) = if is_a {
+        (&mut world.field_a, &mut world.field_b, &mut world.stats_b)
+    } else {
+        (&mut world.field_b, &mut world.field_a, &mut world.stats_a)
+    };
+
+    if attacker_idx >= my_field.creatures.len() {
+        soroban_sdk::panic_with_error!(env, GameError::InvalidTarget);
+    }
+
+    let attacker_power = my_field.creatures.get(attacker_idx).unwrap().power;
+
+    if target_idx == u32::MAX {
+        opp_stats.health = opp_stats.health.saturating_sub(attacker_power);
+    } else {
+        if target_idx >= opp_field.creatures.len() {
+            soroban_sdk::panic_with_error!(env, GameError::InvalidTarget);
+        }
+
+        let blocker_power = opp_field.creatures.get(target_idx).unwrap().power;
+        let blocker_toughness = opp_field
+            .creatures
+            .get(target_idx)
+            .unwrap()
+            .current_toughness;
+        let attacker_toughness = my_field
+            .creatures
+            .get(attacker_idx)
+            .unwrap()
+            .current_toughness;
+
+        let new_blocker_toughness = blocker_toughness.saturating_sub(attacker_power);
+        let new_attacker_toughness = attacker_toughness.saturating_sub(blocker_power);
+
+        let mut attacker = my_field.creatures.get(attacker_idx).unwrap();
+        attacker.current_toughness = new_attacker_toughness;
+        my_field.creatures.set(attacker_idx, attacker);
+
+        let mut blocker = opp_field.creatures.get(target_idx).unwrap();
+        blocker.current_toughness = new_blocker_toughness;
+        opp_field.creatures.set(target_idx, blocker);
+
+        remove_dead(env, my_field);
+        remove_dead(env, opp_field);
+    }
+}
+
+// ── WinConditionSystem ────────────────────────────────────────────────────────
+
+/// Marks the match over if any player's health reaches 0.
+pub(crate) fn win_condition_system(world: &mut ECSWorldState) {
+    use crate::components::{STATUS_A_WINS, STATUS_B_WINS};
+    if world.stats_a.health == 0 {
+        world.match_state.status = STATUS_B_WINS;
+    } else if world.stats_b.health == 0 {
+        world.match_state.status = STATUS_A_WINS;
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+pub(crate) fn find_card_in_hand(hand: &PlayerHand, card_id: u32) -> u32 {
+    for i in 0..hand.cards.len() {
+        if hand.cards.get(i).unwrap() == card_id {
+            return i;
+        }
+    }
+    u32::MAX
+}
+
+pub(crate) fn remove_dead(env: &Env, field: &mut PlayerField) {
+    let mut survivors = Vec::new(env);
+    for i in 0..field.creatures.len() {
+        let c = field.creatures.get(i).unwrap();
+        if c.current_toughness > 0 {
+            survivors.push_back(c);
+        }
+    }
+    field.creatures = survivors;
+}

--- a/examples/trading_card_game/src/systems.rs
+++ b/examples/trading_card_game/src/systems.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{Env, Vec};
 
 use crate::components::{
-    Card, CreatureState, ECSWorldState, GameError, KIND_CREATURE, KIND_SPELL, MAX_FIELD, MAX_HAND,
-    MAX_MANA, PlayerField, PlayerHand,
+    Card, CreatureState, ECSWorldState, GameError, PlayerField, PlayerHand, KIND_CREATURE,
+    KIND_SPELL, MAX_FIELD, MAX_HAND, MAX_MANA,
 };
 
 // ── Card library ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## summary of what was done:

Both examples/bomberman and examples/trading_card_game were refactored from monolithic lib.rs files into a three-module structure matching the pattern used by reversi and sudoku.

For each example:

components.rs — all component structs, ComponentTrait implementations, constants, enums, and world/state types were moved here
systems.rs — all game logic functions (movement, bomb timers, chain reactions, draw/mana/combat systems, win conditions, etc.) were extracted here as pure free functions
lib.rs — stripped down to only the contract struct, #[contractimpl] entrypoints, and a storage helper; it now just orchestrates calls into components and systems


Close #135 