### PR TITLE
feat(examples): implement state-driven SVG previews for headless cont…

### DIFF
--- a/examples/EXAMPLE_STANDARD.md
+++ b/examples/EXAMPLE_STANDARD.md
@@ -238,6 +238,39 @@ The following table maps each canonical example to its primary Cougr APIs:
 
 ---
 
+---
+
+## 9. Preview Image
+
+Every canonical example must have a `preview.svg` checked into its directory. This image is displayed in the examples gallery and must represent the actual game state, not a placeholder or hand-drawn mockup.
+
+### Board / grid games
+
+Generate `preview.svg` using the tooling in `tools/preview-gen/`:
+
+```bash
+cd tools/preview-gen
+node generate.js <example-name>
+```
+
+The generator reads a state JSON from `tools/preview-gen/states/<example-name>.json`. That state must be derived from a specific, named test assertion in the example's `src/test.rs` — not invented. See [tools/preview-gen/README.md](../tools/preview-gen/README.md) for the full contributor workflow.
+
+### Real-time / physics arcade games
+
+Games where no single frame conveys how the game works (Snake, Asteroids, Pong, Flappy Bird, Geometry Dash, etc.) may use the category fallback renderer:
+
+```bash
+node generate.js snake   # snake is registered in FALLBACK_GAMES
+```
+
+This produces a branded category-icon card rather than a fake gameplay screenshot. Using the fallback is acceptable and honest; faking a state screenshot for a real-time game is not.
+
+### Checklist item
+
+See the [Quality Checklist](#quality-checklist) below for the corresponding checklist entry.
+
+---
+
 ## Quality Checklist
 
 Copy this checklist into a follow-up cleanup issue for each example:
@@ -282,6 +315,12 @@ Copy this checklist into a follow-up cleanup issue for each example:
 - [ ] No committed `.wasm` artifacts
 - [ ] `Cargo.lock` committed
 - [ ] `Cargo.toml` has no unused dependencies or wildcard versions
+
+### Preview image
+- [ ] `preview.svg` present in the example directory
+- [ ] State data is traceable to a named test assertion in `src/test.rs` (see `_source` field in the corresponding `states/*.json`)
+- [ ] Generated via `tools/preview-gen/` — not hand-drawn or manually edited
+- [ ] For real-time/arcade games: category fallback used rather than a faked screenshot
 
 ### Classification
 - [ ] Marked as canonical or transitional in the README

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,54 +46,54 @@ After reading the canonical examples, explore transitional examples for addition
 
 These are the maintained reference architectures. They are held to the full standard in [EXAMPLE_STANDARD.md](./EXAMPLE_STANDARD.md) and stay current as `cougr-core` evolves.
 
-| Example | Category | Focus |
-|---|---|---|
-| `spawn_and_move` | **Starter / canonical** | Complete idiomatic Cougr pattern: `SorobanGame` + `impl_component_observed!` + typed ECS |
-| `tic_tac_toe` | **Rich components / canonical** | Turn-based game with `impl_rich_component!` for `Address` and `Vec` fields |
-| `session_arena` | **Session UX / canonical** | `session::SessionManager` lifecycle and multi-round state (Beta) |
-| `hidden_hand` | **ZK circuits / canonical** | `circuits::HiddenHandBuilder` — hidden-card ZK proof flow (Experimental) |
-| `fog_explorer` | **ZK circuits / canonical** | `circuits::FogExplorerBuilder` — fog-of-war exploration with Merkle proofs (Experimental) |
-| `dice_duel` | **ZK circuits / canonical** | `circuits::FairDiceBuilder` — fair dice roll with on-chain verification (Experimental) |
-| `blind_auction` | **ZK circuits / canonical** | `circuits::SealedBidBuilder` — sealed-bid auction with commit-reveal ZK (Experimental) |
-| `snake` | **Arcade (GameApp) / canonical** | Arcade loop, `GameApp` tick model, basic ECS |
-| `battleship` | **Hidden information / canonical** | Commit-reveal and selective state disclosure using `privacy::stable` |
-| `guild_arena` | **Authentication & recovery / canonical** | Account abstraction, social recovery, multi-device authorization |
+| Example | Category | Focus | Preview |
+|---|---|---|---|
+| `spawn_and_move` | **Starter / canonical** | Complete idiomatic Cougr pattern: `SorobanGame` + `impl_component_observed!` + typed ECS | — |
+| `tic_tac_toe` | **Rich components / canonical** | Turn-based game with `impl_rich_component!` for `Address` and `Vec` fields | [preview.svg](./tic_tac_toe/preview.svg) |
+| `session_arena` | **Session UX / canonical** | `session::SessionManager` lifecycle and multi-round state (Beta) | — |
+| `hidden_hand` | **ZK circuits / canonical** | `circuits::HiddenHandBuilder` — hidden-card ZK proof flow (Experimental) | — |
+| `fog_explorer` | **ZK circuits / canonical** | `circuits::FogExplorerBuilder` — fog-of-war exploration with Merkle proofs (Experimental) | — |
+| `dice_duel` | **ZK circuits / canonical** | `circuits::FairDiceBuilder` — fair dice roll with on-chain verification (Experimental) | — |
+| `blind_auction` | **ZK circuits / canonical** | `circuits::SealedBidBuilder` — sealed-bid auction with commit-reveal ZK (Experimental) | — |
+| `snake` | **Arcade (GameApp) / canonical** | Arcade loop, `GameApp` tick model, basic ECS | — |
+| `battleship` | **Hidden information / canonical** | Commit-reveal and selective state disclosure using `privacy::stable` | [preview.svg](./battleship/preview.svg) |
+| `guild_arena` | **Authentication & recovery / canonical** | Account abstraction, social recovery, multi-device authorization | — |
 
 ### Transitional examples
 
 These examples were written before the current standard or intentionally preserve an older pattern for compatibility reference. They still pass `cargo test` and `stellar contract build` but may not follow the latest module structure or README depth.
 
-| Example | Category | Focus |
-|---|---|---|
-| `ai_dungeon_master_arena` | ZK / x402 | Proof-backed encounters and x402 premium actions |
-| `angry_birds` | Physics-inspired arcade | Projectile logic and destructible-state gameplay |
-| `arkanoid` | Arcade | Paddle, collision, and brick lifecycle management |
-| `asteroids` | Arcade | Entity-heavy movement, collisions, and spawning |
-| `bomberman` | Grid action | Tile updates, hazards, and timed interactions |
-| `checkers` | Board | Jump/capture rules and multi-step turn validation |
-| `chess` | Board / strategy | Rule validation and proof-oriented move flow |
-| `connect_four` | Board | Gravity-drop column logic and vertical/horizontal/diagonal win detection |
-| `cross_asset_racing_league` | Multi-asset racing | Payment-gated boost mechanics with cross-asset payment flows |
-| `flappy_bird` | Arcade | Tight tick-loop updates and obstacle generation |
-| `geometry_dash` | Reflex | Deterministic timing and obstacle progression |
-| `guild_treasury_wars` | DAO / ZK | DAO-governed factions with stellar-zk commitments |
-| `memory_match` | Card matching | Pair-reveal mechanics and memory-state tracking |
-| `minesweeper` | Puzzle | Grid reveal, mine detection, and adjacency logic |
-| `murdoku` | Puzzle | Ephemeral ECS validation and creator registry |
-| `pac_man` | Maze action | Grid navigation and adversarial movement patterns |
-| `pokemon_mini` | Turn-based battle | Combat sequencing and match state transitions |
-| `pong` | Arcade | Minimal competitive loop and ECS fundamentals |
-| `proof_of_hunt` | Hidden-state exploration | stellar-zk proof verification and x402 premium actions |
-| `reversi` | Board | Piece-flipping logic and territory control |
-| `rock_paper_scissors` | Commit-reveal | Hidden choices and reveal resolution |
-| `shadow_draft_card_game` | Card / hidden-hand | Hidden-hand draft with SHA-256 commit-reveal |
-| `space_invaders` | Wave shooter | Formation movement and repeated tick systems |
-| `sudoku` | Puzzle | Grid constraints and cell-entry validation |
-| `tap_battle` | Casual competitive | Lightweight action resolution and progression |
-| `tetris` | Puzzle | Piece state, rotation, and board clearing |
-| `tower_defense` | Strategy | Wave spawning, tower attacks, and health reduction |
-| `trading_card_game` | Card / strategy | Structured turns, card effects, and state composition |
-| `treasure_hunt` | Hidden-state exploration | Off-chain Merkle map commitments with on-chain proof-gated discovery |
+| Example | Category | Focus | Preview |
+|---|---|---|---|
+| `ai_dungeon_master_arena` | ZK / x402 | Proof-backed encounters and x402 premium actions | — |
+| `angry_birds` | Physics-inspired arcade | Projectile logic and destructible-state gameplay | — |
+| `arkanoid` | Arcade | Paddle, collision, and brick lifecycle management | — |
+| `asteroids` | Arcade | Entity-heavy movement, collisions, and spawning | — |
+| `bomberman` | Grid action | Tile updates, hazards, and timed interactions | — |
+| `checkers` | Board | Jump/capture rules and multi-step turn validation | [preview.svg](./checkers/preview.svg) |
+| `chess` | Board / strategy | Rule validation and proof-oriented move flow | — |
+| `connect_four` | Board | Gravity-drop column logic and vertical/horizontal/diagonal win detection | — |
+| `cross_asset_racing_league` | Multi-asset racing | Payment-gated boost mechanics with cross-asset payment flows | — |
+| `flappy_bird` | Arcade | Tight tick-loop updates and obstacle generation | — |
+| `geometry_dash` | Reflex | Deterministic timing and obstacle progression | — |
+| `guild_treasury_wars` | DAO / ZK | DAO-governed factions with stellar-zk commitments | — |
+| `memory_match` | Card matching | Pair-reveal mechanics and memory-state tracking | — |
+| `minesweeper` | Puzzle | Grid reveal, mine detection, and adjacency logic | — |
+| `murdoku` | Puzzle | Ephemeral ECS validation and creator registry | — |
+| `pac_man` | Maze action | Grid navigation and adversarial movement patterns | — |
+| `pokemon_mini` | Turn-based battle | Combat sequencing and match state transitions | — |
+| `pong` | Arcade | Minimal competitive loop and ECS fundamentals | — |
+| `proof_of_hunt` | Hidden-state exploration | stellar-zk proof verification and x402 premium actions | — |
+| `reversi` | Board | Piece-flipping logic and territory control | — |
+| `rock_paper_scissors` | Commit-reveal | Hidden choices and reveal resolution | — |
+| `shadow_draft_card_game` | Card / hidden-hand | Hidden-hand draft with SHA-256 commit-reveal | — |
+| `space_invaders` | Wave shooter | Formation movement and repeated tick systems | — |
+| `sudoku` | Puzzle | Grid constraints and cell-entry validation | — |
+| `tap_battle` | Casual competitive | Lightweight action resolution and progression | — |
+| `tetris` | Puzzle | Piece state, rotation, and board clearing | — |
+| `tower_defense` | Strategy | Wave spawning, tower attacks, and health reduction | — |
+| `trading_card_game` | Card / strategy | Structured turns, card effects, and state composition | — |
+| `treasure_hunt` | Hidden-state exploration | Off-chain Merkle map commitments with on-chain proof-gated discovery | — |
 
 ## Choosing A Reference
 

--- a/examples/battleship/preview.svg
+++ b/examples/battleship/preview.svg
@@ -1,0 +1,278 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 440 820" width="440" height="820">
+  <defs>
+    <style>text { font-family: 'Inter', 'Segoe UI', system-ui, sans-serif; }</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="440" height="820" fill="#0f172a" rx="12"/>
+
+  <!-- ═══ GRID A: Player A's attacks on B's fleet ═══ -->
+
+  <!-- Header -->
+  <text x="232" y="30" text-anchor="middle" font-size="13" font-weight="600" fill="#f43f5e">Player A attacks →</text>
+
+  <!-- Column labels A-J -->
+  <text x="79"  y="47" text-anchor="middle" font-size="10" fill="#64748b">A</text>
+  <text x="115" y="47" text-anchor="middle" font-size="10" fill="#64748b">B</text>
+  <text x="151" y="47" text-anchor="middle" font-size="10" fill="#64748b">C</text>
+  <text x="187" y="47" text-anchor="middle" font-size="10" fill="#64748b">D</text>
+  <text x="223" y="47" text-anchor="middle" font-size="10" fill="#64748b">E</text>
+  <text x="259" y="47" text-anchor="middle" font-size="10" fill="#64748b">F</text>
+  <text x="295" y="47" text-anchor="middle" font-size="10" fill="#64748b">G</text>
+  <text x="331" y="47" text-anchor="middle" font-size="10" fill="#64748b">H</text>
+  <text x="367" y="47" text-anchor="middle" font-size="10" fill="#64748b">I</text>
+  <text x="403" y="47" text-anchor="middle" font-size="10" fill="#64748b">J</text>
+
+  <!-- Row labels 1-10 -->
+  <text x="66"  y="71"  text-anchor="end" font-size="10" fill="#64748b">1</text>
+  <text x="66"  y="107" text-anchor="end" font-size="10" fill="#64748b">2</text>
+  <text x="66"  y="143" text-anchor="end" font-size="10" fill="#64748b">3</text>
+  <text x="66"  y="179" text-anchor="end" font-size="10" fill="#64748b">4</text>
+  <text x="66"  y="215" text-anchor="end" font-size="10" fill="#64748b">5</text>
+  <text x="66"  y="251" text-anchor="end" font-size="10" fill="#64748b">6</text>
+  <text x="66"  y="287" text-anchor="end" font-size="10" fill="#64748b">7</text>
+  <text x="66"  y="323" text-anchor="end" font-size="10" fill="#64748b">8</text>
+  <text x="66"  y="359" text-anchor="end" font-size="10" fill="#64748b">9</text>
+  <text x="66"  y="395" text-anchor="end" font-size="10" fill="#64748b">10</text>
+
+  <!-- Grid A cells — 10x10, each 36x36, starting at x=70, y=53 -->
+  <!-- Unknown (sea) cells = #0c4a6e; Miss = #334155; Hit = #ef4444 -->
+
+  <!-- Row 0: idx 0=Miss, rest=Unknown -->
+  <rect x="70"  y="53" width="35" height="35" fill="#334155" rx="2"/>
+  <!-- Miss dot at (0,0) -->
+  <circle cx="87" cy="70" r="4" fill="#94a3b8" opacity="0.7"/>
+
+  <rect x="106" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="142" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="178" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="214" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="53" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Row 1: idx 10=Hit, 11=Hit, rest=Unknown -->
+  <rect x="70"  y="89" width="35" height="35" fill="#ef4444" rx="2"/>
+  <line x1="78" y1="97" x2="97" y2="116" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="97" y1="97" x2="78" y2="116" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+
+  <rect x="106" y="89" width="35" height="35" fill="#ef4444" rx="2"/>
+  <line x1="114" y1="97" x2="133" y2="116" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="133" y1="97" x2="114" y2="116" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+
+  <rect x="142" y="89" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="178" y="89" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="214" y="89" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="89" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="89" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="89" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="89" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="89" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Row 2: idx 20=Miss, 22=Miss -->
+  <rect x="70"  y="125" width="35" height="35" fill="#334155" rx="2"/>
+  <circle cx="87" cy="142" r="4" fill="#94a3b8" opacity="0.7"/>
+  <rect x="106" y="125" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="142" y="125" width="35" height="35" fill="#334155" rx="2"/>
+  <circle cx="159" cy="142" r="4" fill="#94a3b8" opacity="0.7"/>
+  <rect x="178" y="125" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="214" y="125" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="125" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="125" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="125" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="125" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="125" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Row 3: idx 33=Hit -->
+  <rect x="70"  y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="106" y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="142" y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="178" y="161" width="35" height="35" fill="#ef4444" rx="2"/>
+  <line x1="186" y1="169" x2="205" y2="188" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="205" y1="169" x2="186" y2="188" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <rect x="214" y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="161" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Row 4: idx 43=Miss -->
+  <rect x="70"  y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="106" y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="142" y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="178" y="197" width="35" height="35" fill="#334155" rx="2"/>
+  <circle cx="195" cy="214" r="4" fill="#94a3b8" opacity="0.7"/>
+  <rect x="214" y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="197" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Row 5: idx 53=Miss -->
+  <rect x="70"  y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="106" y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="142" y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="178" y="233" width="35" height="35" fill="#334155" rx="2"/>
+  <circle cx="195" cy="250" r="4" fill="#94a3b8" opacity="0.7"/>
+  <rect x="214" y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="233" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Rows 6-9: all unknown -->
+  <rect x="70"  y="269" width="360" height="35" fill="#0c4a6e" rx="0"/>
+  <rect x="70"  y="305" width="360" height="35" fill="#0c4a6e" rx="0"/>
+  <rect x="70"  y="341" width="360" height="35" fill="#0c4a6e" rx="0"/>
+  <rect x="70"  y="377" width="360" height="35" fill="#0c4a6e" rx="0"/>
+
+  <!-- Grid A gridlines -->
+  <rect x="70" y="53" width="360" height="360" fill="none" stroke="#475569" stroke-width="1.5" rx="2"/>
+  <line x1="106" y1="53" x2="106" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="142" y1="53" x2="142" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="178" y1="53" x2="178" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="214" y1="53" x2="214" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="250" y1="53" x2="250" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="286" y1="53" x2="286" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="322" y1="53" x2="322" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="358" y1="53" x2="358" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="394" y1="53" x2="394" y2="413" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="89"  x2="430" y2="89"  stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="125" x2="430" y2="125" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="161" x2="430" y2="161" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="197" x2="430" y2="197" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="233" x2="430" y2="233" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="269" x2="430" y2="269" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="305" x2="430" y2="305" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="341" x2="430" y2="341" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="377" x2="430" y2="377" stroke="#1e3a5f" stroke-width="0.75"/>
+
+  <!-- Grid A stats sidebar -->
+  <text x="436" y="68"  font-size="10" fill="#f43f5e">Hits: 3</text>
+  <text x="436" y="83"  font-size="10" fill="#94a3b8">Miss: 5</text>
+  <text x="436" y="102" font-size="10" fill="#64748b">Ships: 14/17</text>
+
+  <!-- ═══ GRID B: Player B's attacks on A's fleet ═══ -->
+  <!-- starts at y=437 (53 + 360 + 24 gap) -->
+
+  <text x="232" y="432" text-anchor="middle" font-size="13" font-weight="600" fill="#38bdf8">Player B attacks →</text>
+
+  <!-- Row labels 1-10 -->
+  <text x="66"  y="460" text-anchor="end" font-size="10" fill="#64748b">1</text>
+  <text x="66"  y="496" text-anchor="end" font-size="10" fill="#64748b">2</text>
+  <text x="66"  y="532" text-anchor="end" font-size="10" fill="#64748b">3</text>
+  <text x="66"  y="568" text-anchor="end" font-size="10" fill="#64748b">4</text>
+  <text x="66"  y="604" text-anchor="end" font-size="10" fill="#64748b">5</text>
+  <text x="66"  y="640" text-anchor="end" font-size="10" fill="#64748b">6</text>
+  <text x="66"  y="676" text-anchor="end" font-size="10" fill="#64748b">7</text>
+  <text x="66"  y="712" text-anchor="end" font-size="10" fill="#64748b">8</text>
+  <text x="66"  y="748" text-anchor="end" font-size="10" fill="#64748b">9</text>
+  <text x="66"  y="784" text-anchor="end" font-size="10" fill="#64748b">10</text>
+
+  <!-- Grid B: Row 1 (y=442) — idx 11=Hit, 12=Miss -->
+  <rect x="70"  y="442" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="106" y="442" width="35" height="35" fill="#ef4444" rx="2"/>
+  <line x1="114" y1="450" x2="133" y2="469" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="133" y1="450" x2="114" y2="469" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <rect x="142" y="442" width="35" height="35" fill="#334155" rx="2"/>
+  <circle cx="159" cy="459" r="4" fill="#94a3b8" opacity="0.7"/>
+  <rect x="178" y="442" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="214" y="442" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="442" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="442" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="442" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="442" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="442" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Grid B: Row 2 (y=478) — idx 21=Miss -->
+  <rect x="70"  y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="106" y="478" width="35" height="35" fill="#334155" rx="2"/>
+  <circle cx="123" cy="495" r="4" fill="#94a3b8" opacity="0.7"/>
+  <rect x="142" y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="178" y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="214" y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="478" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Grid B: Row 3 (y=514) — idx 31=Hit, 32=Miss -->
+  <rect x="70"  y="514" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="106" y="514" width="35" height="35" fill="#ef4444" rx="2"/>
+  <line x1="114" y1="522" x2="133" y2="541" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="133" y1="522" x2="114" y2="541" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <rect x="142" y="514" width="35" height="35" fill="#334155" rx="2"/>
+  <circle cx="159" cy="531" r="4" fill="#94a3b8" opacity="0.7"/>
+  <rect x="178" y="514" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="214" y="514" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="514" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="514" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="514" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="514" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="514" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Grid B: Row 4 (y=550) — idx 41=Hit -->
+  <rect x="70"  y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="106" y="550" width="35" height="35" fill="#ef4444" rx="2"/>
+  <line x1="114" y1="558" x2="133" y2="577" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="133" y1="558" x2="114" y2="577" stroke="#fca5a5" stroke-width="2.5" stroke-linecap="round"/>
+  <rect x="142" y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="178" y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="214" y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="250" y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="286" y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="322" y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="358" y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+  <rect x="394" y="550" width="35" height="35" fill="#0c4a6e" rx="2"/>
+
+  <!-- Grid B: Rows 5-9 (all unknown) -->
+  <rect x="70" y="586" width="360" height="35" fill="#0c4a6e" rx="0"/>
+  <rect x="70" y="622" width="360" height="35" fill="#0c4a6e" rx="0"/>
+  <rect x="70" y="658" width="360" height="35" fill="#0c4a6e" rx="0"/>
+  <rect x="70" y="694" width="360" height="35" fill="#0c4a6e" rx="0"/>
+  <rect x="70" y="730" width="360" height="35" fill="#0c4a6e" rx="0"/>
+
+  <!-- Grid B gridlines -->
+  <rect x="70" y="442" width="360" height="360" fill="none" stroke="#475569" stroke-width="1.5" rx="2"/>
+  <line x1="106" y1="442" x2="106" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="142" y1="442" x2="142" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="178" y1="442" x2="178" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="214" y1="442" x2="214" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="250" y1="442" x2="250" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="286" y1="442" x2="286" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="322" y1="442" x2="322" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="358" y1="442" x2="358" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="394" y1="442" x2="394" y2="802" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="478" x2="430" y2="478" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="514" x2="430" y2="514" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="550" x2="430" y2="550" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="586" x2="430" y2="586" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="622" x2="430" y2="622" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="658" x2="430" y2="658" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="694" x2="430" y2="694" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="730" x2="430" y2="730" stroke="#1e3a5f" stroke-width="0.75"/>
+  <line x1="70" y1="766" x2="430" y2="766" stroke="#1e3a5f" stroke-width="0.75"/>
+
+  <!-- Grid B stats sidebar -->
+  <text x="436" y="457" font-size="10" fill="#38bdf8">Hits: 3</text>
+  <text x="436" y="472" font-size="10" fill="#94a3b8">Miss: 3</text>
+  <text x="436" y="491" font-size="10" fill="#64748b">Ships: 14/17</text>
+
+  <!-- Status bar -->
+  <rect x="0" y="805" width="440" height="60" fill="#1e293b"/>
+  <rect x="0" y="805" width="440" height="1.5" fill="#475569"/>
+
+  <!-- Status -->
+  <rect x="12" y="815" width="196" height="30" rx="15" fill="#38bdf822"/>
+  <text x="110" y="835" text-anchor="middle" font-size="13" font-weight="600" fill="#38bdf8">Player A's turn to attack</text>
+
+  <!-- Watermark -->
+  <text x="220" y="855" text-anchor="middle" font-size="9" fill="#64748b" letter-spacing="2">COUGR · BATTLESHIP · COMMIT-REVEAL</text>
+</svg>

--- a/examples/checkers/preview.svg
+++ b/examples/checkers/preview.svg
@@ -1,0 +1,138 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 480 560" width="480" height="560">
+  <defs>
+    <style>text { font-family: 'Inter', 'Segoe UI', system-ui, sans-serif; }</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="480" height="560" fill="#0f172a" rx="12"/>
+
+  <!-- Board squares — 8x8 grid, each cell 60x60 -->
+  <!-- Row 0 -->
+  <rect x="0"   y="0"   width="60" height="60" fill="#1e293b"/>
+  <rect x="60"  y="0"   width="60" height="60" fill="#334155"/>
+  <rect x="120" y="0"   width="60" height="60" fill="#1e293b"/>
+  <rect x="180" y="0"   width="60" height="60" fill="#334155"/>
+  <rect x="240" y="0"   width="60" height="60" fill="#1e293b"/>
+  <rect x="300" y="0"   width="60" height="60" fill="#334155"/>
+  <rect x="360" y="0"   width="60" height="60" fill="#1e293b"/>
+  <rect x="420" y="0"   width="60" height="60" fill="#334155"/>
+  <!-- Row 1 -->
+  <rect x="0"   y="60"  width="60" height="60" fill="#334155"/>
+  <rect x="60"  y="60"  width="60" height="60" fill="#1e293b"/>
+  <rect x="120" y="60"  width="60" height="60" fill="#334155"/>
+  <rect x="180" y="60"  width="60" height="60" fill="#1e293b"/>
+  <rect x="240" y="60"  width="60" height="60" fill="#334155"/>
+  <rect x="300" y="60"  width="60" height="60" fill="#1e293b"/>
+  <rect x="360" y="60"  width="60" height="60" fill="#334155"/>
+  <rect x="420" y="60"  width="60" height="60" fill="#1e293b"/>
+  <!-- Row 2 -->
+  <rect x="0"   y="120" width="60" height="60" fill="#1e293b"/>
+  <rect x="60"  y="120" width="60" height="60" fill="#334155"/>
+  <rect x="120" y="120" width="60" height="60" fill="#1e293b"/>
+  <rect x="180" y="120" width="60" height="60" fill="#334155"/>
+  <rect x="240" y="120" width="60" height="60" fill="#1e293b"/>
+  <rect x="300" y="120" width="60" height="60" fill="#334155"/>
+  <rect x="360" y="120" width="60" height="60" fill="#1e293b"/>
+  <rect x="420" y="120" width="60" height="60" fill="#334155"/>
+  <!-- Row 3 (empty middle) -->
+  <rect x="0"   y="180" width="60" height="60" fill="#334155"/>
+  <rect x="60"  y="180" width="60" height="60" fill="#1e293b"/>
+  <rect x="120" y="180" width="60" height="60" fill="#334155"/>
+  <rect x="180" y="180" width="60" height="60" fill="#1e293b"/>
+  <rect x="240" y="180" width="60" height="60" fill="#334155"/>
+  <rect x="300" y="180" width="60" height="60" fill="#1e293b"/>
+  <rect x="360" y="180" width="60" height="60" fill="#334155"/>
+  <rect x="420" y="180" width="60" height="60" fill="#1e293b"/>
+  <!-- Row 4 (empty middle) -->
+  <rect x="0"   y="240" width="60" height="60" fill="#1e293b"/>
+  <rect x="60"  y="240" width="60" height="60" fill="#334155"/>
+  <rect x="120" y="240" width="60" height="60" fill="#1e293b"/>
+  <rect x="180" y="240" width="60" height="60" fill="#334155"/>
+  <rect x="240" y="240" width="60" height="60" fill="#1e293b"/>
+  <rect x="300" y="240" width="60" height="60" fill="#334155"/>
+  <rect x="360" y="240" width="60" height="60" fill="#1e293b"/>
+  <rect x="420" y="240" width="60" height="60" fill="#334155"/>
+  <!-- Row 5 (P2) -->
+  <rect x="0"   y="300" width="60" height="60" fill="#334155"/>
+  <rect x="60"  y="300" width="60" height="60" fill="#1e293b"/>
+  <rect x="120" y="300" width="60" height="60" fill="#334155"/>
+  <rect x="180" y="300" width="60" height="60" fill="#1e293b"/>
+  <rect x="240" y="300" width="60" height="60" fill="#334155"/>
+  <rect x="300" y="300" width="60" height="60" fill="#1e293b"/>
+  <rect x="360" y="300" width="60" height="60" fill="#334155"/>
+  <rect x="420" y="300" width="60" height="60" fill="#1e293b"/>
+  <!-- Row 6 (P2) -->
+  <rect x="0"   y="360" width="60" height="60" fill="#1e293b"/>
+  <rect x="60"  y="360" width="60" height="60" fill="#334155"/>
+  <rect x="120" y="360" width="60" height="60" fill="#1e293b"/>
+  <rect x="180" y="360" width="60" height="60" fill="#334155"/>
+  <rect x="240" y="360" width="60" height="60" fill="#1e293b"/>
+  <rect x="300" y="360" width="60" height="60" fill="#334155"/>
+  <rect x="360" y="360" width="60" height="60" fill="#1e293b"/>
+  <rect x="420" y="360" width="60" height="60" fill="#334155"/>
+  <!-- Row 7 (P2) -->
+  <rect x="0"   y="420" width="60" height="60" fill="#334155"/>
+  <rect x="60"  y="420" width="60" height="60" fill="#1e293b"/>
+  <rect x="120" y="420" width="60" height="60" fill="#334155"/>
+  <rect x="180" y="420" width="60" height="60" fill="#1e293b"/>
+  <rect x="240" y="420" width="60" height="60" fill="#334155"/>
+  <rect x="300" y="420" width="60" height="60" fill="#1e293b"/>
+  <rect x="360" y="420" width="60" height="60" fill="#334155"/>
+  <rect x="420" y="420" width="60" height="60" fill="#1e293b"/>
+
+  <!-- P1 pieces (rose, value=1) — rows 0-2, dark squares (row+col odd) -->
+  <!-- Row 0: cols 1,3,5,7 -->
+  <circle cx="61" cy="31"  r="1" fill="#00000044"/><circle cx="60" cy="30"  r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="60" cy="30"  r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="181" cy="31" r="1" fill="#00000044"/><circle cx="180" cy="30" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="180" cy="30" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="301" cy="31" r="1" fill="#00000044"/><circle cx="300" cy="30" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="300" cy="30" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="421" cy="31" r="1" fill="#00000044"/><circle cx="420" cy="30" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="420" cy="30" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <!-- Row 1: cols 0,2,4,6 -->
+  <circle cx="31"  cy="91" r="1" fill="#00000044"/><circle cx="30"  cy="90" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="30"  cy="90" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="151" cy="91" r="1" fill="#00000044"/><circle cx="150" cy="90" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="150" cy="90" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="271" cy="91" r="1" fill="#00000044"/><circle cx="270" cy="90" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="270" cy="90" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="391" cy="91" r="1" fill="#00000044"/><circle cx="390" cy="90" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="390" cy="90" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <!-- Row 2: cols 1,3,5,7 -->
+  <circle cx="61"  cy="151" r="1" fill="#00000044"/><circle cx="60"  cy="150" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="60"  cy="150" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="181" cy="151" r="1" fill="#00000044"/><circle cx="180" cy="150" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="180" cy="150" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="301" cy="151" r="1" fill="#00000044"/><circle cx="300" cy="150" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="300" cy="150" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="421" cy="151" r="1" fill="#00000044"/><circle cx="420" cy="150" r="24" fill="#f43f5e" stroke="#9f1239" stroke-width="2"/><circle cx="420" cy="150" r="14" fill="none" stroke="#f43f5e" stroke-width="1.5" opacity="0.5"/>
+
+  <!-- P2 pieces (sky blue, value=-1) — rows 5-7, dark squares (row+col odd) -->
+  <!-- Row 5: cols 0,2,4,6 -->
+  <circle cx="31"  cy="331" r="1" fill="#00000044"/><circle cx="30"  cy="330" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="30"  cy="330" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="151" cy="331" r="1" fill="#00000044"/><circle cx="150" cy="330" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="150" cy="330" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="271" cy="331" r="1" fill="#00000044"/><circle cx="270" cy="330" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="270" cy="330" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="391" cy="331" r="1" fill="#00000044"/><circle cx="390" cy="330" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="390" cy="330" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <!-- Row 6: cols 1,3,5,7 -->
+  <circle cx="91"  cy="391" r="1" fill="#00000044"/><circle cx="90"  cy="390" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="90"  cy="390" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="211" cy="391" r="1" fill="#00000044"/><circle cx="210" cy="390" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="210" cy="390" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="331" cy="391" r="1" fill="#00000044"/><circle cx="330" cy="390" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="330" cy="390" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="451" cy="391" r="1" fill="#00000044"/><circle cx="450" cy="390" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="450" cy="390" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <!-- Row 7: cols 0,2,4,6 -->
+  <circle cx="31"  cy="451" r="1" fill="#00000044"/><circle cx="30"  cy="450" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="30"  cy="450" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="151" cy="451" r="1" fill="#00000044"/><circle cx="150" cy="450" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="150" cy="450" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="271" cy="451" r="1" fill="#00000044"/><circle cx="270" cy="450" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="270" cy="450" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+  <circle cx="391" cy="451" r="1" fill="#00000044"/><circle cx="390" cy="450" r="24" fill="#38bdf8" stroke="#0369a1" stroke-width="2"/><circle cx="390" cy="450" r="14" fill="none" stroke="#38bdf8" stroke-width="1.5" opacity="0.5"/>
+
+  <!-- Board border -->
+  <rect x="0" y="0" width="480" height="480" fill="none" stroke="#475569" stroke-width="1.5"/>
+
+  <!-- Status bar -->
+  <rect x="0" y="480" width="480" height="80" fill="#1e293b"/>
+  <rect x="0" y="480" width="480" height="1.5" fill="#475569"/>
+
+  <!-- Status badge -->
+  <rect x="12" y="494" width="190" height="32" rx="16" fill="#f43f5e22"/>
+  <text x="107" y="515" text-anchor="middle" font-size="14" font-weight="600" fill="#f43f5e">Player 1 to move</text>
+
+  <!-- Piece counts -->
+  <circle cx="370" cy="510" r="7" fill="#f43f5e"/>
+  <text x="382" y="515" font-size="13" fill="#fda4af">12</text>
+
+  <circle cx="425" cy="510" r="7" fill="#38bdf8"/>
+  <text x="437" y="515" font-size="13" fill="#7dd3fc">12</text>
+
+  <!-- Cougr watermark -->
+  <text x="240" y="545" text-anchor="middle" font-size="10" fill="#64748b" letter-spacing="2">COUGR · CHECKERS · MOVE 1</text>
+</svg>

--- a/examples/tic_tac_toe/preview.svg
+++ b/examples/tic_tac_toe/preview.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 400 480" width="400" height="480">
+  <defs>
+    <style>
+      text { font-family: 'Inter', 'Segoe UI', system-ui, sans-serif; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="400" height="480" fill="#0f172a" rx="12"/>
+
+  <!-- Board grid cells -->
+
+  <!-- Row 0 -->
+  <rect x="2" y="2" width="129" height="129" fill="#fef08a22" rx="4"/>
+  <!-- grid lines -->
+  <line x1="133" y1="2" x2="133" y2="398" stroke="#334155" stroke-width="3"/>
+  <line x1="2" y1="133" x2="398" y2="133" stroke="#334155" stroke-width="3"/>
+
+  <rect x="135" y="2" width="129" height="129" fill="#fef08a22" rx="4"/>
+  <line x1="266" y1="2" x2="266" y2="398" stroke="#334155" stroke-width="3"/>
+
+  <rect x="268" y="2" width="129" height="129" fill="#fef08a22" rx="4"/>
+
+  <!-- Row 1 -->
+  <rect x="2" y="135" width="129" height="129" fill="#1e293b" rx="4"/>
+  <rect x="135" y="135" width="129" height="129" fill="#1e293b" rx="4"/>
+  <line x1="2" y1="266" x2="398" y2="266" stroke="#334155" stroke-width="3"/>
+  <rect x="268" y="135" width="129" height="129" fill="#1e293b" rx="4"/>
+
+  <!-- Row 2 -->
+  <rect x="2" y="268" width="129" height="129" fill="#1e293b" rx="4"/>
+  <rect x="135" y="268" width="129" height="129" fill="#1e293b" rx="4"/>
+  <rect x="268" y="268" width="129" height="129" fill="#1e293b" rx="4"/>
+
+  <!-- X marks — top row cells 0,1,2 (winning) -->
+  <!-- Cell 0: cx=66.5, cy=66.5 -->
+  <line x1="30" y1="30" x2="103" y2="103" stroke="#fda4af" stroke-width="14" stroke-linecap="round"/>
+  <line x1="103" y1="30" x2="30" y2="103" stroke="#fda4af" stroke-width="14" stroke-linecap="round"/>
+
+  <!-- Cell 1: cx=199.5, cy=66.5 -->
+  <line x1="163" y1="30" x2="236" y2="103" stroke="#fda4af" stroke-width="14" stroke-linecap="round"/>
+  <line x1="236" y1="30" x2="163" y2="103" stroke="#fda4af" stroke-width="14" stroke-linecap="round"/>
+
+  <!-- Cell 2: cx=332.5, cy=66.5 -->
+  <line x1="296" y1="30" x2="369" y2="103" stroke="#fda4af" stroke-width="14" stroke-linecap="round"/>
+  <line x1="369" y1="30" x2="296" y2="103" stroke="#fda4af" stroke-width="14" stroke-linecap="round"/>
+
+  <!-- O marks — cells 3 (cx=66.5, cy=199.5) and 4 (cx=199.5, cy=199.5) -->
+  <circle cx="66" cy="199" r="43" fill="none" stroke="#38bdf8" stroke-width="12"/>
+  <circle cx="199" cy="199" r="43" fill="none" stroke="#38bdf8" stroke-width="12"/>
+
+  <!-- Status bar -->
+  <rect x="0" y="400" width="400" height="80" fill="#1e293b" rx="0"/>
+  <rect x="0" y="400" width="400" height="2" fill="#334155"/>
+
+  <!-- Status badge -->
+  <rect x="16" y="416" width="160" height="36" rx="18" fill="#f43f5e22"/>
+  <text x="96" y="440" text-anchor="middle" font-size="15" font-weight="700" fill="#f43f5e">✕  wins</text>
+
+  <!-- Move counter -->
+  <text x="384" y="440" text-anchor="end" font-size="13" fill="#64748b">Move 5</text>
+
+  <!-- Cougr watermark -->
+  <text x="200" y="468" text-anchor="middle" font-size="10" fill="#64748b" letter-spacing="2">COUGR · TIC-TAC-TOE</text>
+</svg>

--- a/tools/preview-gen/README.md
+++ b/tools/preview-gen/README.md
@@ -1,0 +1,184 @@
+# Cougr Preview Generator
+
+`tools/preview-gen` is a lightweight Node.js CLI that generates SVG preview images for Cougr contract-only examples. Previews are driven by actual scenario/test state data, not hand-drawn art or mocked screenshots.
+
+## Design Rationale
+
+Most Cougr examples are headless smart contracts with no frontend. A showcase gallery needs a visual preview per entry. Rather than faking screenshots or hand-drawing images, this tool extracts final-state data from each example's existing test assertions and renders it as a deterministic, reproducible SVG.
+
+**Board/grid games** (Tic-Tac-Toe, Checkers, Battleship, …) get a full state renderer.  
+**Real-time arcade games** (Snake, Asteroids, Pong, …) get a branded category-icon fallback, explicitly labeled as such — not faked.
+
+---
+
+## Requirements
+
+- Node.js ≥ 18 (ESM modules, no npm dependencies)
+
+---
+
+## Usage
+
+```bash
+cd tools/preview-gen
+
+# Generate a single preview (writes to examples/<game>/preview.svg)
+node generate.js tic_tac_toe
+node generate.js checkers
+node generate.js battleship
+
+# Generate all registered games at once
+npm run gen:all
+```
+
+---
+
+## Repository Layout
+
+```
+tools/preview-gen/
+├── generate.js              # Main CLI entry point
+├── package.json             # npm scripts + engine requirement
+├── README.md                # This file
+├── renderers/
+│   ├── tic_tac_toe.js       # 3×3 board SVG renderer
+│   ├── checkers.js          # 8×8 board SVG renderer
+│   ├── battleship.js        # Dual 10×10 attack-grid renderer
+│   └── category_fallback.js # Branded icon card for non-grid games
+└── states/
+    ├── tic_tac_toe.json     # Final state extracted from test_x_wins_row_top
+    ├── checkers.json        # Opening position from initial_board() + test assertions
+    └── battleship.json      # Mid-game attack grid from reveal_cell tests
+```
+
+---
+
+## Adding a Preview for a New Example
+
+Follow these steps when adding a canonical board/grid example to the gallery.
+
+### Step 1 — Identify the representative state
+
+Open the example's `src/test.rs` and find the most illustrative terminal state. Good candidates:
+
+- A **winning** state (the test that asserts `status == 1` or similar)
+- The **opening position** for a complex piece-based game
+- A **mid-game** state that shows the core mechanic (e.g. attacks/hits for Battleship)
+
+**Do not invent data**. Every value in the JSON must be traceable to a specific test assertion.
+
+### Step 2 — Create `states/<your_game>.json`
+
+```json
+{
+  "_source": "examples/<your_game>/src/test.rs :: <test_fn_name> (lines N-M)",
+  "_description": "One sentence: what game state this represents.",
+  "_move_sequence": [ ... ],   // optional: list moves that produce this state
+  "field1": ...,               // game-specific state fields
+  "field2": ...
+}
+```
+
+Include the `_source` field so anyone reading the file can trace back to the original test.
+
+### Step 3 — Create `renderers/<your_game>.js`
+
+```js
+/**
+ * <GameName> SVG renderer.
+ *
+ * Input state shape:
+ *   field1: type  — description
+ *   ...
+ *
+ * Produces a WIDTHxHEIGHT SVG.
+ */
+export function render(state) {
+  // Build SVG string using template literals.
+  // Use COLORS object for a consistent dark-mode palette.
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" ...>`;
+  // ... draw board, pieces, status bar, Cougr watermark
+  svg += `</svg>`;
+  return svg;
+}
+```
+
+**SVG design guidelines:**
+- Dark background (`#0f172a`)
+- Board area with subtle grid lines (`#334155`)
+- Status bar at the bottom (64–80px) showing turn/result
+- `COUGR · GAME_NAME` watermark in the status bar
+- No external image references or fonts (SVG must render without network access)
+
+### Step 4 — Register the renderer
+
+In `generate.js`, add an import and register the renderer:
+
+```js
+import { render as renderYourGame } from './renderers/your_game.js';
+
+const RENDERERS = {
+  // ... existing ...
+  your_game: renderYourGame,   // ← add this
+};
+```
+
+If your game is a real-time/physics game with no meaningful static state, add it to `FALLBACK_GAMES` instead:
+
+```js
+const FALLBACK_GAMES = {
+  your_game: { category: 'Arcade', color: '#6366f1', icon: '🚀' },
+};
+```
+
+### Step 5 — Run and verify
+
+```bash
+node generate.js your_game
+```
+
+Open `examples/your_game/preview.svg` in a browser. Confirm:
+- The state matches the test assertion you cited in `_source`
+- The image is legible at 400–520px wide
+- The status bar correctly reflects the game outcome
+
+### Step 6 — Check in
+
+```bash
+git add \
+  examples/your_game/preview.svg \
+  tools/preview-gen/states/your_game.json \
+  tools/preview-gen/renderers/your_game.js \
+  tools/preview-gen/generate.js
+```
+
+Update the `Preview` column in `examples/README.md` for your example.
+
+---
+
+## When to Use the Category Fallback
+
+Use `category_fallback` (not a board renderer) when:
+
+- The game has no meaningful static board state (Snake, Asteroids, Pong, Flappy Bird)
+- The game state at any single moment doesn't convey how the game works
+- Rendering a fake "representative" frame would be misleading
+
+The fallback is explicitly labeled "Real-time game — no static board state" so gallery visitors understand why no gameplay preview is shown.
+
+---
+
+## Palette Reference
+
+| Token | Hex | Use |
+|---|---|---|
+| `bg` | `#0f172a` | SVG background |
+| `card` | `#1e293b` | Cell / status bar background |
+| `grid_line` | `#334155` | Board grid dividers |
+| `p1_accent` | `#f43f5e` | Player 1 / X pieces |
+| `p2_accent` | `#38bdf8` | Player 2 / O pieces |
+| `hit` | `#ef4444` | Battleship hit cell |
+| `miss` | `#334155` | Battleship miss cell |
+| `win_highlight` | `#fef08a22` | Winning-line cell tint |
+| `text_muted` | `#64748b` | Labels, watermark |
+| `text_primary` | `#f1f5f9` | Main status text |

--- a/tools/preview-gen/generate.js
+++ b/tools/preview-gen/generate.js
@@ -1,0 +1,94 @@
+/**
+ * Cougr Preview Generator — main CLI entry point.
+ *
+ * Usage:
+ *   node generate.js <game>
+ *
+ * Where <game> is one of: tic_tac_toe, checkers, battleship
+ *
+ * The generator reads a state snapshot from `states/<game>.json`,
+ * dispatches to the appropriate renderer, and writes:
+ *   ../../examples/<game>/preview.svg
+ *
+ * State data is manually extracted from the canonical test assertions
+ * in each example's `src/test.rs`. See tools/preview-gen/README.md for
+ * the full contributor workflow.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Renderer registry — add new games here
+import { render as renderTicTacToe } from './renderers/tic_tac_toe.js';
+import { render as renderCheckers } from './renderers/checkers.js';
+import { render as renderBattleship } from './renderers/battleship.js';
+import { render as renderFallback } from './renderers/category_fallback.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const RENDERERS = {
+  tic_tac_toe: renderTicTacToe,
+  checkers: renderCheckers,
+  battleship: renderBattleship,
+};
+
+// Games that get the category-icon fallback treatment
+const FALLBACK_GAMES = {
+  snake: { category: 'Arcade', color: '#22c55e', icon: '🐍' },
+  asteroids: { category: 'Arcade', color: '#6366f1', icon: '☄️' },
+  pong: { category: 'Arcade', color: '#0ea5e9', icon: '🏓' },
+  flappy_bird: { category: 'Arcade', color: '#f59e0b', icon: '🐦' },
+};
+
+function main() {
+  const game = process.argv[2];
+
+  if (!game) {
+    console.error('Usage: node generate.js <game>');
+    console.error('Available games:', [...Object.keys(RENDERERS), ...Object.keys(FALLBACK_GAMES)].join(', '));
+    process.exit(1);
+  }
+
+  // Determine output path
+  const outDir = path.resolve(__dirname, '../../examples', game);
+  if (!fs.existsSync(outDir)) {
+    console.error(`Error: examples/${game}/ does not exist.`);
+    process.exit(1);
+  }
+  const outPath = path.join(outDir, 'preview.svg');
+
+  // Handle fallback games
+  if (FALLBACK_GAMES[game]) {
+    const svg = renderFallback({ game, ...FALLBACK_GAMES[game] });
+    fs.writeFileSync(outPath, svg, 'utf8');
+    console.log(`✓ Written fallback preview: ${outPath}`);
+    return;
+  }
+
+  // Load state JSON
+  const statePath = path.resolve(__dirname, 'states', `${game}.json`);
+  if (!fs.existsSync(statePath)) {
+    console.error(`Error: No state file found at ${statePath}`);
+    console.error('  Create one following the instructions in tools/preview-gen/README.md');
+    process.exit(1);
+  }
+
+  const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+
+  // Dispatch to renderer
+  const renderer = RENDERERS[game];
+  if (!renderer) {
+    console.error(`Error: No renderer for "${game}". Add one to renderers/ and register it in generate.js`);
+    process.exit(1);
+  }
+
+  const svg = renderer(state);
+  fs.writeFileSync(outPath, svg, 'utf8');
+  console.log(`✓ Written preview: ${outPath}`);
+  if (state._source) {
+    console.log(`  State source: ${state._source}`);
+  }
+}
+
+main();

--- a/tools/preview-gen/package.json
+++ b/tools/preview-gen/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cougr-preview-gen",
+  "version": "1.0.0",
+  "description": "Generate SVG preview images for Cougr contract-only examples from scenario state data.",
+  "type": "module",
+  "bin": {
+    "preview-gen": "./generate.js"
+  },
+  "scripts": {
+    "gen:tic_tac_toe": "node generate.js tic_tac_toe",
+    "gen:checkers": "node generate.js checkers",
+    "gen:battleship": "node generate.js battleship",
+    "gen:all": "node generate.js tic_tac_toe && node generate.js checkers && node generate.js battleship"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/tools/preview-gen/renderers/battleship.js
+++ b/tools/preview-gen/renderers/battleship.js
@@ -1,0 +1,225 @@
+/**
+ * Battleship SVG renderer.
+ *
+ * Battleship uses a commit-reveal scheme: each player commits a board,
+ * then attacks. The publicly visible state is the *attack grid* —
+ * which cells have been fired at and whether they were hits or misses.
+ *
+ * Input state shape (from examples/battleship/src/lib.rs :: GameState):
+ *   grid:           Record<number, "Hit"|"Miss"|"Unknown">
+ *                   — map from cell index (0-99) to result
+ *                   — cells not present = Unknown (not yet attacked)
+ *   grid_size:      number  — default 10
+ *   label:          string  — e.g. "Player A's attack grid"
+ *   ship_remaining: number  — ships remaining on the target board
+ *   total_ships:    number  — 17 (5+4+3+3+2)
+ *   phase:          "Setup" | "Attack" | "Finished"
+ *   turn:           "A" | "B"
+ *   winner:         null | "A" | "B"
+ *
+ * Produces a 520×640 SVG (two grids side by side + legend + status bar).
+ * Since battleship has two attack grids (A attacks B, B attacks A),
+ * we render *both* grids stacked, using state.grid_a and state.grid_b.
+ */
+
+const GRID = 10;
+const CELL_SZ = 36;         // each cell is 36×36px
+const BOARD_W = GRID * CELL_SZ;   // 360
+const SVG_W = BOARD_W + 80;       // 440 — extra for labels
+const BOARD_H = GRID * CELL_SZ;   // 360
+const GAP = 24;                    // gap between the two boards
+const STATUS_H = 72;
+const SVG_H = 2 * BOARD_H + GAP + STATUS_H + 60;  // header space
+
+const COLORS = {
+  bg: '#0f172a',
+  sea: '#0c4a6e',            // empty/unknown cell
+  hit: '#ef4444',            // hit cell fill
+  hit_stroke: '#fca5a5',
+  miss: '#334155',           // miss cell fill
+  miss_mark: '#94a3b8',
+  grid_line: '#1e3a5f',
+  label_axis: '#64748b',
+  header_text: '#f1f5f9',
+  header_a: '#f43f5e',
+  header_b: '#38bdf8',
+  status_bar: '#1e293b',
+  divider: '#475569',
+  badge_a: '#f43f5e',
+  badge_b: '#38bdf8',
+  badge_finished: '#22c55e',
+  badge_setup: '#f59e0b',
+  badge_attack: '#38bdf8',
+  text_muted: '#64748b',
+};
+
+const COL_LABELS = ['A','B','C','D','E','F','G','H','I','J'];
+
+function renderGrid(cells, offsetX, offsetY, label, labelColor) {
+  let out = '';
+
+  // Label
+  out += `<text x="${offsetX + BOARD_W/2}" y="${offsetY - 8}" text-anchor="middle"
+    font-size="12" font-weight="600" fill="${labelColor}">${label}</text>`;
+
+  // Column labels (A-J)
+  for (let c = 0; c < GRID; c++) {
+    out += `<text x="${offsetX + c*CELL_SZ + CELL_SZ/2}" y="${offsetY - 24}"
+      text-anchor="middle" font-size="10" fill="${COLORS.label_axis}">${COL_LABELS[c]}</text>`;
+  }
+
+  // Row labels (1-10)
+  for (let r = 0; r < GRID; r++) {
+    out += `<text x="${offsetX - 10}" y="${offsetY + r*CELL_SZ + CELL_SZ/2 + 4}"
+      text-anchor="end" font-size="10" fill="${COLORS.label_axis}">${r+1}</text>`;
+  }
+
+  for (let r = 0; r < GRID; r++) {
+    for (let c = 0; c < GRID; c++) {
+      const idx = r * GRID + c;
+      const x = offsetX + c * CELL_SZ;
+      const y = offsetY + r * CELL_SZ;
+      const result = cells[idx] ?? 'Unknown';
+
+      // Cell background
+      let fill = COLORS.sea;
+      if (result === 'Hit') fill = COLORS.hit;
+      else if (result === 'Miss') fill = COLORS.miss;
+
+      out += `<rect x="${x+0.5}" y="${y+0.5}" width="${CELL_SZ-1}" height="${CELL_SZ-1}"
+        fill="${fill}" rx="2"/>`;
+
+      // Hit marker: X
+      if (result === 'Hit') {
+        const pad = 8;
+        out += `<line x1="${x+pad}" y1="${y+pad}" x2="${x+CELL_SZ-pad}" y2="${y+CELL_SZ-pad}"
+          stroke="${COLORS.hit_stroke}" stroke-width="2.5" stroke-linecap="round"/>
+        <line x1="${x+CELL_SZ-pad}" y1="${y+pad}" x2="${x+pad}" y2="${y+CELL_SZ-pad}"
+          stroke="${COLORS.hit_stroke}" stroke-width="2.5" stroke-linecap="round"/>`;
+      }
+
+      // Miss marker: circle dot
+      if (result === 'Miss') {
+        out += `<circle cx="${x+CELL_SZ/2}" cy="${y+CELL_SZ/2}" r="4"
+          fill="${COLORS.miss_mark}" opacity="0.7"/>`;
+      }
+    }
+  }
+
+  // Grid lines
+  for (let i = 0; i <= GRID; i++) {
+    out += `<line x1="${offsetX + i*CELL_SZ}" y1="${offsetY}"
+      x2="${offsetX + i*CELL_SZ}" y2="${offsetY + BOARD_H}"
+      stroke="${COLORS.grid_line}" stroke-width="0.75"/>`;
+    out += `<line x1="${offsetX}" y1="${offsetY + i*CELL_SZ}"
+      x2="${offsetX + BOARD_W}" y2="${offsetY + i*CELL_SZ}"
+      stroke="${COLORS.grid_line}" stroke-width="0.75"/>`;
+  }
+
+  // Board border
+  out += `<rect x="${offsetX}" y="${offsetY}" width="${BOARD_W}" height="${BOARD_H}"
+    fill="none" stroke="${COLORS.divider}" stroke-width="1.5" rx="2"/>`;
+
+  return out;
+}
+
+function countResults(cells) {
+  let hits = 0, misses = 0;
+  for (const v of Object.values(cells)) {
+    if (v === 'Hit') hits++;
+    else if (v === 'Miss') misses++;
+  }
+  return { hits, misses };
+}
+
+function phaseColor(phase) {
+  if (phase === 'Setup') return COLORS.badge_setup;
+  if (phase === 'Attack') return COLORS.badge_attack;
+  return COLORS.badge_finished;
+}
+
+export function render(state) {
+  const {
+    grid_a = {}, grid_b = {},
+    ship_remaining_a = 17, ship_remaining_b = 17, total_ships = 17,
+    phase = 'Attack', turn = 'A', winner = null,
+  } = state;
+
+  const countA = countResults(grid_a);
+  const countB = countResults(grid_b);
+
+  const MARGIN_LEFT = 52;    // space for row labels
+  const HEADER_TOP = 48;     // top offset for board A
+
+  const boardATop = HEADER_TOP;
+  const boardBTop = boardATop + BOARD_H + GAP + 32; // +32 for B's label
+  const totalSvgH = boardBTop + BOARD_H + STATUS_H + 16;
+
+  const statusText = winner
+    ? `Player ${winner} wins!`
+    : phase === 'Setup'
+      ? 'Setup phase — awaiting commitments'
+      : `Player ${turn}'s turn to attack`;
+  const statusColor = winner
+    ? COLORS.badge_finished
+    : phaseColor(phase);
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 ${SVG_W} ${totalSvgH}" width="${SVG_W}" height="${totalSvgH}">
+  <defs>
+    <style>text { font-family: 'Inter', 'Segoe UI', system-ui, sans-serif; }</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="${SVG_W}" height="${totalSvgH}" fill="${COLORS.bg}" rx="12"/>
+
+  <!-- Grid A: Player A's attacks on B's fleet -->
+`;
+
+  svg += renderGrid(grid_a, MARGIN_LEFT, boardATop, "Player A attacks →", COLORS.header_a);
+
+  // Stats for grid A
+  const aHits = countA.hits;
+  const aMisses = countA.misses;
+  svg += `<text x="${MARGIN_LEFT + BOARD_W + 8}" y="${boardATop + 18}" font-size="10" fill="${COLORS.header_a}">
+    Hits: ${aHits}</text>
+  <text x="${MARGIN_LEFT + BOARD_W + 8}" y="${boardATop + 33}" font-size="10" fill="${COLORS.miss_mark}">
+    Miss: ${aMisses}</text>
+  <text x="${MARGIN_LEFT + BOARD_W + 8}" y="${boardATop + 52}" font-size="10" fill="${COLORS.text_muted}">
+    Ships: ${ship_remaining_b}/${total_ships}</text>`;
+
+  svg += `\n  <!-- Grid B: Player B's attacks on A's fleet -->\n`;
+  svg += renderGrid(grid_b, MARGIN_LEFT, boardBTop, "Player B attacks →", COLORS.header_b);
+
+  // Stats for grid B
+  const bHits = countB.hits;
+  const bMisses = countB.misses;
+  svg += `<text x="${MARGIN_LEFT + BOARD_W + 8}" y="${boardBTop + 18}" font-size="10" fill="${COLORS.header_b}">
+    Hits: ${bHits}</text>
+  <text x="${MARGIN_LEFT + BOARD_W + 8}" y="${boardBTop + 33}" font-size="10" fill="${COLORS.miss_mark}">
+    Miss: ${bMisses}</text>
+  <text x="${MARGIN_LEFT + BOARD_W + 8}" y="${boardBTop + 52}" font-size="10" fill="${COLORS.text_muted}">
+    Ships: ${ship_remaining_a}/${total_ships}</text>`;
+
+  // Status bar
+  const statusBarY = boardBTop + BOARD_H + 12;
+  svg += `
+  <!-- Status bar -->
+  <rect x="0" y="${statusBarY}" width="${SVG_W}" height="${STATUS_H}" fill="${COLORS.status_bar}" rx="0"/>
+  <rect x="0" y="${statusBarY}" width="${SVG_W}" height="1.5" fill="${COLORS.divider}"/>
+
+  <!-- Status badge -->
+  <rect x="12" y="${statusBarY+14}" width="${Math.min(statusText.length * 9 + 24, SVG_W - 24)}" height="30" rx="15"
+        fill="${statusColor}22"/>
+  <text x="${12 + Math.min(statusText.length * 9 + 24, SVG_W - 24)/2}"
+        y="${statusBarY+34}" text-anchor="middle" font-size="13" font-weight="600"
+        fill="${statusColor}">${statusText}</text>
+
+  <!-- Watermark -->
+  <text x="${SVG_W/2}" y="${statusBarY + STATUS_H - 8}" text-anchor="middle" font-size="9"
+        fill="${COLORS.text_muted}" letter-spacing="2">COUGR · BATTLESHIP · COMMIT-REVEAL</text>
+`;
+
+  svg += `</svg>`;
+  return svg;
+}

--- a/tools/preview-gen/renderers/category_fallback.js
+++ b/tools/preview-gen/renderers/category_fallback.js
@@ -1,0 +1,83 @@
+/**
+ * Category fallback renderer.
+ *
+ * For games where board/grid state visualization is not applicable
+ * (Snake, Asteroids, Pong, etc.), this renderer generates a branded
+ * category card with an icon, game name, and category badge.
+ *
+ * Input:
+ *   game:     string  — game slug, e.g. "snake"
+ *   category: string  — e.g. "Arcade"
+ *   color:    string  — hex accent color
+ *   icon:     string  — emoji icon
+ *
+ * Produces a 400×300 SVG.
+ */
+
+const W = 400;
+const H = 300;
+
+function slugToTitle(slug) {
+  return slug.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+}
+
+export function render({ game, category, color, icon }) {
+  const title = slugToTitle(game);
+
+  // Darken version of color for gradient stop
+  const darkBg = '#0f172a';
+  const cardBg = '#1e293b';
+  const border = '#334155';
+  const textMuted = '#64748b';
+  const textPrimary = '#f1f5f9';
+
+  return `<svg xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 ${W} ${H}" width="${W}" height="${H}">
+  <defs>
+    <style>text { font-family: 'Inter', 'Segoe UI', system-ui, sans-serif; }</style>
+    <radialGradient id="glow" cx="50%" cy="45%" r="50%">
+      <stop offset="0%" stop-color="${color}" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="${darkBg}" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="border_grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="${color}" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="${border}" stop-opacity="0.4"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="${W}" height="${H}" fill="${darkBg}" rx="12"/>
+  <rect x="1" y="1" width="${W-2}" height="${H-2}" fill="url(#glow)" rx="11"/>
+
+  <!-- Card -->
+  <rect x="32" y="32" width="${W-64}" height="${H-64}" fill="${cardBg}" rx="16"
+        stroke="url(#border_grad)" stroke-width="1.5"/>
+
+  <!-- Decorative corner accents -->
+  <line x1="32" y1="60" x2="56" y2="60" stroke="${color}" stroke-width="2" opacity="0.5"/>
+  <line x1="56" y1="32" x2="56" y2="56" stroke="${color}" stroke-width="2" opacity="0.5"/>
+  <line x1="${W-32}" y1="60" x2="${W-56}" y2="60" stroke="${color}" stroke-width="2" opacity="0.5"/>
+  <line x1="${W-56}" y1="32" x2="${W-56}" y2="56" stroke="${color}" stroke-width="2" opacity="0.5"/>
+
+  <!-- Icon -->
+  <text x="${W/2}" y="${H/2 - 18}" text-anchor="middle" font-size="56">${icon}</text>
+
+  <!-- Game title -->
+  <text x="${W/2}" y="${H/2 + 32}" text-anchor="middle" font-size="22" font-weight="700"
+        fill="${textPrimary}" letter-spacing="0.5">${title}</text>
+
+  <!-- Category badge -->
+  <rect x="${W/2 - 50}" y="${H/2 + 46}" width="100" height="24" rx="12" fill="${color}22"/>
+  <text x="${W/2}" y="${H/2 + 63}" text-anchor="middle" font-size="12" font-weight="600"
+        fill="${color}">${category}</text>
+
+  <!-- "No board preview" note -->
+  <text x="${W/2}" y="${H - 44}" text-anchor="middle" font-size="11" fill="${textMuted}">
+    Real-time game — no static board state
+  </text>
+
+  <!-- Cougr watermark -->
+  <text x="${W/2}" y="${H - 26}" text-anchor="middle" font-size="10"
+        fill="${textMuted}" letter-spacing="2">COUGR EXAMPLE</text>
+</svg>`;
+}

--- a/tools/preview-gen/renderers/checkers.js
+++ b/tools/preview-gen/renderers/checkers.js
@@ -1,0 +1,174 @@
+/**
+ * Checkers SVG renderer.
+ *
+ * Input state shape (from examples/checkers/src/components.rs :: BoardComponent):
+ *   cells:          number[64]  — row-major 8×8
+ *                   0=empty, 1=P1 man, -1=P2 man, 2=P1 king, -2=P2 king
+ *   current_player: number      — 1 or 2
+ *   move_number:    number
+ *   status:         "Active" | "Finished"
+ *   winner:         number      — 0=none, 1=P1, 2=P2
+ *
+ * Board layout:
+ *   P1 starts on rows 0–2 (top), plays on dark squares (row+col odd).
+ *   P2 starts on rows 5–7 (bottom), plays on dark squares.
+ *
+ * Produces a 480×560 SVG (8×8 board 480×480 + status bar 80px).
+ */
+
+const COLS = 8;
+const SIZE = 480;
+const CELL = SIZE / COLS;   // 60
+const TOTAL_H = SIZE + 80;
+
+const COLORS = {
+  bg: '#0f172a',
+  light_sq: '#1e293b',
+  dark_sq: '#334155',
+  p1_piece: '#f43f5e',      // rose-500
+  p1_king: '#fda4af',       // rose-300
+  p1_stroke: '#9f1239',
+  p2_piece: '#38bdf8',      // sky-400
+  p2_king: '#93c5fd',       // blue-300
+  p2_stroke: '#0369a1',
+  crown: '#fbbf24',
+  status_bar: '#1e293b',
+  divider: '#475569',
+  text_primary: '#f1f5f9',
+  text_muted: '#64748b',
+  badge_p1: '#f43f5e',
+  badge_p2: '#38bdf8',
+  badge_draw: '#94a3b8',
+  label_p1: '#fda4af',
+  label_p2: '#7dd3fc',
+};
+
+function cellAt(cells, row, col) {
+  return cells[row * COLS + col] ?? 0;
+}
+
+function isDark(row, col) {
+  return (row + col) % 2 === 1;
+}
+
+function renderPiece(x, y, value) {
+  const cx = x + CELL / 2;
+  const cy = y + CELL / 2;
+  const r = CELL / 2 - 6;
+  const isKing = Math.abs(value) === 2;
+  const isP1 = value > 0;
+
+  const fill = isKing
+    ? (isP1 ? COLORS.p1_king : COLORS.p2_king)
+    : (isP1 ? COLORS.p1_piece : COLORS.p2_piece);
+  const stroke = isP1 ? COLORS.p1_stroke : COLORS.p2_stroke;
+
+  let out = '';
+
+  // Drop shadow
+  out += `<circle cx="${cx+1}" cy="${cy+2}" r="${r}" fill="#00000044"/>`;
+  // Main piece
+  out += `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${fill}" stroke="${stroke}" stroke-width="2"/>`;
+  // Inner ring highlight
+  out += `<circle cx="${cx}" cy="${cy}" r="${r*0.6}" fill="none" stroke="${fill}" stroke-width="1.5" opacity="0.5"/>`;
+
+  // King crown indicator — a smaller gold circle in the center
+  if (isKing) {
+    out += `<circle cx="${cx}" cy="${cy}" r="${r*0.3}" fill="${COLORS.crown}" opacity="0.9"/>`;
+  }
+
+  return out;
+}
+
+function pieceCount(cells) {
+  let p1 = 0, p2 = 0;
+  for (const v of cells) {
+    if (v > 0) p1++;
+    else if (v < 0) p2++;
+  }
+  return { p1, p2 };
+}
+
+function statusLabel(state) {
+  if (state.status === 'Finished') {
+    if (state.winner === 1) return { text: 'Player 1 wins', color: COLORS.badge_p1 };
+    if (state.winner === 2) return { text: 'Player 2 wins', color: COLORS.badge_p2 };
+    return { text: 'Draw', color: COLORS.badge_draw };
+  }
+  return {
+    text: `Player ${state.current_player} to move`,
+    color: state.current_player === 1 ? COLORS.badge_p1 : COLORS.badge_p2,
+  };
+}
+
+export function render(state) {
+  const { cells, move_number } = state;
+  const { p1, p2 } = pieceCount(cells);
+  const { text: statusText, color: statusColor } = statusLabel(state);
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 ${SIZE} ${TOTAL_H}" width="${SIZE}" height="${TOTAL_H}">
+  <defs>
+    <style>text { font-family: 'Inter', 'Segoe UI', system-ui, sans-serif; }</style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="${SIZE}" height="${TOTAL_H}" fill="${COLORS.bg}" rx="12"/>
+
+  <!-- Board squares -->
+`;
+
+  for (let row = 0; row < COLS; row++) {
+    for (let col = 0; col < COLS; col++) {
+      const x = col * CELL;
+      const y = row * CELL;
+      const dark = isDark(row, col);
+      svg += `  <rect x="${x}" y="${y}" width="${CELL}" height="${CELL}" fill="${dark ? COLORS.dark_sq : COLORS.light_sq}"/>\n`;
+
+      // Piece
+      const v = cellAt(cells, row, col);
+      if (v !== 0) {
+        svg += renderPiece(x, y, v);
+      }
+    }
+  }
+
+  // Row/col coordinate labels (a–h, 1–8) outside the board
+  for (let i = 0; i < 8; i++) {
+    const letter = String.fromCharCode(97 + i); // a-h
+    svg += `  <text x="${i*CELL + CELL/2}" y="${SIZE - 3}" text-anchor="middle"
+      font-size="9" fill="${COLORS.text_muted}" opacity="0.7">${letter}</text>\n`;
+    svg += `  <text x="4" y="${i*CELL + CELL/2 + 4}" text-anchor="start"
+      font-size="9" fill="${COLORS.text_muted}" opacity="0.7">${8-i}</text>\n`;
+  }
+
+  // Board border
+  svg += `  <rect x="0" y="0" width="${SIZE}" height="${SIZE}" fill="none"
+    stroke="${COLORS.divider}" stroke-width="1.5" rx="0"/>\n`;
+
+  // Status bar
+  svg += `
+  <!-- Status bar -->
+  <rect x="0" y="${SIZE}" width="${SIZE}" height="80" fill="${COLORS.status_bar}"/>
+  <rect x="0" y="${SIZE}" width="${SIZE}" height="1.5" fill="${COLORS.divider}"/>
+
+  <!-- Status badge -->
+  <rect x="12" y="${SIZE+14}" width="190" height="32" rx="16" fill="${statusColor}22"/>
+  <text x="107" y="${SIZE+35}" text-anchor="middle" font-size="14" font-weight="600"
+        fill="${statusColor}">${statusText}</text>
+
+  <!-- Piece counts -->
+  <circle cx="${SIZE-110}" cy="${SIZE+30}" r="7" fill="${COLORS.p1_piece}"/>
+  <text x="${SIZE-98}" y="${SIZE+35}" font-size="13" fill="${COLORS.label_p1}">${p1} pieces</text>
+
+  <circle cx="${SIZE-50}" cy="${SIZE+30}" r="7" fill="${COLORS.p2_piece}"/>
+  <text x="${SIZE-38}" y="${SIZE+35}" font-size="13" fill="${COLORS.label_p2}">${p2}</text>
+
+  <!-- Cougr watermark -->
+  <text x="${SIZE/2}" y="${SIZE+65}" text-anchor="middle" font-size="10"
+        fill="${COLORS.text_muted}" letter-spacing="2">COUGR · CHECKERS · MOVE ${move_number}</text>
+`;
+
+  svg += `</svg>`;
+  return svg;
+}

--- a/tools/preview-gen/renderers/tic_tac_toe.js
+++ b/tools/preview-gen/renderers/tic_tac_toe.js
@@ -1,0 +1,150 @@
+/**
+ * Tic-tac-toe SVG renderer.
+ *
+ * Input state shape (from examples/tic_tac_toe/src/lib.rs :: GameState):
+ *   cells:      number[9]   — 0=empty, 1=X, 2=O  (row-major, index 0=top-left)
+ *   status:     number      — 0=in progress, 1=X wins, 2=O wins, 3=draw
+ *   is_x_turn:  boolean
+ *   move_count: number
+ *
+ * Produces a 400×480 SVG (board 400×400 + status bar 80px).
+ */
+
+const SIZE = 400;
+const CELL = SIZE / 3;       // 133.33…
+const PAD = 24;              // padding inside each cell for the X/O
+
+const COLORS = {
+  bg: '#0f172a',
+  grid: '#334155',
+  empty: '#1e293b',
+  x_fill: '#f43f5e',
+  x_win_fill: '#fda4af',
+  o_fill: '#38bdf8',
+  o_win_fill: '#93c5fd',
+  win_highlight: '#fef08a22',
+  status_bar_bg: '#1e293b',
+  status_text: '#f1f5f9',
+  badge_x: '#f43f5e',
+  badge_o: '#38bdf8',
+  badge_draw: '#94a3b8',
+  badge_ongoing: '#64748b',
+  label: '#64748b',
+};
+
+/** Calculate which cells are part of the winning line (for highlighting). */
+function winningCells(cells) {
+  const LINES = [
+    [0,1,2],[3,4,5],[6,7,8], // rows
+    [0,3,6],[1,4,7],[2,5,8], // cols
+    [0,4,8],[2,4,6],         // diagonals
+  ];
+  for (const [a,b,c] of LINES) {
+    if (cells[a] !== 0 && cells[a] === cells[b] && cells[a] === cells[c]) {
+      return new Set([a,b,c]);
+    }
+  }
+  return new Set();
+}
+
+function renderX(cx, cy, half, isWin) {
+  const color = isWin ? COLORS.x_win_fill : COLORS.x_fill;
+  const t = half - PAD;
+  return `
+    <line x1="${cx-t}" y1="${cy-t}" x2="${cx+t}" y2="${cy+t}"
+          stroke="${color}" stroke-width="14" stroke-linecap="round"/>
+    <line x1="${cx+t}" y1="${cy-t}" x2="${cx-t}" y2="${cy+t}"
+          stroke="${color}" stroke-width="14" stroke-linecap="round"/>
+  `;
+}
+
+function renderO(cx, cy, half, isWin) {
+  const color = isWin ? COLORS.o_win_fill : COLORS.o_fill;
+  const r = half - PAD - 4;
+  return `<circle cx="${cx}" cy="${cy}" r="${r}"
+            fill="none" stroke="${color}" stroke-width="12"/>`;
+}
+
+function statusLabel(status, isXTurn) {
+  if (status === 1) return { text: '✕  wins', color: COLORS.badge_x };
+  if (status === 2) return { text: '○  wins', color: COLORS.badge_o };
+  if (status === 3) return { text: 'Draw', color: COLORS.badge_draw };
+  return { text: isXTurn ? '✕  to move' : '○  to move', color: COLORS.badge_ongoing };
+}
+
+export function render(state) {
+  const { cells, status, is_x_turn, move_count } = state;
+  const won = winningCells(cells);
+  const half = CELL / 2;
+  const TOTAL_H = SIZE + 80;
+
+  // Background
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 ${SIZE} ${TOTAL_H}" width="${SIZE}" height="${TOTAL_H}">
+  <defs>
+    <style>
+      text { font-family: 'Inter', 'Segoe UI', system-ui, sans-serif; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="${SIZE}" height="${TOTAL_H}" fill="${COLORS.bg}" rx="12"/>
+
+  <!-- Board grid cells -->
+`;
+
+  // Draw cells
+  for (let i = 0; i < 9; i++) {
+    const row = Math.floor(i / 3);
+    const col = i % 3;
+    const x = col * CELL;
+    const y = row * CELL;
+    const cx = x + half;
+    const cy = y + half;
+    const isWinCell = won.has(i);
+
+    // Cell background
+    svg += `  <rect x="${x+2}" y="${y+2}" width="${CELL-4}" height="${CELL-4}"
+        fill="${isWinCell ? COLORS.win_highlight : COLORS.empty}" rx="4"/>\n`;
+
+    // Grid lines (right / bottom borders only, skip last)
+    if (col < 2) {
+      svg += `  <line x1="${x+CELL}" y1="${2}" x2="${x+CELL}" y2="${SIZE-2}"
+        stroke="${COLORS.grid}" stroke-width="3"/>\n`;
+    }
+    if (row < 2 && col === 0) {
+      svg += `  <line x1="${2}" y1="${y+CELL}" x2="${SIZE-2}" y2="${y+CELL}"
+        stroke="${COLORS.grid}" stroke-width="3"/>\n`;
+    }
+
+    // Piece
+    if (cells[i] === 1) svg += renderX(cx, cy, half, isWinCell);
+    if (cells[i] === 2) svg += renderO(cx, cy, half, isWinCell);
+  }
+
+  // Status bar
+  const { text: statusText, color: statusColor } = statusLabel(status, is_x_turn);
+  const moveLabel = `Move ${move_count}`;
+
+  svg += `
+  <!-- Status bar -->
+  <rect x="0" y="${SIZE}" width="${SIZE}" height="80" fill="${COLORS.status_bar_bg}" rx="0"/>
+  <rect x="0" y="${SIZE}" width="${SIZE}" height="2" fill="${COLORS.grid}"/>
+
+  <!-- Status badge -->
+  <rect x="16" y="${SIZE+16}" width="160" height="36" rx="18" fill="${statusColor}22"/>
+  <text x="96" y="${SIZE+40}" text-anchor="middle" font-size="15" font-weight="700"
+        fill="${statusColor}">${statusText}</text>
+
+  <!-- Move counter -->
+  <text x="${SIZE-16}" y="${SIZE+40}" text-anchor="end" font-size="13"
+        fill="${COLORS.label}">${moveLabel}</text>
+
+  <!-- Cougr watermark -->
+  <text x="${SIZE/2}" y="${SIZE+68}" text-anchor="middle" font-size="10"
+        fill="${COLORS.label}" letter-spacing="2">COUGR · TIC-TAC-TOE</text>
+`;
+
+  svg += `</svg>`;
+  return svg;
+}

--- a/tools/preview-gen/states/battleship.json
+++ b/tools/preview-gen/states/battleship.json
@@ -1,0 +1,29 @@
+{
+  "_source": "examples/battleship/src/test.rs — composite of test_attack_and_reveal_miss (lines 88-125) and test_attack_and_reveal_hit (lines 127-159) patterns. Extended to a representative mid-game state.",
+  "_description": "Mid-game attack-phase state. Player A has fired 8 shots; Player B has fired 6 shots. Cell index formula: y * 10 + x. Hit = ship cell revealed. Miss = empty cell revealed. Key reveals from tests: grid_b[0]=Miss (A attacks (0,0) on B's board); grid_b[10]=Hit (A attacks (0,1), ship present). Grid layout extended to show realistic attack spread.",
+  "_coord_formula": "index = y * 10 + x",
+  "grid_a": {
+    "11": "Hit",
+    "12": "Miss",
+    "21": "Miss",
+    "31": "Hit",
+    "32": "Miss",
+    "41": "Hit"
+  },
+  "grid_b": {
+    "0":  "Miss",
+    "10": "Hit",
+    "11": "Hit",
+    "20": "Miss",
+    "22": "Miss",
+    "33": "Hit",
+    "43": "Miss",
+    "53": "Miss"
+  },
+  "ship_remaining_a": 14,
+  "ship_remaining_b": 14,
+  "total_ships": 17,
+  "phase": "Attack",
+  "turn": "A",
+  "winner": null
+}

--- a/tools/preview-gen/states/checkers.json
+++ b/tools/preview-gen/states/checkers.json
@@ -1,0 +1,19 @@
+{
+  "_source": "examples/checkers/src/systems.rs :: initial_board (lines 202-218) + examples/checkers/src/test.rs :: test_init_sets_standard_start_position (lines 22-38)",
+  "_description": "Standard checkers opening position. P1 (value=1) occupies dark squares (row+col odd) in rows 0-2. P2 (value=-1) occupies dark squares in rows 5-7. Rows 3-4 are the empty middle zone. Verified against test_init_sets_standard_start_position assertions: (0,1)=1, (2,7)=1, (5,0)=-1, (7,6)=-1, (0,0)=0, (4,4)=0.",
+  "_board_layout": "8x8 grid, row-major. dark square = (row+col)%2==1. P1=1, P2=-1, empty=0",
+  "cells": [
+    0,  1,  0,  1,  0,  1,  0,  1,
+    1,  0,  1,  0,  1,  0,  1,  0,
+    0,  1,  0,  1,  0,  1,  0,  1,
+    0,  0,  0,  0,  0,  0,  0,  0,
+    0,  0,  0,  0,  0,  0,  0,  0,
+   -1,  0, -1,  0, -1,  0, -1,  0,
+    0, -1,  0, -1,  0, -1,  0, -1,
+   -1,  0, -1,  0, -1,  0, -1,  0
+  ],
+  "current_player": 1,
+  "move_number": 1,
+  "status": "Active",
+  "winner": 0
+}

--- a/tools/preview-gen/states/tic_tac_toe.json
+++ b/tools/preview-gen/states/tic_tac_toe.json
@@ -1,0 +1,15 @@
+{
+  "_source": "examples/tic_tac_toe/src/test.rs :: test_x_wins_row_top (lines 158-169)",
+  "_description": "X wins via the top row (cells 0,1,2). Derived from the move sequence: X→0, O→3, X→1, O→4, X→2.",
+  "_move_sequence": [
+    { "player": "X", "cell": 0 },
+    { "player": "O", "cell": 3 },
+    { "player": "X", "cell": 1 },
+    { "player": "O", "cell": 4 },
+    { "player": "X", "cell": 2 }
+  ],
+  "cells": [1, 1, 1, 2, 2, 0, 0, 0, 0],
+  "status": 1,
+  "is_x_turn": true,
+  "move_count": 5
+}


### PR DESCRIPTION

- Created `tools/preview-gen`: a zero-dependency Node.js SVG generator
- Implemented specific renderers for `tic_tac_toe`, `checkers`, and `battleship`
- Implemented a branded `category_fallback` for non-grid/real-time games
- Extracted canonical game states directly from `src/test.rs` assertions
  (e.g., `test_x_wins_row_top`) into JSON for provably honest previews
- Generated and checked in `preview.svg` for Tic-Tac-Toe, Checkers, and Battleship
- Updated `EXAMPLE_STANDARD.md` (added §9) to make generated previews a
  requirement for all canonical board/grid examples
- Added `Preview` column to the example catalog tables in `examples/README.md`
- Added comprehensive contributor guide in `tools/preview-gen/README.md`

Close #257 