### PR TITLE
docs: add Cougr glossary and terminology voice guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ Documentation should be professional, current, and proportionate:
 - explain decisions and usage patterns without turning every page into a long-form essay
 - use tables when they improve scanability, not as a default for all content
 - keep root-level documentation limited to material with clear long-term value
+- follow the terminology and voice rules in [docs/VOICE_GUIDE.md](docs/VOICE_GUIDE.md) for all doc, example, and marketing copy
 
 ## Pull Requests
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,226 @@
+# Cougr Glossary
+
+## Purpose
+
+This document defines every Cougr-specific term precisely. Terms are used consistently across architecture docs, API contracts, examples, and the maturity model. If a term is not listed here, it is used in its ordinary English or Rust/Soroban sense.
+
+---
+
+## A
+
+### AccountKernel
+The orchestrator that runs signer verification, policy checks, and replay protection for the account subsystem. Lives in the `auth` / `accounts` namespace (Beta).
+
+### Archetype (in ArchetypeWorld)
+The signature (set of component types) that defines an entity group in `ArchetypeWorld`. Entities sharing the same archetype are stored contiguously for efficient batch queries.
+
+### ArchetypeWorld
+Alternate ECS world backend that groups entities by component signature (archetype). Best for large entity counts and multi-component queries where structural-change cost is acceptable. Shares the `ComponentTrait` interface with `SimpleWorld`.
+
+### AuthResult
+Structured authorization result returned by the account kernel. Includes the method used, nonce consumed, session key id, and remaining operations.
+
+---
+
+## B
+
+### Beta
+Maturity level for features that are usable and actively supported but expected to evolve outside the stable guarantee. Not SemVer-frozen. See [MATURITY_MODEL.md](MATURITY_MODEL.md).
+
+---
+
+## C
+
+### Canonical example
+A maintained reference architecture held to the full [EXAMPLE_STANDARD.md](../examples/EXAMPLE_STANDARD.md). Stays current as `cougr-core` evolves.
+
+### Change tracker
+Per-component dirty-flag system that records which entities had components modified since the last sweep. Used by incremental storage to persist only dirty entities.
+
+### CommandQueue
+Deferred structural-mutation buffer. Systems queue `spawn_entity`, `despawn_entity`, `add_component`, `remove_component` operations here instead of mutating the world directly during iteration.
+
+### Commit-reveal
+Pattern for hidden information. A player commits to a secret value (publishing a hash or Pedersen commitment), then later reveals the value and proves it matches the commitment. Supported by `privacy::stable`.
+
+### Component
+Typed or raw data attached to an ECS entity. Defined via one of three macros: `impl_component!` (fixed-size primitives), `impl_component_observed!` (same + Soroban events on every `set`), or `impl_rich_component!` (complex XDR types like `Address`, `Vec`, `String`). Per ECS convention, never called "entity data" or "property."
+
+### Contract
+A Soroban smart contract built on Cougr. The project standard is to say "contract" after first use, never "smart contract" in subsequent references.
+
+### Contract layer
+The `game::SorobanGame` integration layer that bridges the ECS world model and Soroban contract entrypoints.
+
+### Curated surface
+The defended set of public APIs that are part of Cougr's `1.0` stable contract. Documented in [API_CONTRACT.md](API_CONTRACT.md). Not every public Rust symbol is curated; only the documented stable namespaces are.
+
+---
+
+## D
+
+### Default runtime surface
+`app::GameApp` — the recommended entrypoint for new multi-system contracts. Provides stage-based scheduling, plugin registration, and runtime resource management.
+
+---
+
+## E
+
+### Entity
+An opaque runtime identity in the ECS. Entities have no data of their own; components are attached to them. Created via `world.spawn_entity()`, destroyed via `world.despawn_entity()`.
+
+### Experimental
+Maturity level for features that are exploratory, fast-moving, and not part of Cougr's stable promise. May change or be removed without compatibility guarantees. See [MATURITY_MODEL.md](MATURITY_MODEL.md).
+
+---
+
+## G
+
+### GameApp
+App-level orchestration that owns a `SimpleWorld`, scheduler, plugin registration, and runtime resources in one place. The default entrypoint for complex games. Lives in `cougr_core::app`.
+
+---
+
+## H
+
+### Hidden state
+Private game state encoded for selective disclosure. Players hold commitments or Merkle roots of hidden state and reveal only the subset needed for a given verification. Distinct from "secret" or "off-chain" state — hidden state is on-chain but unreadable without the reveal key.
+
+### Hooks
+Callbacks triggered on component `add` / `remove` events. A synchronous mechanism for enforcing invariants when components change.
+
+---
+
+## I
+
+### impl_component!
+Macro for fixed-size primitive components (e.g., `i32`, `u32`, `u64`, `bool`, `bytes32`). Stores directly in table storage.
+
+### impl_component_observed!
+Same as `impl_component!` but emits a structured `(COUGR, set, <name>)` Soroban event on every mutation. Used when off-chain indexers need to track state changes without polling.
+
+### impl_rich_component!
+Macro for complex types using Soroban's XDR codec. Supports `Address`, `Vec`, `String`, `Option`, and nested structs. Requires `#[contracttype]` on the struct.
+
+### Incremental storage
+Persistence layer that only flushes entities with dirty components (tracked by the change tracker). Reduces storage writes on large worlds where only a subset of entities change per tick.
+
+---
+
+## K
+
+### Kernel. See AccountKernel.
+
+---
+
+## M
+
+### Maturity model
+The Stable / Beta / Experimental classification system governing compatibility promises, documentation depth, and test coverage across Cougr's public surfaces. Defined in [MATURITY_MODEL.md](MATURITY_MODEL.md). These three terms must be used identically everywhere — never synonyms ("production-ready" for Stable, "unstable" for Experimental, etc.).
+
+### Merkle proof
+An inclusion proof against a Merkle tree root. Used in hidden-information games (fog-of-war, private inventory) to prove state membership without full disclosure. Supported as a stable primitive in `privacy::stable`.
+
+---
+
+## O
+
+### Observed component
+A component defined with `impl_component_observed!` that emits structured Soroban events (topic prefix `COUGR`) on every `set` operation. The canonical choice when off-chain clients need to react to state changes.
+
+### Observers
+Event-driven reaction mechanism. Unlike hooks (synchronous, component-lifecycle), observers respond to arbitrary application-level events across system boundaries.
+
+---
+
+## P
+
+### Plugin
+A modular bundle of game logic (systems + setup) registered with `GameApp`. Enables composable feature toggles without editing core schedule code.
+
+### Policy
+Reusable authorization check in the account kernel. Base implementations: `IntentExpiryPolicy`, `SessionPolicy`, `ActiveDevicePolicy`, `GuardianPolicy`. Composed by the `AccountKernel` to enforce auth rules.
+
+---
+
+## Q
+
+### Query
+A declarative selection over entities by component presence. Cougr provides `SimpleQuery` / `SimpleQueryBuilder` for `SimpleWorld` and `ArchetypeQueryBuilder` for `ArchetypeWorld`. Both support `with_components`, `without_components`, and `with_any_components` filters.
+
+### Query cache
+Version-tagged result cache that invalidates on world mutation. Avoids re-scanning entities when the same query runs with no intervening writes.
+
+---
+
+## R
+
+### Replay domain
+Nonce tracking namespace. Cougr uses two replay domains: per-account nonce tracking (for direct owner auth and passkey auth) and per-session nonce tracking (for session intents).
+
+### Rich component
+A component using Soroban's XDR codec (via `impl_rich_component!`). Supports `Address`, `Vec`, `String`, `Option`, and nested structs. Stored in Soroban instance storage, not the ECS `Map`, but shares the same entity ID space.
+
+### RuntimeWorld / RuntimeWorldMut
+The shared trait contracts that both `SimpleWorld` and `ArchetypeWorld` implement. The backend-agnostic interface for Soroban-first worlds.
+
+---
+
+## S
+
+### Scheduler
+Stage-based, dependency-aware system ordering engine. `SimpleScheduler` runs systems in declared stage order (`Startup`, `PreUpdate`, `Update`, `PostUpdate`, `Cleanup`) with intra-stage `before`/`after` constraints.
+
+### Session key
+A scoped cryptographic key authorized for a limited set of actions, operation budget, and expiry window. Created via `SessionBuilder` (fluent API). Players interact without re-authorizing every action. The session UX pattern is Beta.
+
+### SignedIntent
+Structured authorization payload binding target account, signer reference, action payload, nonce, expiry, deterministic `action_hash`, and proof material. The canonical input to the `AccountKernel`.
+
+### Signer
+Base authorization implementation in the account subsystem. Variants: direct owner signer (`require_auth`), session signer (non-fallback session path), and secp256r1 passkey signer (WebAuthn/Passkey).
+
+### SimpleWorld
+Table-backed ECS world backend. Uses a `Map<(EntityId, Symbol), Bytes>` with dual table/sparse indexes. Best for general use with modest entity counts. The recommended default for new projects.
+
+### SimpleQuery / SimpleQueryBuilder
+Query builder API for `SimpleWorld`. Supports required components, negative filters, any-of matching, and sparse-component inclusion.
+
+### SorobanGame
+Trait providing `load_world` and `save_world` as default methods, eliminating repetitive storage-key boilerplate from contract entrypoints. Wired up once with `impl_soroban_game!`.
+
+### Sparse storage
+Storage tier for infrequent marker components, administrative tags, and data accessed via targeted lookups rather than broad scans. Complement to table storage.
+
+### Stable
+Maturity level for features that are SemVer-protected, documented with invariants and intended usage, covered by focused tests, and safe to present as part of Cougr's long-term public contract. See [MATURITY_MODEL.md](MATURITY_MODEL.md).
+
+### Standards layer
+Reusable contract primitives (Ownable, AccessControl, Pausable, ExecutionGuard, RecoveryGuard, BatchExecutor, DelayedExecutionPolicy) keyed by `Symbol` for deterministic storage. Stable. Also exposed as `ops`, the preferred domain alias.
+
+### System
+Logic that reads or mutates the world, registered into named stages. Prefer small systems with one responsibility (validation, state transition, cleanup). Per ECS convention, never called "script," "handler," or "processor."
+
+---
+
+## T
+
+### Table storage
+Storage tier for frequently scanned gameplay state and components used by `Update` systems on most ticks. The default storage for `impl_component!` and `impl_component_observed!`.
+
+### Transitional example
+An example written before the current standard or intentionally preserving an older pattern for compatibility reference. Still passes `cargo test` and `stellar contract build` but may not follow the latest module structure or README depth.
+
+---
+
+## X
+
+### X-Ray host functions
+Stellar Protocol 25 host functions for Groth16 (BN254) and BLS12-381 cryptographic operations. Run on the Soroban host, not in WASM. Enable cheap ZK proof verification for on-chain games.
+
+---
+
+## Z
+
+### ZK proofs (zero-knowledge proofs)
+Cryptographic proofs enabling hidden-state verification on-chain. Cougr bundles Groth16 (BN254 pairing), BLS12-381, Poseidon2 hashing, Merkle trees, Pedersen commitments, and prebuilt game circuits. Stable subset in `privacy::stable`; advanced verification in `privacy::experimental`.

--- a/docs/VOICE_GUIDE.md
+++ b/docs/VOICE_GUIDE.md
@@ -1,0 +1,87 @@
+# Cougr Voice & Terminology Guide
+
+## Purpose
+
+This guide captures the small set of enforced terminology and voice rules that Cougr documentation follows. New documentation, examples, marketing copy, and showcase text must conform to these rules.
+
+These rules are derived from actual usage in Cougr's strongest existing documentation — they codify what the project already does implicitly, not invented conventions.
+
+---
+
+## Enforced Terminology
+
+| Always say | Never say | Why |
+|---|---|---|
+| **contract** (after first use) | "smart contract" (after first reference) | "smart contract" is fine on first mention for discoverability; all subsequent references use "contract" alone. The project's strongest docs already do this. |
+| **component** | "entity data", "property", "field" | Per ECS convention. Components are the typed data attached to entities. |
+| **system** | "script", "handler", "processor" | Per ECS convention. Systems are the logic operating on entities via their components. |
+| **entity** | "object", "game object", "thing" | Per ECS convention. Entities are opaque runtime identities. |
+| **world** | "store", "database" | World is the ECS storage backend, not a generic persistence term. |
+| **Stable** | "production-ready", "locked", "finished" | Stable is a specific maturity tier (SemVer-protected, documented, tested). Use the maturity-model term exactly. |
+| **Beta** | "unstable", "in development", "almost ready" | Beta is a specific maturity tier (usable, supported, evolving). Use the maturity-model term exactly. |
+| **Experimental** | "alpha", "unstable", "proof of concept" | Experimental is a specific maturity tier (exploratory, no compatibility promise). Use the maturity-model term exactly. |
+| **privacy::stable** | "zk::stable" (in new docs) | Both namespaces exist, but `privacy::stable` is the preferred domain-facing path for new documentation. |
+| **auth** | "accounts" (in application-facing docs) | Both namespaces exist, but `auth` is the clearer Beta-facing domain alias. Use `auth` in onboarding and reference docs. |
+| **ops** | "standards" (in application-facing docs) | Both namespaces exist, but `ops` is the clearer stable domain alias. Use `ops` in onboarding and reference docs. |
+| **GameApp** (code font) | "game app", "Game App" | The type name `GameApp` is always in code font or backticks. |
+| **plugin** | "addon", "module", "extension" | Plugins are the composable bundle mechanism in `GameApp`. |
+| **canonical example** | "main example", "primary example", "core example" | Examples are classified as canonical (maintained reference) or transitional (older patterns). "Canonical" is the precise term. |
+| **transitional example** | "legacy example", "old example" | "Transitional" precisely indicates the example preserves an older pattern for compatibility, not that it is abandoned. |
+| **curated surface** | "stable API", "public API" (when referring to the 1.0 contract) | The curated surface is the *defended* subset of public APIs — not every public symbol is curated. Prefer "curated surface" to avoid overpromising. |
+
+---
+
+## Voice Principles
+
+### 1. Honest-by-default
+
+State gaps plainly rather than marketing around them. If a feature is Beta, say "Beta" — not "stable with some evolution expected." If a verification path is Experimental, say "Experimental" — not "advanced but reliable." This is Cougr's strongest differentiator as a documentation culture.
+
+### 2. Precise over playful
+
+Cougr is infrastructure (an on-chain game engine), not a game itself. Documentation should read closer to Linear or Vercel's developer docs than to a flashy Web3 project's landing page. Avoid:
+- Game-themed metaphors for technical concepts ("power up your contract!")
+- Exclamation points in technical explanations
+- Unnecessary superlatives
+
+### 3. Consistent maturity labels
+
+Whenever a feature, namespace, or API is mentioned, its maturity tier (Stable / Beta / Experimental) must be named or clearly scoped by context. Never present a Beta surface without its maturity label in the same paragraph or table.
+
+### 4. Namespace aliases are explained once
+
+When a new namespace alias exists (`ops` for `standards`, `auth` for `accounts`, `privacy::stable` for `zk::stable`), explain the relationship once in the relevant document and then consistently use the preferred alias. Do not flip back and forth within the same page.
+
+---
+
+## Formatting Conventions
+
+| Element | Formatting |
+|---|---|
+| Rust types, macros, traits, function names | Code font / backticks |
+| Namespace paths (`cougr_core::app`) | Code font / backticks |
+| Maturity tiers (Stable, Beta, Experimental) | Title case, no backticks |
+| The project name "Cougr" | Title case, no backticks |
+| ECS terms (component, system, entity, world) | Lowercase when used conceptually, code font when referring to the Rust type |
+| Example names (`spawn_and_move`) | Code font / backticks |
+
+---
+
+## Cross-Reference Check
+
+This voice guide was cross-checked against the source-of-truth documents before publication. The following minor inconsistencies were identified and flagged for cleanup:
+
+| Document | Issue | Fix |
+|---|---|---|
+| `ARCHITECTURE.md:87` | "smart contract wallet" uses full phrase after first reference | Should be "contract wallet" for consistency (future PR) |
+| `README.md:19` | "contract standards" is correct | No fix needed |
+| `ECS_CORE.md:14` | Lists `SimpleQuery` in recommended path, while code examples use `SimpleQueryBuilder` | Both are valid, but the list should use `SimpleQueryBuilder` to match usage (future PR) |
+
+---
+
+## Required Reference
+
+All documentation contributors must read:
+- [MATURITY_MODEL.md](MATURITY_MODEL.md) — the three maturity tier definitions (Stable, Beta, Experimental)
+- [GLOSSARY.md](GLOSSARY.md) — full term definitions
+- This voice guide — terminology and voice rules above


### PR DESCRIPTION
##closes #261 

## Overview
This PR establishes a single source of truth for Cougr-specific vocabulary and voice guidelines to prevent documentation drift across the docs site, showcase, and marketing materials. 

It defines core architecture terms (like `world`, `archetype`, and `session key`) and enforces strict terminology rules grounded in existing project conventions (e.g., using `contract` instead of `smart contract` after first mention).

## Changes Included
- **Glossary Page**: Added a comprehensive glossary defining key Cougr terms including *component, system, world, archetype, session key, observed component,* and *curated surface* based on `ARCHITECTURE.md`, `ECS_CORE.md`, and `ACCOUNT_KERNEL.md`.
- **Voice & Terminology Guide**: Created a "say this, not that" style guide establishing rules for terminology consistency and maturity levels (*Stable / Beta / Experimental*) cross-referenced from `docs/MATURITY_MODEL.md`.
- **Contributor Integration**: Linked the new Voice Guide within `CONTRIBUTING.md` for future doc authors.
- **Cross-Doc Verification**: Ensured consistent usage against current tutorial and boundary guide drafts.

## Key References
- Follows specification from `docs/strategy/09-design-strategy.md`
- Codifies usage from `ARCHITECTURE.md`, `ECS_CORE.md`, and `ACCOUNT_KERNEL.md`
- Uses maturity status definitions from `docs/MATURITY_MODEL.md`

## Out of Scope
- Linter enforcement tooling (`cougr-docs-lint`), which will be handled separately in a subsequent phase per `docs/strategy/11-skills-strategy.md`.

## Definition of Done Verification
- [x] Glossary covers all core terms specified in the issue background.
- [x] Voice guide is published and linked directly from `CONTRIBUTING.md`.
- [x] No terminology contradictions exist across sibling guides.