### PR TITLE
fix(examples): add cougr-core dependency to checkers

### DIFF
--- a/examples/checkers/Cargo.toml
+++ b/examples/checkers/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }


### PR DESCRIPTION
## Description

This PR fixes the dependency issue in the `checkers` example as outlined in #134. 

Previously, `examples/checkers/src/lib.rs` used `cougr_core`, but `examples/checkers/Cargo.toml` did not explicitly declare it. This prevented the example from serving as a reliable standalone reference that could be built in isolation.

**Changes:**
- Explicitly added `cougr-core = "1.0.0"` (the published crate version) to the `[dependencies]` section in `examples/checkers/Cargo.toml`.

## Validation Performed
- ✅ Verified that `cargo test` runs successfully from the `examples/checkers` directory.
- ✅ Verified that `stellar contract build` completes successfully for the checkers example.
- ✅ Ensured no unrelated examples were modified.

## Related Issues
- Closes #134
