### PR TITLE
fix(examples): use published cougr-core crate in snake and space_invaders(#129)

### DIFF
--- a/examples/snake/Cargo.toml
+++ b/examples/snake/Cargo.toml
@@ -10,7 +10,7 @@ description = "Snake on-chain game example using cougr-core ECS framework"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/space_invaders/Cargo.toml
+++ b/examples/space_invaders/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Closes #129 

Updates `snake` and `space_invaders` to depend on the published
`cougr-core` crate instead of a repository-local path dependency.

## Changes

- `examples/snake/Cargo.toml`: replaced `path = "../../"` with `cougr-core = "1.0.0"`
- `examples/space_invaders/Cargo.toml`: replaced `path = "../../"` with `cougr-core = "1.0.0"`

## Validation

Both examples verified with:
- `cargo test`
- `stellar contract build`

## Notes

- No README updates required; neither README references path or git dependencies
- No gameplay or unrelated dependency changes
- No other examples modified