### PR TITLE
fix(examples): use published cougr-core crate in battleship and chess

### DIFF
--- a/examples/battleship/Cargo.toml
+++ b/examples/battleship/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/chess/Cargo.toml
+++ b/examples/chess/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }


### PR DESCRIPTION
## Summary

Closes #121

Updates `battleship` and `chess` to depend on the published
`cougr-core` crate instead of a repository-local path dependency.

## Changes

- `examples/battleship/Cargo.toml`: replaced `path = "../../"` with `cougr-core = "1.0.0"`
- `examples/chess/Cargo.toml`: replaced `path = "../../"` with `cougr-core = "1.0.0"`

## Validation

Both examples verified with:
- `cargo test`
- `stellar contract build`

## Notes

- No README updates required; neither README references path or git dependencies
- No gameplay, ZK circuit, or architectural changes
- No other examples modified