### PR TITLE
feat: Use published cougr-core crate in pac_man and pokemon_mini exam…

### DIFF
--- a/examples/pac_man/Cargo.toml
+++ b/examples/pac_man/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/pokemon_mini/Cargo.toml
+++ b/examples/pokemon_mini/Cargo.toml
@@ -10,7 +10,7 @@ description = "Pokémon Mini on-chain game example using cougr-core ECS framewor
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
…ples

- Replace local path dependencies with published cougr-core v1.0.0
- Update examples/pac_man/Cargo.toml and examples/pokemon_mini/Cargo.toml
- Both examples now consume published crate instead of repository-local dependency
- Validated with cargo test and stellar contract build for both examples

Resolves #126