### PR TITLE
fix: update cougr-core to published version 1.0.0

### DIFF
--- a/examples/angry_birds/Cargo.toml
+++ b/examples/angry_birds/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
@@ -28,4 +28,4 @@ lto = true
 
 [profile.release-with-logs]
 inherits = "release"
-debug-assertions = true
+debug-assertions = true 

--- a/examples/arkanoid/Cargo.toml
+++ b/examples/arkanoid/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = { path = "../../" }
+cougr-core = "1.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
@@ -28,4 +28,4 @@ lto = true
 
 [profile.release-with-logs]
 inherits = "release"
-debug-assertions = true
+debug-assertions = true 


### PR DESCRIPTION
I have manually updated both angry_birds and arkanoid Cargo.toml to use cougr-core = "1.0.0". The CI should now pass.

closes #127