### PR TITLE
feat(examples): bump cougr-core to 1.1.0 across all examples

### DIFF
--- a/examples/ai_dungeon_master_arena/Cargo.toml
+++ b/examples/ai_dungeon_master_arena/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/angry_birds/Cargo.toml
+++ b/examples/angry_birds/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
@@ -28,5 +28,5 @@ lto = true
 
 [profile.release-with-logs]
 inherits = "release"
-debug-assertions = true 
+debug-assertions = true
 [workspace]

--- a/examples/arkanoid/Cargo.toml
+++ b/examples/arkanoid/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
@@ -28,6 +28,6 @@ lto = true
 
 [profile.release-with-logs]
 inherits = "release"
-debug-assertions = true 
+debug-assertions = true
 
 [workspace]

--- a/examples/asteroids/Cargo.lock
+++ b/examples/asteroids/Cargo.lock
@@ -285,7 +285,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cougr-core"
-version = "1.0.0"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc489e355664841b5fb4d0b19e014c3be1a9b81cd1cd9f7ad29f02fe54a4135"
 dependencies = [
  "soroban-sdk",
  "wee_alloc",

--- a/examples/asteroids/Cargo.toml
+++ b/examples/asteroids/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/battleship/Cargo.toml
+++ b/examples/battleship/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/bomberman/Cargo.lock
+++ b/examples/bomberman/Cargo.lock
@@ -286,7 +286,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cougr-core"
-version = "1.0.0"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc489e355664841b5fb4d0b19e014c3be1a9b81cd1cd9f7ad29f02fe54a4135"
 dependencies = [
  "soroban-sdk",
  "wee_alloc",

--- a/examples/bomberman/Cargo.toml
+++ b/examples/bomberman/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["rlib"]
 [dependencies]
 soroban-sdk = "25.1.0"
 num-derive = "0.4"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/checkers/Cargo.toml
+++ b/examples/checkers/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/chess/Cargo.toml
+++ b/examples/chess/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/connect_four/Cargo.toml
+++ b/examples/connect_four/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/cross_asset_racing_league/Cargo.toml
+++ b/examples/cross_asset_racing_league/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/flappy_bird/Cargo.toml
+++ b/examples/flappy_bird/Cargo.toml
@@ -10,7 +10,7 @@ description = "Flappy Bird on-chain game example using cougr-core ECS framework"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/geometry_dash/Cargo.toml
+++ b/examples/geometry_dash/Cargo.toml
@@ -10,7 +10,7 @@ description = "Geometry Dash on-chain game example using cougr-core ECS framewor
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/guild_arena/Cargo.toml
+++ b/examples/guild_arena/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
@@ -28,5 +28,5 @@ lto = true
 
 [profile.release-with-logs]
 inherits = "release"
-debug-assertions = true 
+debug-assertions = true
 [workspace]

--- a/examples/guild_treasury_wars/Cargo.toml
+++ b/examples/guild_treasury_wars/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/memory_match/Cargo.toml
+++ b/examples/memory_match/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/minesweeper/Cargo.toml
+++ b/examples/minesweeper/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/murdoku/Cargo.toml
+++ b/examples/murdoku/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 zk = ["cougr-core/hazmat-crypto", "soroban-sdk/hazmat-crypto"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "=25.3.0"
 
 [dev-dependencies]

--- a/examples/pac_man/Cargo.toml
+++ b/examples/pac_man/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/pokemon_mini/Cargo.toml
+++ b/examples/pokemon_mini/Cargo.toml
@@ -10,7 +10,7 @@ description = "Pokémon Mini on-chain game example using cougr-core ECS framewor
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/pong/Cargo.toml
+++ b/examples/pong/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
@@ -28,5 +28,5 @@ lto = true
 
 [profile.release-with-logs]
 inherits = "release"
-debug-assertions = true 
+debug-assertions = true
 [workspace]

--- a/examples/proof_of_hunt/Cargo.toml
+++ b/examples/proof_of_hunt/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/reversi/Cargo.toml
+++ b/examples/reversi/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/rock_paper_scissors/Cargo.toml
+++ b/examples/rock_paper_scissors/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/shadow_draft_card_game/Cargo.toml
+++ b/examples/shadow_draft_card_game/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/snake/Cargo.toml
+++ b/examples/snake/Cargo.toml
@@ -10,7 +10,7 @@ description = "Snake on-chain game example using cougr-core ECS framework"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/space_invaders/Cargo.lock
+++ b/examples/space_invaders/Cargo.lock
@@ -277,7 +277,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cougr-core"
-version = "1.0.0"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc489e355664841b5fb4d0b19e014c3be1a9b81cd1cd9f7ad29f02fe54a4135"
 dependencies = [
  "soroban-sdk",
  "wee_alloc",

--- a/examples/space_invaders/Cargo.toml
+++ b/examples/space_invaders/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/sudoku/Cargo.toml
+++ b/examples/sudoku/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/tap_battle/Cargo.toml
+++ b/examples/tap_battle/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/tetris/Cargo.lock
+++ b/examples/tetris/Cargo.lock
@@ -277,9 +277,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cougr-core"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5f72b6d594ecb5ea5d42340cced45bbf8e13bf1506e48209eab64a4d7a931d"
+checksum = "afc489e355664841b5fb4d0b19e014c3be1a9b81cd1cd9f7ad29f02fe54a4135"
 dependencies = [
  "soroban-sdk",
  "wee_alloc",

--- a/examples/tetris/Cargo.toml
+++ b/examples/tetris/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/tetris/README.md
+++ b/examples/tetris/README.md
@@ -165,7 +165,7 @@ examples/tetris/
 ```toml
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 ```
 
 ## 📚 Resources

--- a/examples/tic_tac_toe/Cargo.toml
+++ b/examples/tic_tac_toe/Cargo.toml
@@ -11,11 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-<<<<<<< HEAD
-cougr-core = { path = "../../" }
-=======
 cougr-core = "1.1.0"
->>>>>>> e1e5837 (feat(examples): bump cougr-core to 1.1.0 across all examples)
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/tic_tac_toe/Cargo.toml
+++ b/examples/tic_tac_toe/Cargo.toml
@@ -11,7 +11,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
+<<<<<<< HEAD
 cougr-core = { path = "../../" }
+=======
+cougr-core = "1.1.0"
+>>>>>>> e1e5837 (feat(examples): bump cougr-core to 1.1.0 across all examples)
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/tic_tac_toe/src/lib.rs
+++ b/examples/tic_tac_toe/src/lib.rs
@@ -101,7 +101,15 @@ impl TicTacToeContract {
 
         world.set_rich(&env, GAME_ENTITY, &Board::new(&env));
         world.set_rich(&env, GAME_ENTITY, &Players { player_x, player_o });
-        world.set_typed(&env, GAME_ENTITY, &TurnState { is_x_turn: true, move_count: 0, status: 0 });
+        world.set_typed(
+            &env,
+            GAME_ENTITY,
+            &TurnState {
+                is_x_turn: true,
+                move_count: 0,
+                status: 0,
+            },
+        );
 
         TicTacToeContract::save_world(&env, &world);
         Self::read_game_state(&env, &world)
@@ -111,11 +119,14 @@ impl TicTacToeContract {
     pub fn make_move(env: Env, player: Address, position: u32) -> MoveResult {
         let mut world = TicTacToeContract::load_world(&env);
 
-        let players: Players = world.get_rich::<Players>(&env, GAME_ENTITY)
+        let players: Players = world
+            .get_rich::<Players>(&env, GAME_ENTITY)
             .unwrap_or_else(|| panic!("game not initialised"));
-        let turn: TurnState = world.get_typed::<TurnState>(&env, GAME_ENTITY)
+        let turn: TurnState = world
+            .get_typed::<TurnState>(&env, GAME_ENTITY)
             .unwrap_or_else(|| panic!("game not initialised"));
-        let mut board: Board = world.get_rich::<Board>(&env, GAME_ENTITY)
+        let mut board: Board = world
+            .get_rich::<Board>(&env, GAME_ENTITY)
             .unwrap_or_else(|| panic!("game not initialised"));
 
         // Validate
@@ -146,14 +157,22 @@ impl TicTacToeContract {
 
         let new_move_count = turn.move_count + 1;
         let new_status = Self::detect_winner(&board.cells, new_move_count);
-        let new_is_x_turn = if new_status == 0 { !turn.is_x_turn } else { turn.is_x_turn };
+        let new_is_x_turn = if new_status == 0 {
+            !turn.is_x_turn
+        } else {
+            turn.is_x_turn
+        };
 
         world.set_rich(&env, GAME_ENTITY, &board);
-        world.set_typed(&env, GAME_ENTITY, &TurnState {
-            is_x_turn: new_is_x_turn,
-            move_count: new_move_count,
-            status: new_status,
-        });
+        world.set_typed(
+            &env,
+            GAME_ENTITY,
+            &TurnState {
+                is_x_turn: new_is_x_turn,
+                move_count: new_move_count,
+                status: new_status,
+            },
+        );
 
         TicTacToeContract::save_world(&env, &world);
 
@@ -205,7 +224,8 @@ impl TicTacToeContract {
     /// Reset the board but keep the same players.
     pub fn reset_game(env: Env) -> GameState {
         let world = TicTacToeContract::load_world(&env);
-        let players: Players = world.get_rich::<Players>(&env, GAME_ENTITY)
+        let players: Players = world
+            .get_rich::<Players>(&env, GAME_ENTITY)
             .unwrap_or_else(|| panic!("game not initialised"));
         Self::init_game(env, players.player_x, players.player_o)
     }
@@ -213,12 +233,19 @@ impl TicTacToeContract {
     // ─── Internal helpers ─────────────────────────────────────────────────────
 
     fn read_game_state(env: &Env, world: &cougr_core::simple_world::SimpleWorld) -> GameState {
-        let board: Board = world.get_rich::<Board>(env, GAME_ENTITY)
+        let board: Board = world
+            .get_rich::<Board>(env, GAME_ENTITY)
             .unwrap_or_else(|| Board::new(env));
-        let players: Players = world.get_rich::<Players>(env, GAME_ENTITY)
+        let players: Players = world
+            .get_rich::<Players>(env, GAME_ENTITY)
             .unwrap_or_else(|| panic!("players not found"));
-        let turn: TurnState = world.get_typed::<TurnState>(env, GAME_ENTITY)
-            .unwrap_or(TurnState { is_x_turn: true, move_count: 0, status: 0 });
+        let turn: TurnState = world
+            .get_typed::<TurnState>(env, GAME_ENTITY)
+            .unwrap_or(TurnState {
+                is_x_turn: true,
+                move_count: 0,
+                status: 0,
+            });
 
         GameState {
             cells: board.cells,
@@ -230,7 +257,11 @@ impl TicTacToeContract {
         }
     }
 
-    fn failure(env: &Env, world: &cougr_core::simple_world::SimpleWorld, msg: Symbol) -> MoveResult {
+    fn failure(
+        env: &Env,
+        world: &cougr_core::simple_world::SimpleWorld,
+        msg: Symbol,
+    ) -> MoveResult {
         MoveResult {
             success: false,
             game_state: Self::read_game_state(env, world),
@@ -240,9 +271,14 @@ impl TicTacToeContract {
 
     fn detect_winner(cells: &Vec<u32>, move_count: u32) -> u32 {
         const LINES: [[u32; 3]; 8] = [
-            [0, 1, 2], [3, 4, 5], [6, 7, 8], // rows
-            [0, 3, 6], [1, 4, 7], [2, 5, 8], // columns
-            [0, 4, 8], [2, 4, 6],             // diagonals
+            [0, 1, 2],
+            [3, 4, 5],
+            [6, 7, 8], // rows
+            [0, 3, 6],
+            [1, 4, 7],
+            [2, 5, 8], // columns
+            [0, 4, 8],
+            [2, 4, 6], // diagonals
         ];
         for line in LINES.iter() {
             let a = cells.get(line[0]).unwrap_or(0);
@@ -252,7 +288,11 @@ impl TicTacToeContract {
                 return a; // 1 = X wins, 2 = O wins
             }
         }
-        if move_count >= 9 { 3 } else { 0 }
+        if move_count >= 9 {
+            3
+        } else {
+            0
+        }
     }
 }
 

--- a/examples/tic_tac_toe/src/lib.rs
+++ b/examples/tic_tac_toe/src/lib.rs
@@ -8,7 +8,6 @@
 
 #![no_std]
 
-use cougr_core::component::ComponentTrait;
 use cougr_core::game::SorobanGame;
 use cougr_core::{impl_component, impl_rich_component, impl_soroban_game};
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec};

--- a/examples/tower_defense/Cargo.toml
+++ b/examples/tower_defense/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tower defense on-chain game example using cougr-core ECS framewor
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]

--- a/examples/trading_card_game/Cargo.toml
+++ b/examples/trading_card_game/Cargo.toml
@@ -9,12 +9,8 @@ description = "Tower defense on-chain game example using cougr-core ECS framewor
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cougr-core = "1.0.0"
-soroban-sdk = "25.1.0"
-<<<<<<< HEAD
-=======
 cougr-core = "1.1.0"
->>>>>>> e1e5837 (feat(examples): bump cougr-core to 1.1.0 across all examples)
+soroban-sdk = "25.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }

--- a/examples/trading_card_game/Cargo.toml
+++ b/examples/trading_card_game/Cargo.toml
@@ -11,6 +11,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 cougr-core = "1.0.0"
 soroban-sdk = "25.1.0"
+<<<<<<< HEAD
+=======
+cougr-core = "1.1.0"
+>>>>>>> e1e5837 (feat(examples): bump cougr-core to 1.1.0 across all examples)
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
@@ -24,5 +28,5 @@ panic = "abort"
 
 [profile.release-with-logs]
 inherits = "release"
-debug-assertions = true 
+debug-assertions = true
 [workspace]

--- a/examples/treasure_hunt/Cargo.toml
+++ b/examples/treasure_hunt/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "25.1.0"
-cougr-core = "1.0.0"
+cougr-core = "1.1.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }


### PR DESCRIPTION
## Summary

- Bumps `cougr-core` from `1.0.0` → `1.1.0` in all 32 affected examples
- Migrates path dependencies (`path = "../../"`) to published version `"1.1.0"`
- Bumps `soroban-sdk` to `25.1.0` where not already updated
- Regenerates `Cargo.lock` for asteroids, bomberman, space_invaders, tetris
- Fixes documented version snippet in `examples/tetris/README.md`

## Definition of done

- `rg 'cougr-core = "1.0.0"' examples/` returns no matches
- All affected example CI workflows pass on main
- No changes to public contract function signatures

Closes #219