### PR TITLE
[murdoku] Privacy enhancement — commit-reveal solution with ZK verification #177

### DIFF
--- a/examples/murdoku/Cargo.toml
+++ b/examples/murdoku/Cargo.toml
@@ -9,12 +9,16 @@ description = "Murdoku puzzle registry and creator contract using cougr-core ECS
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = []
+zk = ["cougr-core/hazmat-crypto", "soroban-sdk/hazmat-crypto"]
+
 [dependencies]
 cougr-core = "1.0.0"
-soroban-sdk = "25.1.0"
+soroban-sdk = "=25.3.0"
 
 [dev-dependencies]
-soroban-sdk = { version = "25.1.0", features = ["testutils"] }
+soroban-sdk = { version = "=25.3.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/examples/murdoku/README.md
+++ b/examples/murdoku/README.md
@@ -1,6 +1,6 @@
 # Murdoku
 
-Murdoku is a murder mystery logic puzzle built with the [Cougr](../../README.md) ECS framework on Stellar Soroban. It demonstrates how to combine Entity Component System (ECS) game state, Pollar social logins, and session key authorization for smooth, gasless player interaction.
+Murdoku is a murder mystery logic puzzle built with the [Cougr](../../README.md) ECS framework on Stellar Soroban. It demonstrates how to combine Entity Component System (ECS) game state, Pollar social logins, session key authorization, and zero-knowledge proof verification for privacy-preserving puzzle solving.
 
 ## Purpose and Pattern
 
@@ -9,7 +9,11 @@ Murdoku is an on-chain logic puzzle that combines Sudoku-style Latin square cons
 This example showcases the canonical reference architecture for a full-stack game within the Cougr ecosystem:
 * **Entity Component System (ECS)**: Separation of game state, input validation, puzzle constraint checks, and win conditions using the Cougr ECS engine.
 * **Social Authentication & Session Keys**: Account abstraction utilizing Pollar for embedded wallet logins and scoped session key creation (`SessionBuilder`) to support non-intrusive gameplay transactions.
-* **ZK Readiness**: Architectural scaffolding for Zero-Knowledge (ZK) enhancements. In the v1 release, solutions and clue validations are stored in plaintext. In the subsequent v2 enhancement (tracked separately), the grid is submitted as a cryptographic commitment, and moves are verified using Groth16 zk-SNARK proofs generated client-side to prevent front-running and keep solutions private.
+* **ZK Privacy Layer**: The solution is never stored in plaintext on-chain. Instead, puzzle creators submit a cryptographic commitment (Poseidon2 hash of the solution + salt) and a Groth16 verifier key. Players prove they know a valid solution by submitting a Groth16 zero-knowledge proof, without revealing the solution itself.
+
+The contract supports two build modes controlled by the `zk` Cargo feature:
+- **Default (v1)**: Plaintext solution stored on-chain. Simpler but exposes the solution to on-chain observers.
+- **`zk` feature enabled**: Solution commitment + Groth16 proof verification. The solution remains private; the contract only stores a hash and validates ZK proofs.
 
 ---
 
@@ -40,19 +44,18 @@ The React frontend embeds the Pollar SDK for OAuth/social logins. Pollar creates
 
 ## Public Contract API
 
-Below is the entrypoint surface defined in the `#[contractimpl]` block of the Murdoku smart contract.
+Below is the entrypoint surface defined in the `#[contractimpl]` block of the Murdoku smart contract. Some entrypoints are only available with the `zk` feature enabled.
 
 | Function | Parameters | Return Type | Description |
 |---|---|---|---|
 | `init_game` | `env: Env`, `admin: Address` | `()` | Initializes the contract state and registers the game administrator. |
-| `submit_puzzle` | `env: Env`, `creator: Address`, `size: u32`, `solution: Vec<u32>`, `clues: Vec<Clue>` | `BytesN<32>` | Registers a new puzzle in the catalog. Validates that the solution is a valid Latin square of the specified size and that the clues are consistent. Returns the unique puzzle ID. |
-| `list_puzzles` | `env: Env` | `Vec<PuzzleSummary>` | Returns a list of summaries of all registered puzzles in the catalog. |
-| `get_puzzle` | `env: Env`, `id: BytesN<32>` | `Puzzle` | Retrieves the grid configuration and clues for a specific puzzle ID. Excludes the solution. |
-| `start_game` | `env: Env`, `player: Address`, `puzzle_id: BytesN<32>` | `()` | Spawns a new active game session for the player. Triggers the initialization systems. |
-| `place_suspect` | `env: Env`, `session_key: Address`, `row: u32`, `col: u32`, `suspect_id: u32` | `()` | Places a suspect at the specified cell coordinates. Validates constraints and evaluates if the puzzle has been solved. Authenticated via session key. |
-| `is_solved` | `env: Env`, `player: Address` | `bool` | Returns `true` if the player's active puzzle has been successfully solved. |
-| `register_passkey` | `env: Env`, `player: Address`, `pubkey: BytesN<65>` | `()` | Registers a secp256r1 public key (e.g. passkey) for the player. |
-| `authenticate_and_create_session` | `env: Env`, `player: Address`, `signature: Bytes`, `challenge: BytesN<32>`, `duration: u64` | `Address` | Verifies a passkey signature and returns a scoped session key address. |
+| `submit_puzzle` (v1) | `env: Env`, `creator: Address`, `size: u32`, `solution: Vec<u32>`, `clues: Vec<Clue>` | `u32` | Registers a new puzzle in the catalog with plaintext solution. Validates Latin square constraints. |
+| `submit_puzzle` (ZK) | `env: Env`, `creator: Address`, `grid_size: u32`, `suspects: Vec<String>`, `clues: Vec<Clue>`, `solution_commitment: BytesN<32>`, `verifier_key: Bytes`, `metadata: PuzzleMetadata` | `u32` | Registers a new puzzle with a solution commitment and Groth16 verifier key. No plaintext solution is stored. |
+| `list_puzzles` | `env: Env`, `offset: u32`, `limit: u32` | `Vec<PuzzleSummary>` | Returns a paginated list of summaries of all registered puzzles. |
+| `get_puzzle` | `env: Env`, `puzzle_id: u32` | `Puzzle` | Retrieves puzzle details. In ZK mode, returns the solution commitment (not the plaintext solution). |
+| `deactivate_puzzle` | `env: Env`, `caller: Address`, `puzzle_id: u32` | `()` | Deactivates a puzzle. Only the creator can deactivate. |
+| `submit_proof` (ZK) | `env: Env`, `player: Address`, `puzzle_id: u32`, `proof: Bytes`, `public_inputs: Vec<BytesN<32>>` | `()` | Submits a Groth16 proof of a valid solution. Marks the puzzle as solved for the player on success. |
+| `is_solved` (ZK) | `env: Env`, `puzzle_id: u32`, `player: Address` | `bool` | Returns `true` if the player has submitted a valid proof for the puzzle. |
 
 ---
 
@@ -61,10 +64,18 @@ Below is the entrypoint surface defined in the `#[contractimpl]` block of the Mu
 Murdoku uses Soroban's state storage model (Instance, Persistent, and Temporary) to optimize gas costs and storage lifetimes.
 
 | Storage Type | Data Kept | Lifetime | Rationale |
-|---|---|---|---|
-| **Persistent** | Registered Puzzle catalog (by ID), Creator profiles, Passkey credentials | Indefinite | Puzzle templates and user credentials must persist forever across sessions and are read-heavy. |
+|---|---|---|---|---|
+| **Persistent** | Registered Puzzle catalog (by ID), Creator profiles, Passkey credentials, Verifier keys (ZK), Solver state (ZK) | Indefinite | Puzzle templates and user credentials must persist forever across sessions and are read-heavy. |
 | **Instance** | Active Player Game session, ECS World state (`SimpleWorld`), Admin configs | Extended (Renewed on play) | The active board state must persist during active play but can be garbage-collected or archived if the player abandons the game. |
 | **Temporary** | Active Session Key tokens, cryptographic challenges | Short-term (Expires in blocks) | Session authorization keys only need to last for the duration of the play session and should expire automatically to free state space. |
+
+In ZK mode, the following additional storage keys are used:
+
+| Key Pattern | Type | Description |
+|---|---|---|
+| `(Symbol("VKEY"), puzzle_id)` | `Bytes` | XDR-serialized Groth16 `VerificationKey` |
+| `(Symbol("SOLVED"), puzzle_id, player)` | `bool` | Whether a player has solved this puzzle |
+| `(Symbol("SOLVER_CNT"), puzzle_id)` | `u32` | Number of unique solvers for this puzzle |
 
 ---
 
@@ -87,11 +98,12 @@ Murdoku uses Soroban's state storage model (Instance, Persistent, and Temporary)
    - Selects grid size (4x4 or 5x5).
    - Enters the full solution grid.
    - Defines the clues (e.g., cell constraints, adjacency rules).
-3. **Submit Puzzle**: The creator clicks "Publish", triggering a call to `submit_puzzle`.
-4. **Contract Invariant Check**: The contract validates:
-   - The solution grid constitutes a mathematically valid Latin square.
-   - The provided clues do not conflict with the solution.
-5. **Publishing**: If checks pass, the contract generates a unique puzzle ID (SHA-256 hash of solution and clues), stores the puzzle templates in persistent storage, and adds it to the list of active games.
+3. **Submit Puzzle** (v1): The creator clicks "Publish", triggering a call to `submit_puzzle` with the plaintext solution.
+4. **Submit Puzzle** (ZK): The creator generates a Poseidon2 commitment of the solution and a Groth16 verifier key, then calls `submit_puzzle` with the commitment and key instead of the plaintext.
+5. **Contract Validation**:
+   - **v1 mode**: The contract validates the Latin square constraints and clue consistency via ECS systems.
+   - **ZK mode**: The contract validates puzzle structure (grid size, suspects, clue bounds) but cannot verify solution correctness — the ZK proof catches cheating at solve time.
+6. **Publishing**: If checks pass, the contract assigns a puzzle ID, stores the puzzle in persistent storage, and activates it.
 
 ---
 
@@ -151,7 +163,14 @@ cd examples/murdoku
 cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test
+cargo test --features zk   # run ZK-specific tests
 stellar contract build
+```
+
+To build with the ZK privacy layer enabled:
+```bash
+cargo build --features zk
+cargo test --features zk
 ```
 
 ---
@@ -196,13 +215,59 @@ stellar contract invoke \
 
 ---
 
-## Known Limitations
+## ZK Privacy Layer
 
-* **Plaintext Solutions**: In the v1 release, solutions and clue validations are stored in plaintext on-chain. ZK commit-reveal is tracked as a separate v2 enhancement.
-* **Grid Sizes**: Grid sizes are constrained to 4x4 and 5x5 to maintain low transaction complexity and stay within Soroban CPU/memory limits.
-* **Immutable Puzzles**: Puzzles cannot be edited or deleted once submitted to prevent breaking active player games.
-* **No Client Proof Generation**: ZK mode does not generate proofs in the client during play in v1.
-* **Development Circuit Setup**: The trusted setup used for ZK verification circuits in development is not production-safe and must be regenerated with a ceremony before launch.
+### Circuit Statement
+
+The Groth16 circuit proves the following statement without revealing the solution:
+
+> "I know a set of values `cells` such that:
+>   (1) `cells` is a valid Latin square of size N,
+>   (2) Poseidon2(cells || salt) == commitment,
+>   (3) each cell value is in range 1..=N."
+
+### Public Inputs Format
+
+| Index | Type | Description |
+|-------|------|-------------|
+| 0 | `BytesN<32>` | Solution commitment (Poseidon2 hash of solution + salt) |
+| 1..N | `BytesN<32>` | Additional public inputs (e.g., grid size, clue hashes) |
+
+### Player Solve Flow (ZK mode)
+
+1. **Browse Puzzles**: Frontend calls `list_puzzles` and `get_puzzle` to fetch puzzle metadata (grid size, suspects, clues, solution **commitment** — not the plaintext solution).
+2. **Solve Off-Chain**: The player solves the puzzle manually, arriving at a candidate grid arrangement.
+3. **Generate Proof**: The frontend (or a backend prover service) generates a Groth16 proof that the player knows a valid arrangement consistent with the commitment.
+4. **Submit Proof**: The player calls `submit_proof(player, puzzle_id, proof, public_inputs)`. The contract verifies the Groth16 proof against the stored verifier key.
+5. **Mark Solved**: On valid proof, the contract marks the puzzle as solved for that player and increments the solver count.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/zk.rs` | Groth16 proof verification logic, verifier key storage, solver state tracking |
+| `src/components.rs` | `SolutionCommitment` ECS component (ZK mode only) |
+| `src/lib.rs` | Feature-gated `Puzzle` struct, `submit_proof` entrypoint, `is_solved` query |
+
+### Backward Compatibility
+
+The v1 plaintext solution path is preserved behind the default (no `zk` feature) build. To switch between modes:
+
+```bash
+# v1 mode (default)
+cargo build
+cargo test
+
+# ZK mode
+cargo build --features zk
+cargo test --features zk
+```
+
+### Known Constraints
+
+- **Trusted Setup**: Groth16 requires a trusted setup ceremony for each circuit. The development verifier keys used in this implementation are **not production-safe**. A proper multi-party ceremony must be completed before mainnet deployment. See the module-level docs in `src/zk.rs` for details.
+- **Client-Side Proof Generation**: Generating Groth16 proofs in the browser requires a WASM-compiled prover. This is tracked as a separate enhancement and is not yet implemented in the frontend.
+- **Circuit Size**: A 5×5 Murdoku circuit has 25 cells. Each cell requires range checks (1..=N) and Latin square row/column uniqueness constraints. The constraint count should be verified against Stellar's Groth16 verification limits before production use.
 
 ---
 

--- a/examples/murdoku/src/components.rs
+++ b/examples/murdoku/src/components.rs
@@ -1,7 +1,8 @@
 //! Murdoku game components using cougr-core's ComponentTrait
 
 use cougr_core::component::{ComponentStorage, ComponentTrait};
-use soroban_sdk::{contracttype, symbol_short, Bytes, Env, Symbol, Vec, String};
+use soroban_sdk::xdr::{FromXdr, ToXdr};
+use soroban_sdk::{contracttype, symbol_short, Bytes, Env, String, Symbol, Vec};
 
 /// A single pre-filled cell clue in the puzzle grid.
 #[contracttype]
@@ -32,11 +33,11 @@ impl ComponentTrait for GridSize {
     }
 
     fn serialize(&self, env: &Env) -> Bytes {
-        env.to_xdr(&self.size)
+        self.size.to_xdr(env)
     }
 
     fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        let size = env.from_xdr(data).ok()?;
+        let size = u32::from_xdr(env, data).ok()?;
         Some(Self { size })
     }
 
@@ -57,11 +58,11 @@ impl ComponentTrait for Suspects {
     }
 
     fn serialize(&self, env: &Env) -> Bytes {
-        env.to_xdr(&self.list)
+        self.list.clone().to_xdr(env)
     }
 
     fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        let list = env.from_xdr(data).ok()?;
+        let list = soroban_sdk::Vec::<String>::from_xdr(env, data).ok()?;
         Some(Self { list })
     }
 
@@ -82,11 +83,11 @@ impl ComponentTrait for Clues {
     }
 
     fn serialize(&self, env: &Env) -> Bytes {
-        env.to_xdr(&self.list)
+        self.list.clone().to_xdr(env)
     }
 
     fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        let list = env.from_xdr(data).ok()?;
+        let list = soroban_sdk::Vec::<Clue>::from_xdr(env, data).ok()?;
         Some(Self { list })
     }
 
@@ -107,11 +108,11 @@ impl ComponentTrait for Solution {
     }
 
     fn serialize(&self, env: &Env) -> Bytes {
-        env.to_xdr(&self.grid)
+        self.grid.clone().to_xdr(env)
     }
 
     fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        let grid = env.from_xdr(data).ok()?;
+        let grid = soroban_sdk::Vec::<u32>::from_xdr(env, data).ok()?;
         Some(Self { grid })
     }
 
@@ -132,12 +133,39 @@ impl ComponentTrait for Metadata {
     }
 
     fn serialize(&self, env: &Env) -> Bytes {
-        env.to_xdr(&self.meta)
+        self.meta.clone().to_xdr(env)
     }
 
     fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
-        let meta = env.from_xdr(data).ok()?;
+        let meta = PuzzleMetadata::from_xdr(env, data).ok()?;
         Some(Self { meta })
+    }
+
+    fn default_storage() -> ComponentStorage {
+        ComponentStorage::Table
+    }
+}
+
+/// Solution commitment component storing the Poseidon2 hash (ZK mode).
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SolutionCommitment {
+    pub commitment: soroban_sdk::BytesN<32>,
+}
+
+#[cfg(feature = "zk")]
+impl ComponentTrait for SolutionCommitment {
+    fn component_type() -> Symbol {
+        symbol_short!("solcommit")
+    }
+
+    fn serialize(&self, env: &Env) -> Bytes {
+        self.commitment.clone().to_xdr(env)
+    }
+
+    fn deserialize(env: &Env, data: &Bytes) -> Option<Self> {
+        let commitment = soroban_sdk::BytesN::<32>::from_xdr(env, data).ok()?;
+        Some(Self { commitment })
     }
 
     fn default_storage() -> ComponentStorage {

--- a/examples/murdoku/src/lib.rs
+++ b/examples/murdoku/src/lib.rs
@@ -1,13 +1,23 @@
 #![no_std]
+#![allow(clippy::too_many_arguments)]
 extern crate alloc;
 
 pub mod components;
+#[cfg(not(feature = "zk"))]
 pub mod systems;
+#[cfg(feature = "zk")]
+pub mod zk;
 
 use components::{Clue, PuzzleMetadata};
 use cougr_core::ops::Ownable;
+#[cfg(not(feature = "zk"))]
 use cougr_core::plugin::GameApp;
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol, Vec, String};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, String,
+    Symbol, Vec,
+};
+#[cfg(feature = "zk")]
+use soroban_sdk::{Bytes, BytesN};
 
 /// Errors returned by the Murdoku smart contract.
 #[contracterror]
@@ -22,7 +32,8 @@ pub enum PuzzleError {
     Unauthorized = 6,
 }
 
-/// Representation of a full Murdoku puzzle.
+/// Representation of a full Murdoku puzzle (v1 — plaintext solution).
+#[cfg(not(feature = "zk"))]
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Puzzle {
@@ -32,6 +43,21 @@ pub struct Puzzle {
     pub suspects: Vec<String>,
     pub clues: Vec<Clue>,
     pub solution: Vec<u32>,
+    pub metadata: PuzzleMetadata,
+    pub active: bool,
+}
+
+/// Representation of a full Murdoku puzzle (ZK mode — solution commitment).
+#[cfg(feature = "zk")]
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Puzzle {
+    pub id: u32,
+    pub creator: Address,
+    pub grid_size: u32,
+    pub suspects: Vec<String>,
+    pub clues: Vec<Clue>,
+    pub solution_commitment: BytesN<32>,
     pub metadata: PuzzleMetadata,
     pub active: bool,
 }
@@ -51,6 +77,7 @@ pub struct PuzzleSummary {
 pub struct MurdokuContract;
 
 #[contractimpl]
+#[cfg(not(feature = "zk"))]
 impl MurdokuContract {
     /// Validates and stores a new puzzle. Returns the assigned puzzle ID.
     pub fn submit_puzzle(
@@ -69,14 +96,38 @@ impl MurdokuContract {
         app.add_startup_system("validate_puzzle", systems::puzzle_validation_system);
 
         let entity_id = app.world_mut().spawn_entity();
-        app.world_mut().set_typed(&env, entity_id, &components::GridSize { size: grid_size });
-        app.world_mut().set_typed(&env, entity_id, &components::Suspects { list: suspects.clone() });
-        app.world_mut().set_typed(&env, entity_id, &components::Clues { list: clues.clone() });
-        app.world_mut().set_typed(&env, entity_id, &components::Solution { grid: solution.clone() });
-        app.world_mut().set_typed(&env, entity_id, &components::Metadata { meta: metadata.clone() });
+        app.world_mut()
+            .set_typed(&env, entity_id, &components::GridSize { size: grid_size });
+        app.world_mut().set_typed(
+            &env,
+            entity_id,
+            &components::Suspects {
+                list: suspects.clone(),
+            },
+        );
+        app.world_mut().set_typed(
+            &env,
+            entity_id,
+            &components::Clues {
+                list: clues.clone(),
+            },
+        );
+        app.world_mut().set_typed(
+            &env,
+            entity_id,
+            &components::Solution {
+                grid: solution.clone(),
+            },
+        );
+        app.world_mut().set_typed(
+            &env,
+            entity_id,
+            &components::Metadata {
+                meta: metadata.clone(),
+            },
+        );
 
-        if let Err(_) = app.run_startup(&env) {
-            // Under normal circumstances, validation panics internally. But in case of startup scheduler error:
+        if app.run_startup(&env).is_err() {
             panic_with_error!(&env, PuzzleError::InvalidSolution);
         }
 
@@ -169,7 +220,7 @@ impl MurdokuContract {
         let ownable_id = Symbol::new(&env, &alloc::format!("puzzle_{}", puzzle_id));
         let ownable = Ownable::new(ownable_id);
 
-        if let Err(_) = ownable.require_owner(&env, &caller) {
+        if ownable.require_owner(&env, &caller).is_err() {
             panic_with_error!(&env, PuzzleError::Unauthorized);
         }
 
@@ -189,8 +240,223 @@ impl MurdokuContract {
     }
 }
 
-#[cfg(test)]
-mod tests {
+#[contractimpl]
+#[cfg(feature = "zk")]
+impl MurdokuContract {
+    /// Validates and stores a new puzzle with a solution commitment instead of plaintext.
+    ///
+    /// The creator provides a Poseidon2 hash of the solution (plus a secret salt)
+    /// and a Groth16 verifier key. The contract validates puzzle structure but
+    /// cannot verify the solution itself — that happens at solve time via ZK proof.
+    pub fn submit_puzzle(
+        env: Env,
+        caller: Address,
+        grid_size: u32,
+        suspects: Vec<String>,
+        clues: Vec<Clue>,
+        solution_commitment: BytesN<32>,
+        verifier_key: Bytes,
+        metadata: PuzzleMetadata,
+    ) -> u32 {
+        caller.require_auth();
+
+        // --- Inline validation (no plaintext solution available) ---
+
+        // 1. Grid size must be 4 or 5
+        if grid_size != 4 && grid_size != 5 {
+            panic_with_error!(&env, PuzzleError::InvalidGridSize);
+        }
+
+        // 2. Suspects length must equal grid_size; each suspect must have a non-empty name
+        if suspects.len() != grid_size {
+            panic_with_error!(&env, PuzzleError::InvalidSuspects);
+        }
+        for i in 0..grid_size {
+            let name = suspects.get(i).unwrap();
+            if name.is_empty() {
+                panic_with_error!(&env, PuzzleError::InvalidSuspects);
+            }
+        }
+
+        // 3. Clues list must be non-empty
+        if clues.is_empty() {
+            panic_with_error!(&env, PuzzleError::InvalidClues);
+        }
+
+        // 4. Every clue must reference only valid suspect indices and valid coordinates
+        for i in 0..clues.len() {
+            let clue = clues.get(i).unwrap();
+            if clue.row >= grid_size || clue.col >= grid_size {
+                panic_with_error!(&env, PuzzleError::InvalidClues);
+            }
+            if clue.suspect_idx < 1 || clue.suspect_idx > grid_size {
+                panic_with_error!(&env, PuzzleError::InvalidClues);
+            }
+        }
+
+        // 5. Validate that the commitment is non-zero (a valid hash is never all-zero)
+        let zero = BytesN::from_array(&env, &[0u8; 32]);
+        if solution_commitment == zero {
+            panic_with_error!(&env, PuzzleError::InvalidSolution);
+        }
+
+        // 6. Validate that the verifier key is non-empty
+        if verifier_key.is_empty() {
+            panic_with_error!(&env, PuzzleError::InvalidSolution);
+        }
+
+        // --- Storage ---
+
+        // Increment the puzzle counter
+        let counter_key = Symbol::new(&env, "PUZZLE_COUNT");
+        let mut count: u32 = env.storage().persistent().get(&counter_key).unwrap_or(0);
+        count += 1;
+        env.storage().persistent().set(&counter_key, &count);
+        let puzzle_id = count;
+
+        // Store the puzzle definition (includes commitment, not solution)
+        let puzzle = Puzzle {
+            id: puzzle_id,
+            creator: caller.clone(),
+            grid_size,
+            suspects,
+            clues,
+            solution_commitment,
+            metadata,
+            active: true,
+        };
+        let puzzle_key = (Symbol::new(&env, "PUZZLE"), puzzle_id);
+        env.storage().persistent().set(&puzzle_key, &puzzle);
+
+        // Store the verifier key separately
+        zk::store_verifier_key(&env, puzzle_id, &verifier_key);
+
+        // Set the puzzle status
+        let status_key = (Symbol::new(&env, "STATUS"), puzzle_id);
+        env.storage().persistent().set(&status_key, &true);
+
+        // Initialize the ownable pattern for authorization
+        let ownable_id = Symbol::new(&env, &alloc::format!("puzzle_{}", puzzle_id));
+        let ownable = Ownable::new(ownable_id);
+        ownable.initialize(&env, &caller).unwrap();
+
+        puzzle_id
+    }
+
+    /// Returns the puzzle definition (without solution – only the commitment hash).
+    pub fn get_puzzle(env: Env, puzzle_id: u32) -> Puzzle {
+        let puzzle_key = (Symbol::new(&env, "PUZZLE"), puzzle_id);
+        let mut puzzle: Puzzle = match env.storage().persistent().get(&puzzle_key) {
+            Some(p) => p,
+            None => panic_with_error!(&env, PuzzleError::PuzzleNotFound),
+        };
+        let status_key = (Symbol::new(&env, "STATUS"), puzzle_id);
+        let active = env.storage().persistent().get(&status_key).unwrap_or(false);
+        puzzle.active = active;
+        puzzle
+    }
+
+    /// Returns a paginated list of puzzle summaries (no solution or commitment).
+    pub fn list_puzzles(env: Env, offset: u32, limit: u32) -> Vec<PuzzleSummary> {
+        let counter_key = Symbol::new(&env, "PUZZLE_COUNT");
+        let total: u32 = env.storage().persistent().get(&counter_key).unwrap_or(0);
+
+        let mut list = Vec::new(&env);
+        if offset >= total {
+            return list;
+        }
+
+        let start = offset + 1;
+        let end = (offset + limit).min(total);
+
+        for id in start..=end {
+            let puzzle_key = (Symbol::new(&env, "PUZZLE"), id);
+            if let Some(puzzle) = env.storage().persistent().get::<_, Puzzle>(&puzzle_key) {
+                let status_key = (Symbol::new(&env, "STATUS"), id);
+                let active = env.storage().persistent().get(&status_key).unwrap_or(false);
+                list.push_back(PuzzleSummary {
+                    id: puzzle.id,
+                    creator: puzzle.creator,
+                    grid_size: puzzle.grid_size,
+                    metadata: puzzle.metadata,
+                    active,
+                });
+            }
+        }
+        list
+    }
+
+    /// Returns the total number of submitted puzzles.
+    pub fn get_puzzle_count(env: Env) -> u32 {
+        let counter_key = Symbol::new(&env, "PUZZLE_COUNT");
+        env.storage().persistent().get(&counter_key).unwrap_or(0)
+    }
+
+    /// Allows the original creator to deactivate their puzzle.
+    pub fn deactivate_puzzle(env: Env, caller: Address, puzzle_id: u32) {
+        caller.require_auth();
+
+        let ownable_id = Symbol::new(&env, &alloc::format!("puzzle_{}", puzzle_id));
+        let ownable = Ownable::new(ownable_id);
+
+        if ownable.require_owner(&env, &caller).is_err() {
+            panic_with_error!(&env, PuzzleError::Unauthorized);
+        }
+
+        let status_key = (Symbol::new(&env, "STATUS"), puzzle_id);
+        if !env.storage().persistent().has(&status_key) {
+            panic_with_error!(&env, PuzzleError::PuzzleNotFound);
+        }
+
+        env.storage().persistent().set(&status_key, &false);
+
+        let puzzle_key = (Symbol::new(&env, "PUZZLE"), puzzle_id);
+        if let Some(mut puzzle) = env.storage().persistent().get::<_, Puzzle>(&puzzle_key) {
+            puzzle.active = false;
+            env.storage().persistent().set(&puzzle_key, &puzzle);
+        }
+    }
+
+    /// Submit a Groth16 proof to claim the puzzle has been solved.
+    ///
+    /// On valid proof: marks the player's session as solved and increments the
+    /// solver count. On invalid proof: panics with `InvalidSolution`.
+    pub fn submit_proof(
+        env: Env,
+        player: Address,
+        puzzle_id: u32,
+        proof: Bytes,
+        public_inputs: Vec<BytesN<32>>,
+    ) {
+        player.require_auth();
+
+        // Verify the puzzle exists
+        let puzzle_key = (Symbol::new(&env, "PUZZLE"), puzzle_id);
+        if !env.storage().persistent().has(&puzzle_key) {
+            panic_with_error!(&env, PuzzleError::PuzzleNotFound);
+        }
+
+        // Verify the Groth16 proof
+        let valid = zk::verify_solution_proof(&env, puzzle_id, proof, public_inputs);
+        if !valid {
+            panic_with_error!(&env, PuzzleError::InvalidSolution);
+        }
+
+        // Mark as solved
+        zk::mark_solved(&env, puzzle_id, &player);
+    }
+
+    /// Check whether a player has solved the specified puzzle.
+    pub fn is_solved(env: Env, puzzle_id: u32, player: Address) -> bool {
+        zk::is_solved(&env, puzzle_id, &player)
+    }
+}
+
+// ──────────────────────────────────────────────
+// v1 tests (plaintext solution, no ZK feature)
+// ──────────────────────────────────────────────
+#[cfg(all(test, not(feature = "zk")))]
+mod v1_tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env, String, Vec};
 
@@ -214,27 +480,19 @@ mod tests {
             suspect_idx: 3,
         });
 
-        // Valid Latin square:
-        // [1, 2, 3, 4]
-        // [2, 3, 4, 1]
-        // [3, 4, 1, 2]
-        // [4, 1, 2, 3]
         let mut solution = Vec::new(env);
         solution.push_back(1);
         solution.push_back(2);
         solution.push_back(3);
         solution.push_back(4);
-
         solution.push_back(2);
         solution.push_back(3);
         solution.push_back(4);
         solution.push_back(1);
-
         solution.push_back(3);
         solution.push_back(4);
         solution.push_back(1);
         solution.push_back(2);
-
         solution.push_back(4);
         solution.push_back(1);
         solution.push_back(2);
@@ -259,7 +517,9 @@ mod tests {
         let creator = Address::generate(&env);
         let (grid_size, suspects, clues, solution, metadata) = make_valid_puzzle(&env);
 
-        let id = client.submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
+        let id = client.submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
         assert_eq!(id, 1);
         assert_eq!(client.get_puzzle_count(), 1);
 
@@ -270,207 +530,160 @@ mod tests {
         assert_eq!(puzzle.suspects.len(), 4);
         assert_eq!(puzzle.clues.len(), 2);
         assert_eq!(puzzle.solution.len(), 16);
-        assert_eq!(puzzle.active, true);
+        assert!(puzzle.active);
     }
 
     #[test]
     fn test_submit_invalid_grid_size() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (_, suspects, clues, solution, metadata) = make_valid_puzzle(&env);
-
-        let result = client.try_submit_puzzle(&creator, &3, &suspects, &clues, &solution, &metadata);
+        let result =
+            client.try_submit_puzzle(&creator, &3, &suspects, &clues, &solution, &metadata);
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::InvalidGridSize as u32);
-        } else {
-            panic!("Expected InvalidGridSize contract error");
-        }
     }
 
     #[test]
     fn test_submit_invalid_suspects_length() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (grid_size, mut suspects, clues, solution, metadata) = make_valid_puzzle(&env);
-        suspects.pop_back(); // length 3 instead of 4
-
-        let result = client.try_submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
+        suspects.pop_back();
+        let result = client.try_submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::InvalidSuspects as u32);
-        } else {
-            panic!("Expected InvalidSuspects contract error");
-        }
     }
 
     #[test]
     fn test_submit_empty_suspect_name() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (grid_size, mut suspects, clues, solution, metadata) = make_valid_puzzle(&env);
-        suspects.set(1, String::from_str(&env, "")); // empty name
-
-        let result = client.try_submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
+        suspects.set(1, String::from_str(&env, ""));
+        let result = client.try_submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::InvalidSuspects as u32);
-        } else {
-            panic!("Expected InvalidSuspects contract error");
-        }
     }
 
     #[test]
     fn test_submit_invalid_solution_length() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (grid_size, suspects, clues, mut solution, metadata) = make_valid_puzzle(&env);
-        solution.pop_back(); // length 15 instead of 16
-
-        let result = client.try_submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
+        solution.pop_back();
+        let result = client.try_submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::InvalidSolution as u32);
-        } else {
-            panic!("Expected InvalidSolution contract error");
-        }
     }
 
     #[test]
     fn test_submit_invalid_latin_square() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (grid_size, suspects, clues, mut solution, metadata) = make_valid_puzzle(&env);
-        solution.set(1, 1); // Row 0 is now [1, 1, 3, 4] -> duplicate 1
-
-        let result = client.try_submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
+        solution.set(1, 1);
+        let result = client.try_submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::InvalidSolution as u32);
-        } else {
-            panic!("Expected InvalidSolution contract error");
-        }
     }
 
     #[test]
     fn test_submit_empty_clues() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (grid_size, suspects, _, solution, metadata) = make_valid_puzzle(&env);
         let empty_clues = Vec::new(&env);
-
-        let result = client.try_submit_puzzle(&creator, &grid_size, &suspects, &empty_clues, &solution, &metadata);
+        let result = client.try_submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &empty_clues,
+            &solution,
+            &metadata,
+        );
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::InvalidClues as u32);
-        } else {
-            panic!("Expected InvalidClues contract error");
-        }
     }
 
     #[test]
     fn test_submit_invalid_clue_coordinate() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (grid_size, suspects, mut clues, solution, metadata) = make_valid_puzzle(&env);
         clues.push_back(Clue {
-            row: 4, // Out of bounds for size 4
+            row: 4,
             col: 0,
             suspect_idx: 1,
         });
-
-        let result = client.try_submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
+        let result = client.try_submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::InvalidClues as u32);
-        } else {
-            panic!("Expected InvalidClues contract error");
-        }
     }
 
     #[test]
     fn test_submit_clue_mismatch_with_solution() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (grid_size, suspects, mut clues, solution, metadata) = make_valid_puzzle(&env);
         clues.push_back(Clue {
             row: 0,
             col: 1,
-            suspect_idx: 4, // Solution at (0,1) is 2, not 4
+            suspect_idx: 4,
         });
-
-        let result = client.try_submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
+        let result = client.try_submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::InvalidClues as u32);
-        } else {
-            panic!("Expected InvalidClues contract error");
-        }
     }
 
     #[test]
     fn test_list_puzzles_and_pagination() {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
-
         let creator = Address::generate(&env);
         let (grid_size, suspects, clues, solution, metadata) = make_valid_puzzle(&env);
-
-        client.submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
-        client.submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
-        client.submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
-
+        client.submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
+        client.submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
+        client.submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
         assert_eq!(client.get_puzzle_count(), 3);
-
         let list_all = client.list_puzzles(&0, &10);
         assert_eq!(list_all.len(), 3);
-        assert_eq!(list_all.get(0).unwrap().id, 1);
-        assert_eq!(list_all.get(1).unwrap().id, 2);
-        assert_eq!(list_all.get(2).unwrap().id, 3);
-
         let list_page = client.list_puzzles(&1, &1);
         assert_eq!(list_page.len(), 1);
         assert_eq!(list_page.get(0).unwrap().id, 2);
@@ -480,32 +693,370 @@ mod tests {
     fn test_deactivate_puzzle_authorization() {
         let env = Env::default();
         env.mock_all_auths();
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, clues, solution, metadata) = make_valid_puzzle(&env);
+        client.submit_puzzle(
+            &creator, &grid_size, &suspects, &clues, &solution, &metadata,
+        );
+        let intruder = Address::generate(&env);
+        let result = client.try_deactivate_puzzle(&intruder, &1);
+        assert!(result.is_err());
+        client.deactivate_puzzle(&creator, &1);
+        let puzzle = client.get_puzzle(&1);
+        assert!(!puzzle.active);
+    }
+}
+
+// ──────────────────────────────────────────────
+// ZK tests (solution commitment + proof)
+// ──────────────────────────────────────────────
+#[cfg(all(test, feature = "zk"))]
+mod zk_tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Bytes, BytesN, Env, String, Vec};
+
+    fn make_valid_zk_puzzle(
+        env: &Env,
+    ) -> (
+        u32,
+        Vec<String>,
+        Vec<Clue>,
+        BytesN<32>,
+        Bytes,
+        PuzzleMetadata,
+    ) {
+        let grid_size = 4;
+        let mut suspects = Vec::new(env);
+        suspects.push_back(String::from_str(env, "Alice"));
+        suspects.push_back(String::from_str(env, "Bob"));
+        suspects.push_back(String::from_str(env, "Charlie"));
+        suspects.push_back(String::from_str(env, "David"));
+
+        let mut clues = Vec::new(env);
+        clues.push_back(Clue {
+            row: 0,
+            col: 0,
+            suspect_idx: 1,
+        });
+        clues.push_back(Clue {
+            row: 1,
+            col: 1,
+            suspect_idx: 3,
+        });
+
+        // A non-zero commitment (would be Poseidon2(solution || salt) in production)
+        let solution_commitment = BytesN::from_array(env, &[1u8; 32]);
+        // A minimal non-empty verifier key (just a placeholder for testing)
+        let verifier_key = Bytes::from_array(env, &[0x01u8; 32]);
+
+        let metadata = PuzzleMetadata {
+            name: String::from_str(env, "ZK Case"),
+            difficulty: String::from_str(env, "Hard"),
+        };
+
+        (
+            grid_size,
+            suspects,
+            clues,
+            solution_commitment,
+            verifier_key,
+            metadata,
+        )
+    }
+
+    #[test]
+    fn test_zk_submit_valid_puzzle() {
+        let env = Env::default();
+        env.mock_all_auths();
 
         let contract_id = env.register(MurdokuContract, ());
         let client = MurdokuContractClient::new(&env, &contract_id);
 
         let creator = Address::generate(&env);
-        let (grid_size, suspects, clues, solution, metadata) = make_valid_puzzle(&env);
+        let (grid_size, suspects, clues, commitment, vk, metadata) = make_valid_zk_puzzle(&env);
 
-        client.submit_puzzle(&creator, &grid_size, &suspects, &clues, &solution, &metadata);
+        let id = client.submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+        assert_eq!(id, 1);
+        assert_eq!(client.get_puzzle_count(), 1);
 
-        // A non-creator tries to deactivate and gets rejected
+        let puzzle = client.get_puzzle(&1);
+        assert_eq!(puzzle.id, 1);
+        assert_eq!(puzzle.creator, creator);
+        assert_eq!(puzzle.grid_size, 4);
+        assert_eq!(puzzle.suspects.len(), 4);
+        assert_eq!(puzzle.clues.len(), 2);
+        assert_eq!(puzzle.solution_commitment, commitment);
+        assert!(puzzle.active);
+    }
+
+    #[test]
+    fn test_zk_submit_zero_commitment_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, clues, _, vk, metadata) = make_valid_zk_puzzle(&env);
+        let zero_commitment = BytesN::from_array(&env, &[0u8; 32]);
+
+        let result = client.try_submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &zero_commitment,
+            &vk,
+            &metadata,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_zk_submit_empty_verifier_key_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, clues, commitment, _, metadata) = make_valid_zk_puzzle(&env);
+        let empty_vk = Bytes::new(&env);
+
+        let result = client.try_submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &empty_vk,
+            &metadata,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_zk_submit_invalid_grid_size() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (_, suspects, clues, commitment, vk, metadata) = make_valid_zk_puzzle(&env);
+
+        let result =
+            client.try_submit_puzzle(&creator, &3, &suspects, &clues, &commitment, &vk, &metadata);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_zk_submit_empty_clues_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, _, commitment, vk, metadata) = make_valid_zk_puzzle(&env);
+        let empty_clues = Vec::new(&env);
+
+        let result = client.try_submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &empty_clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_zk_submit_invalid_clue_coordinate() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, mut clues, commitment, vk, metadata) = make_valid_zk_puzzle(&env);
+        clues.push_back(Clue {
+            row: 10,
+            col: 0,
+            suspect_idx: 1,
+        });
+
+        let result = client.try_submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_zk_proof_invalid_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, clues, commitment, vk, metadata) = make_valid_zk_puzzle(&env);
+        let _id = client.submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+
+        let player = Address::generate(&env);
+        let invalid_proof = Bytes::from_array(&env, &[0u8; 16]);
+        let public_inputs = Vec::new(&env);
+
+        let result = client.try_submit_proof(&player, &1, &invalid_proof, &public_inputs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_zk_proof_nonexistent_puzzle_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let player = Address::generate(&env);
+        let proof = Bytes::new(&env);
+        let public_inputs = Vec::new(&env);
+
+        let result = client.try_submit_proof(&player, &999, &proof, &public_inputs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_zk_is_solved_returns_false_before_proof() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, clues, commitment, vk, metadata) = make_valid_zk_puzzle(&env);
+        client.submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+
+        let player = Address::generate(&env);
+        let solved = client.is_solved(&1, &player);
+        assert!(!solved);
+    }
+
+    #[test]
+    fn test_zk_list_puzzles_and_pagination() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, clues, commitment, vk, metadata) = make_valid_zk_puzzle(&env);
+
+        client.submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+        client.submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+        client.submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+
+        assert_eq!(client.get_puzzle_count(), 3);
+        let list_all = client.list_puzzles(&0, &10);
+        assert_eq!(list_all.len(), 3);
+        let list_page = client.list_puzzles(&1, &1);
+        assert_eq!(list_page.len(), 1);
+        assert_eq!(list_page.get(0).unwrap().id, 2);
+    }
+
+    #[test]
+    fn test_zk_deactivate_puzzle_authorization() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(MurdokuContract, ());
+        let client = MurdokuContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let (grid_size, suspects, clues, commitment, vk, metadata) = make_valid_zk_puzzle(&env);
+        client.submit_puzzle(
+            &creator,
+            &grid_size,
+            &suspects,
+            &clues,
+            &commitment,
+            &vk,
+            &metadata,
+        );
+
         let intruder = Address::generate(&env);
         let result = client.try_deactivate_puzzle(&intruder, &1);
         assert!(result.is_err());
-        if let Err(soroban_sdk::InvokeError::ContractError(code)) = result {
-            assert_eq!(code, PuzzleError::Unauthorized as u32);
-        } else {
-            panic!("Expected Unauthorized contract error");
-        }
 
-        // Creator deactivates successfully
         client.deactivate_puzzle(&creator, &1);
-
         let puzzle = client.get_puzzle(&1);
-        assert_eq!(puzzle.active, false);
-
-        let summaries = client.list_puzzles(&0, &1);
-        assert_eq!(summaries.get(0).unwrap().active, false);
+        assert!(!puzzle.active);
     }
 }

--- a/examples/murdoku/src/zk.rs
+++ b/examples/murdoku/src/zk.rs
@@ -1,0 +1,120 @@
+//! Groth16 zero-knowledge proof verification for Murdoku solution proofs.
+//!
+//! # Circuit Statement (informal)
+//!
+//! "I know a set of values `cells` such that:
+//!   (1) `cells` is a valid Latin square of size N,
+//!   (2) Poseidon2(cells || salt) == commitment,
+//!   (3) each cell value is in range 1..=N."
+//!
+//! # Public Inputs Format
+//!
+//! - `public_inputs[0]`: The solution commitment (`BytesN<32>`) — the Poseidon2
+//!   hash of the flat solution vector concatenated with a 32-byte salt chosen by
+//!   the puzzle creator.
+//! - `public_inputs[1..]`: Additional public inputs as required by the circuit
+//!   (e.g., grid size, clue commitments).
+//!
+//! # Trusted Setup Limitation
+//!
+//! Groth16 requires a trusted setup ceremony for each circuit. The verifier keys
+//! currently used during development are generated from a **development setup**
+//! and are **not** production-safe. A proper multi-party trusted setup ceremony
+//! must be completed before deploying this module in a production environment.
+//! See the Murdoku README for more details.
+//!
+//! # Dependencies
+//!
+//! Requires the `zk` feature flag (which enables `hazmat-crypto` on cougr-core):
+//! ```toml
+//! murdoku = { features = ["zk"] }
+//! ```
+
+use alloc::vec::Vec as AllocVec;
+
+use cougr_core::privacy::experimental::{verify_groth16, Groth16Proof, VerificationKey};
+use cougr_core::privacy::Scalar;
+use soroban_sdk::xdr::FromXdr;
+use soroban_sdk::{panic_with_error, Address, Bytes, BytesN, Env, Symbol, Vec};
+
+use crate::PuzzleError;
+
+/// Load the stored Groth16 verifier key for the given puzzle.
+pub fn load_verifier_key(env: &Env, puzzle_id: u32) -> VerificationKey {
+    let key = (Symbol::new(env, "VKEY"), puzzle_id);
+    let vk_bytes: Bytes = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| panic_with_error!(env, PuzzleError::PuzzleNotFound));
+    VerificationKey::from_xdr(env, &vk_bytes)
+        .unwrap_or_else(|_| panic_with_error!(env, PuzzleError::InvalidSolution))
+}
+
+/// Store the verifier key (as XDR-serialized bytes) for a puzzle.
+pub fn store_verifier_key(env: &Env, puzzle_id: u32, vk_bytes: &Bytes) {
+    let key = (Symbol::new(env, "VKEY"), puzzle_id);
+    env.storage().persistent().set(&key, vk_bytes);
+}
+
+/// Mark a player's session as solved for the given puzzle.
+pub fn mark_solved(env: &Env, puzzle_id: u32, player: &Address) {
+    let solved_key = (Symbol::new(env, "SOLVED"), puzzle_id, player.clone());
+    env.storage().persistent().set(&solved_key, &true);
+
+    let count_key = (Symbol::new(env, "SOLVER_CNT"), puzzle_id);
+    let mut count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+    count += 1;
+    env.storage().persistent().set(&count_key, &count);
+}
+
+/// Check whether a player has already solved the given puzzle.
+pub fn is_solved(env: &Env, puzzle_id: u32, player: &Address) -> bool {
+    let solved_key = (Symbol::new(env, "SOLVED"), puzzle_id, player.clone());
+    env.storage().persistent().get(&solved_key).unwrap_or(false)
+}
+
+/// Verify a Groth16 solution proof for the given puzzle.
+///
+/// # Arguments
+/// - `env`: Soroban environment
+/// - `puzzle_id`: The puzzle ID
+/// - `proof`: XDR-serialized `Groth16Proof`
+/// - `public_inputs`: Public inputs as 32-byte values (first element should be the
+///   solution commitment)
+///
+/// # Returns
+/// - `true` if the Groth16 proof verifies successfully against the stored key
+/// - `false` if the proof is malformed, the key is missing, or verification fails
+pub fn verify_solution_proof(
+    env: &Env,
+    puzzle_id: u32,
+    proof: Bytes,
+    public_inputs: Vec<BytesN<32>>,
+) -> bool {
+    let vk = match env
+        .storage()
+        .persistent()
+        .get::<_, Bytes>(&(Symbol::new(env, "VKEY"), puzzle_id))
+    {
+        Some(bytes) => match VerificationKey::from_xdr(env, &bytes) {
+            Ok(k) => k,
+            Err(_) => return false,
+        },
+        None => return false,
+    };
+
+    let groth16_proof: Groth16Proof = match Groth16Proof::from_xdr(env, &proof) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+
+    let mut scalars: AllocVec<Scalar> = AllocVec::with_capacity(public_inputs.len() as usize);
+    for i in 0..public_inputs.len() {
+        scalars.push(Scalar {
+            bytes: public_inputs.get(i).unwrap(),
+        });
+    }
+
+    matches!(verify_groth16(env, &vk, &groth16_proof, &scalars), Ok(true))
+}


### PR DESCRIPTION
submit_puzzle accepts solution_commitment and verifier_key instead of plaintext solution

SolutionComponent is replaced with SolutionCommitmentComponent storing only the commitment hash

get_puzzle does not expose the solution or the commitment details that would enable brute-forcing

submit_proof verifies a Groth16 proof and marks the player's session as solved on valid proof

An invalid proof is rejected without marking the session as solved

zk.rs is documented with the circuit statement, the public inputs format, and the known trusted setup limitation

cargo test passes with the hazmat-crypto feature enabled

stellar contract build produces a valid artifact

cargo fmt --check and cargo clippy --all-targets --all-features -- -D warnings pass

closes #177