### PR TITLE
fix(examples): remove duplicate place_suspect signature in murdoku

### DIFF
--- a/examples/murdoku/src/lib.rs
+++ b/examples/murdoku/src/lib.rs
@@ -546,7 +546,6 @@ impl MurdokuContract {
         revoke_session(env, player, puzzle_id)
     }
 
-    pub fn place_suspect(env: Env, player: Address, puzzle_id: u32, x: u32, y: u32, _suspect_idx: u32) -> MoveResult {
     pub fn place_suspect(env: Env, player: Address, puzzle_id: u32, x: u32, y: u32, suspect_idx: u32) -> MoveResult {
         crate::auth::require_player_auth(&env, &player, puzzle_id, symbol_short!("place_suspect"));
         


### PR DESCRIPTION
## Background

`examples/murdoku/src/lib.rs` contained a duplicated `place_suspect` function signature (lines 549–550). This prevented `cargo fmt --check` from parsing the file and blocked CI for #220 / PR #232.

## Change

Remove the stale duplicate signature line, keeping the implementation with `suspect_idx`.

## Verification

- [x] Duplicate signature removed
- [ ] Full CI validation depends on PR #232 workflow (or local `cargo test` + `stellar contract build`)

## Unblocks

- PR #232 (murdoku CI)
- Any future murdoku example workflow

Closes no issue directly; fixes a pre-existing `main` regression.