### PR TITLE
feat(cli): scaffold cougr-cli workspace crate with clap command dispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "internal/cougr-core-circuits",
     "internal/cougr-core-session",
     "internal/cougr-core-test",
+    "cougr-cli",
 ]
 resolver = "2"
 

--- a/cougr-cli/Cargo.toml
+++ b/cougr-cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "cougr-cli"
+version = "0.1.0"
+edition = "2021"
+description = "Cougr CLI - scaffold, validate, and inspect Cougr on-chain game projects"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/salazarsebas/Cougr"
+homepage = "https://github.com/salazarsebas/Cougr"
+keywords = ["ecs", "game", "soroban", "blockchain", "stellar", "cli"]
+categories = ["game-engines", "command-line-utilities", "wasm"]
+rust-version = "1.70.0"
+publish = true
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+
+[[bin]]
+name = "cougr"
+path = "src/main.rs"

--- a/cougr-cli/README.md
+++ b/cougr-cli/README.md
@@ -1,0 +1,22 @@
+# cougr-cli
+
+The Cougr CLI — scaffold, validate, and inspect Cougr on-chain game projects.
+
+## Status
+
+Early development. Subcommand implementations are tracked in separate issues:
+
+- `cougr new`   — scaffold a new project (coming soon)
+- `cougr add`   — add a component/system pair to an existing project (coming soon)
+- `cougr check` — run hygiene and standard-compliance checks (coming soon)
+- `cougr doctor` — verify the local toolchain (coming soon)
+
+## Usage
+
+```bash
+cargo run -p cougr-cli -- --help
+```
+
+## License
+
+MIT

--- a/cougr-cli/src/main.rs
+++ b/cougr-cli/src/main.rs
@@ -1,0 +1,53 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(
+    name = "cougr",
+    about = "Cougr CLI — scaffold, validate, and inspect Cougr on-chain game projects",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Scaffold a new Soroban contract crate with cougr-core wired up
+    New {
+        /// Name of the project
+        name: String,
+    },
+    /// Pull a specific component/system pair into an existing project
+    Add {
+        /// Piece to add (e.g., session-auth, hidden-hand, standards/pausable)
+        piece: String,
+    },
+    /// Run hygiene and standard-compliance checks on the current project
+    Check,
+    /// Verify the local toolchain and give actionable fix instructions
+    Doctor,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::New { name } => {
+            eprintln!("error: 'cougr new' is not yet implemented (scaffolding {name})");
+            std::process::exit(1);
+        }
+        Commands::Add { piece } => {
+            eprintln!("error: 'cougr add' is not yet implemented (adding {piece})");
+            std::process::exit(1);
+        }
+        Commands::Check => {
+            eprintln!("error: 'cougr check' is not yet implemented");
+            std::process::exit(1);
+        }
+        Commands::Doctor => {
+            eprintln!("error: 'cougr doctor' is not yet implemented");
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Closes #243 

## Description

Scaffold the `cougr-cli` binary crate as a new workspace member with a `clap`-based argument parser and four subcommand stubs (`new`, `add`, `check`, `doctor`). Each stub prints a "not yet implemented" message and exits non-zero, providing a concrete integration point for follow-up issues to implement the actual logic.

Part of #243

## Implementation approach

The CLI uses `clap` derive for ergonomic subcommand routing and auto-generated `--help` / `--version` output. The binary name is `cougr`, installed via `cargo install cougr-cli`. The crate is `publish = true` and lives in the root of the workspace alongside `cougr-core`.

### Subcommand stubs

| Subcommand | Status | Exit code | Description |
|---|---|---|---|
| `cougr new <name>` | Stub | 1 | Scaffold a new Soroban contract crate |
| `cougr add <piece>` | Stub | 1 | Pull a component/system pair into an existing project |
| `cougr check` | Stub | 1 | Run hygiene and standard-compliance checks |
| `cougr doctor` | Stub | 1 | Verify the local toolchain |

## Changes

- **`cougr-cli/Cargo.toml`** — New binary crate with `clap` derive, MIT license, `publish = true`, metadata consistent with `cougr-core` conventions
- **`cougr-cli/src/main.rs`** — `clap` derive argument parser with 4 subcommand stubs
- **`cougr-cli/README.md`** — Minimal stub with usage and status
- **`Cargo.toml`** — Added `"cougr-cli"` to workspace `members`

## Verification

```bash
cargo run -p cougr-cli -- --help
cargo run -p cougr-cli -- --version
cargo run -p cougr-cli -- new my-game    # exits 1
cargo run -p cougr-cli -- add session-auth  # exits 1
cargo run -p cougr-cli -- check          # exits 1
cargo run -p cougr-cli -- doctor         # exits 1
cargo clippy -p cougr-cli -- -D warnings
cargo build --workspace
```

## Out of scope

- Actual subcommand logic — each has a dedicated follow-up issue
- CI / publish pipeline wiring — tracked in a dedicated CI sub-issue
