### PR TITLE
docs(adr): add ADR sandbox and ADR session UX

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,7 @@ CougrAccount (trait)
 
 Key traits: `CougrAccount`, `SessionKeyProvider`, `RecoveryProvider`, `MultiDeviceProvider`.
 
-`SessionBuilder` provides a fluent API for constructing scoped session keys. `authorize_with_fallback` handles graceful degradation from session keys to direct authorization.
+`SessionBuilder` provides a fluent API for constructing scoped session keys. `authorize_with_fallback` handles graceful degradation from session keys to direct authorization. See [ADR 0005](docs/adr/0005-session-ux.md).
 
 ## Standards (`src/standards/`)
 
@@ -126,7 +126,7 @@ Circuit builders: `hidden_cards`, `fog_of_war`, `fair_dice`, `sealed_bid` →
 
 The test sandbox uses `no_std` + `alloc` with Soroban `testutils` — not `std`.
 Enable with `cougr-core` feature `testutils`. Modules: `GameHarness`, `Scenario`,
-`WorldFixture`, `ReplayLog`, `SnapshotAssert`. See [ADR 0007](docs/adr/0007-workspace-subcrates.md).
+`WorldFixture`, `ReplayLog`, `SnapshotAssert`. See [ADR 0004](docs/adr/0004-sandbox-design.md) and [ADR 0007](docs/adr/0007-workspace-subcrates.md).
 
 ## Feature Flags
 

--- a/docs/adr/0004-sandbox-design.md
+++ b/docs/adr/0004-sandbox-design.md
@@ -1,0 +1,19 @@
+# ADR 0004: Sandbox Design
+
+## Status
+
+Accepted
+
+## Context
+
+We need a secure testing and simulation environment for contracts to allow developers to validate logic (like ECS events and ZK proofs) locally without full node deployments. The sandbox should emulate the target environment accurately.
+
+## Decision
+
+We introduce a test sandbox utilizing `no_std` and `alloc` alongside the Soroban `testutils` feature. This sandbox provides core modules for testing games (such as `GameHarness`, `Scenario`, `WorldFixture`, `ReplayLog`, and `SnapshotAssert`).
+
+## Consequences
+
+- Developers can write fast local tests with a familiar testing API.
+- We must maintain parity between sandbox behavior and on-chain execution.
+- Relies on the `testutils` feature flag being managed correctly in the crate.

--- a/docs/adr/0005-session-ux.md
+++ b/docs/adr/0005-session-ux.md
@@ -1,0 +1,19 @@
+# ADR 0005: Session UX
+
+## Status
+
+Accepted
+
+## Context
+
+Repeatedly signing transactions degrades the user experience for on-chain games, especially those requiring frequent interactions (like real-time or turn-based strategy). Players expect a seamless experience akin to Web2 gaming without constantly engaging with a wallet prompt.
+
+## Decision
+
+We introduce session keys with a fluent `SessionBuilder` API to authorize specific game actions over a time-bound window without requiring repeated user prompts. `authorize_with_fallback` will be used for graceful degradation, allowing operations to fall back to direct authorization when a session is expired or unavailable.
+
+## Consequences
+
+- Massively improved gameplay experience for end users.
+- Integration becomes slightly more complex to handle session lifecycles.
+- Wallets and client integrations must support and manage session key delegation.

--- a/docs/adr/0008-standards-stable.md
+++ b/docs/adr/0008-standards-stable.md
@@ -1,4 +1,4 @@
-# ADR 0004: Include Standards In The Stable 1.0 Contract
+# ADR 0008: Include Standards In The Stable 1.0 Contract
 
 ## Status
 


### PR DESCRIPTION
 I have successfully fulfilled the requirements for this issue. Here is a summary of the actions taken:

  1. Branch Created: I created and switched to the new branch ADR-sandbox.
  2. Missing ADRs Added:
      • Created 0004-sandbox-design.md which discusses the design decisions around the testutils and no_std/alloc
      test sandbox setup.
      • Created 0005-session-ux.md which covers the SessionBuilder UX and authorization fallback patterns.
  3. Numbering Conflict Resolved: The existing file 0004-standards-stable.md had occupied the ADR 0004 spot. To
  address this collision and maintain sequence integrity, I safely renamed it to 0008-standards-stable.md and updated
  its markdown heading to match ADR 0008.
  4. Acceptance Linked: I updated ARCHITECTURE.md to cross-link the new ADRs:
      • Linked ADR 0004 in the workspace subcrates section referring to the Sandbox test environment.
      • Linked ADR 0005 in the Accounts section referring to the session management design.
  5. Committed: All changes have been committed with the message docs(adr): add ADR sandbox and ADR session UX.
closes #215 