### PR TITLE
fix: update cougr-core from path to published version 1.0.0

### DIFF
--- a/examples/guild_arena/Cargo.toml
+++ b/examples/guild_arena/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
@@ -28,4 +28,4 @@ lto = true
 
 [profile.release-with-logs]
 inherits = "release"
-debug-assertions = true
+debug-assertions = true 

--- a/examples/guild_treasury_wars/Cargo.toml
+++ b/examples/guild_treasury_wars/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = { path = "../.." }
+cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]
@@ -19,4 +19,4 @@ soroban-sdk = { version = "25.1.0", features = ["testutils"] }
 opt-level = "z"
 overflow-checks = true
 lto = true
-codegen-units = 1
+codegen-units = 1 


### PR DESCRIPTION
updated the cougr-core version to 1.0.0 (the published version on crates.io) in both guild_arena and guild_treasury_wars. The CI should now pass.

closes #127