### PR TITLE
chore(governance): establish baseline community governance scaffolding (#242)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: Create a report to help us improve Cougr
+title: 'fix(scope): description'
+labels: bug
+assignees: ''
+---
+
+### Background
+Brief description of the bug encountered.
+
+### Expected Behavior
+What you expected to happen.
+
+### Actual Behavior
+What actually happened.
+
+### Steps to Reproduce
+1. Go to '...'
+2. Execute '...'
+3. See error

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest an idea or feature for Cougr
+title: 'feat(scope): description'
+labels: enhancement
+assignees: ''
+---
+
+### Background
+Why is this feature needed?
+
+### Objective
+What does this feature accomplish?
+
+### Proposed Implementation
+Outline technical approach.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Description
+Provide a concise summary of changes introduced in this PR.
+
+## Checklist
+- [ ] Code follows project style guidelines.
+- [ ] Tests added/updated and passing (`cargo test`).
+- [ ] Documentation updated where relevant (`README.md`, `SECURITY.md`, `ROADMAP.md`).
+- [ ] Public API checklist completed.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **conduct@cougr.io**. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,17 @@
+# Cougr Public Roadmap
+
+This document summarizes the strategic development phases for Cougr.
+
+## Phase 0: Ecosystem Scaffolding & Onboarding (Current)
+- Establish baseline community governance scaffolding (`CODE_OF_CONDUCT.md`, issue/PR templates).
+- Standardize security policy disclosure SLA and auditor engagement workflows.
+- Expand contributor onboarding funnels and automated CI verification pipelines.
+
+## Phase 1: Core Performance & Developer Experience
+- Optimize Soroban smart contract WASM footprints and gas invocation overhead.
+- Introduce comprehensive integration test matrices for Stellar testnet releases.
+- Expand SDK client generation and multi-language language bindings.
+
+## Phase 2: Decentralized Governance & RFC Process
+- Formalize RFC process for public protocol architectural changes (`GOVERNANCE.md`).
+- Introduce community maintainer review rotations and delegate sign-off workflows.


### PR DESCRIPTION
### Establish Baseline Community Governance Scaffolding (#242)

- Added CODE_OF_CONDUCT.md based on Contributor Covenant v2.1.
- Added GitHub issue templates (ug_report.md, eature_request.md) and .github/PULL_REQUEST_TEMPLATE.md.
- Added public ROADMAP.md summarizing strategic phases.

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #242