### PR TITLE
feat(cli): implement cougr doctor toolchain diagnostics (#247)

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -8,6 +8,7 @@ on:
       - 'internal/**'
       - 'tests/**'
       - 'benches/**'
+      - 'cli/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/core.yml'
@@ -19,6 +20,7 @@ on:
       - 'internal/**'
       - 'tests/**'
       - 'benches/**'
+      - 'cli/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/core.yml'
@@ -59,3 +61,9 @@ jobs:
 
       - name: Build library
         run: cargo build
+
+      - name: Run hygiene check (cli)
+        run: cargo run --bin cougr -- check --path .
+
+      - name: Run verified check (canonical examples)
+        run: cargo run --bin cougr -- check --path . --verified --canonical-only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +31,62 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -264,6 +329,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +385,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cougr-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "regex",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cougr-core"
@@ -818,6 +940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1218,35 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
@@ -1578,6 +1741,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1813,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -1834,6 +2014,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "internal/cougr-core-circuits",
     "internal/cougr-core-session",
     "internal/cougr-core-test",
+    "cli",
 ]
 resolver = "2"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cougr-cli"
+version = "0.1.0"
+edition = "2021"
+description = "Cougr CLI — hygiene and development tooling for the Cougr ECS framework"
+license = "MIT"
+publish = false
+
+[[bin]]
+name = "cougr"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+regex = "1"
+anyhow = "1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,3 +14,5 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 regex = "1"
 anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/cli/src/check.rs
+++ b/cli/src/check.rs
@@ -1,0 +1,411 @@
+//! Hygiene check logic for `cougr check`.
+//!
+//! Mirrors the checks in `scripts/verify_hygiene.sh` and
+//! `scripts/enforce_hygiene.sh`, ported to Rust for cross-platform
+//! operation with no external script dependencies (shells out only for
+//! `git ls-files` and `cargo metadata`, which are required regardless).
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{exit, Command};
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run hygiene checks.
+///
+/// * `explicit_root` — if `Some`, use this as the repo root.
+/// * `single_example` — if `Some`, only check this named example (requires
+///   repo-root context to locate `examples/<name>/`).
+pub fn run(explicit_root: Option<&str>, single_example: Option<&str>) -> Result<()> {
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+
+    let (repo_root, examples) = resolve_context(&cwd, explicit_root, single_example)?;
+
+    println!("=== Cougr Hygiene Check ===");
+    println!("Repository root : {}", repo_root.display());
+    if examples.len() == 1 {
+        println!("Checking example: {}", examples[0].name);
+    } else {
+        println!("Checking        : {} examples", examples.len());
+    }
+    println!();
+
+    let mut failures: Vec<String> = Vec::new();
+
+    // Root-level checks always run — tracked artifacts and root .gitignore
+    // issues would fail CI regardless of which example is being checked.
+
+    // Check 1 — root .gitignore must NOT ignore Cargo.lock
+    check_root_gitignore_cargo_lock(&repo_root, &mut failures);
+
+    // Check 2 & 3 — no tracked build artifacts (git ls-files)
+    check_tracked_artifacts(&repo_root, &mut failures);
+
+    // Per-example checks
+    for ex in &examples {
+        let example_dir = repo_root.join("examples").join(&ex.name);
+
+        // Check 4 — no hardcoded contract IDs in README
+        check_readme_contract_ids(&example_dir, &ex.name, &mut failures);
+
+        // Check 5 — .gitignore exists and has target/
+        check_example_gitignore(&example_dir, &ex.name, &mut failures);
+
+        // Check 6 — .gitignore must NOT ignore Cargo.lock
+        check_example_gitignore_cargo_lock(&example_dir, &ex.name, &mut failures);
+
+        // Check 7 — Cargo.toml has description
+        check_cargo_toml_description(&example_dir, &ex.name, &mut failures);
+
+        // Check 8 — cargo metadata --no-deps
+        check_cargo_metadata(&example_dir, &ex.name, &mut failures);
+    }
+
+    // Report
+    if failures.is_empty() {
+        println!("=== ALL CHECKS PASSED ===");
+        Ok(())
+    } else {
+        eprintln!();
+        eprintln!("=== {} CHECK(S) FAILED ===", failures.len());
+        for f in &failures {
+            eprintln!("  FAIL: {}", f);
+        }
+        exit(1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Context resolution
+// ---------------------------------------------------------------------------
+
+struct Example {
+    name: String,
+}
+
+/// Determine the repo root and which examples to check.
+fn resolve_context(
+    cwd: &Path,
+    explicit_root: Option<&str>,
+    single_example: Option<&str>,
+) -> Result<(PathBuf, Vec<Example>)> {
+    // 1. Determine repo root
+    let repo_root = if let Some(r) = explicit_root {
+        let p = PathBuf::from(r);
+        p.canonicalize()
+            .context(format!("explicit --path does not exist: {}", r))?
+    } else {
+        find_repo_root(cwd)?
+    };
+
+    // 2. Determine examples to check
+    if let Some(name) = single_example {
+        let example_dir = repo_root.join("examples").join(&name);
+        if !example_dir.is_dir() {
+            anyhow::bail!("example '{}' not found at {}", name, example_dir.display());
+        }
+        return Ok((repo_root, vec![Example { name }]));
+    }
+
+    // Auto-detect: if cwd is inside examples/<name>/, just check that one.
+    // Only auto-detect when no explicit --path was given, to avoid confusing
+    // interactions (e.g. user specifies --path but happens to be sitting in
+    // an example directory).
+    if explicit_root.is_none() && is_inside_example_dir(cwd) {
+        if let Some(parent) = cwd.parent() {
+            if parent.file_name().map(|n| n == "examples").unwrap_or(false) {
+                if let Some(name) = cwd.file_name().and_then(|n| n.to_str()) {
+                    return Ok((repo_root, vec![Example { name: name.to_string() }]));
+                }
+            }
+        }
+    }
+
+    // Otherwise, discover all examples
+    let examples_dir = repo_root.join("examples");
+    let mut examples = Vec::new();
+    if examples_dir.is_dir() {
+        for entry in fs::read_dir(&examples_dir).context("cannot read examples/ directory")? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                let dir_name = entry.file_name();
+                if let Some(name) = dir_name.to_str() {
+                    // Only include directories that have a Cargo.toml (actual examples)
+                    if entry.path().join("Cargo.toml").is_file() {
+                        examples.push(Example {
+                            name: name.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    if examples.is_empty() {
+        anyhow::bail!("no examples found under {}", examples_dir.display());
+    }
+
+    Ok((repo_root, examples))
+}
+
+/// Walk upward from `cwd` looking for a directory that contains both
+/// `Cargo.toml` and an `examples/` subdirectory (the repo root).
+fn find_repo_root(cwd: &Path) -> Result<PathBuf> {
+    let mut current = cwd.to_path_buf();
+    loop {
+        if current.join("Cargo.toml").is_file() && current.join("examples").is_dir() {
+            return Ok(current);
+        }
+        if !current.pop() {
+            anyhow::bail!(
+                "could not find repo root (no Cargo.toml + examples/ found above {:?}). \
+                 Use --path to specify the repo root explicitly.",
+                cwd
+            );
+        }
+    }
+}
+
+/// True when `cwd` is inside an `examples/<name>/` directory.
+fn is_inside_example_dir(cwd: &Path) -> bool {
+    if let Some(parent) = cwd.parent() {
+        parent.file_name().map(|n| n == "examples").unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+/// Check 1: root `.gitignore` must NOT ignore `Cargo.lock`.
+fn check_root_gitignore_cargo_lock(repo_root: &Path, failures: &mut Vec<String>) {
+    let gitignore = repo_root.join(".gitignore");
+    match fs::read_to_string(&gitignore) {
+        Ok(contents) => {
+            let re = Regex::new(r"(?m)^Cargo\.lock$").unwrap();
+            if re.is_match(&contents) {
+                failures.push(
+                    "root .gitignore must not ignore Cargo.lock (examples are applications)"
+                        .to_string(),
+                );
+            }
+        }
+        Err(e) => {
+            failures.push(format!("cannot read root .gitignore: {}", e));
+        }
+    }
+}
+
+/// Checks 2 & 3: no tracked `target/` directories or `.wasm` files in examples/.
+fn check_tracked_artifacts(repo_root: &Path, failures: &mut Vec<String>) {
+    // Check for tracked target/ artifacts
+    match run_git_ls_files(repo_root, "examples/**/target/**") {
+        Ok(output) => {
+            let trimmed = output.trim();
+            if !trimmed.is_empty() {
+                failures.push(format!(
+                    "tracked target/ artifacts found:\n{}",
+                    indent_lines(trimmed, "    ")
+                ));
+            }
+        }
+        Err(e) => {
+            failures.push(format!("failed to check for tracked target/ artifacts: {}", e));
+        }
+    }
+
+    // Check for tracked .wasm artifacts
+    match run_git_ls_files(repo_root, "examples/**/*.wasm") {
+        Ok(output) => {
+            let trimmed = output.trim();
+            if !trimmed.is_empty() {
+                failures.push(format!(
+                    "tracked .wasm artifacts found:\n{}",
+                    indent_lines(trimmed, "    ")
+                ));
+            }
+        }
+        Err(e) => {
+            failures.push(format!(
+                "failed to check for tracked .wasm artifacts: {}",
+                e
+            ));
+        }
+    }
+}
+
+/// Check 4: no hardcoded contract IDs (`C[A-Z2-7]{55}`) in example READMEs.
+fn check_readme_contract_ids(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+    let readme = example_dir.join("README.md");
+    if !readme.is_file() {
+        // No README — not a hygiene failure per se (some examples might legitimately lack one),
+        // but the EXAMPLE_STANDARD requires it. We flag a separate, softer warning via
+        // the description check or similar. For now, skip.
+        return;
+    }
+
+    match fs::read_to_string(&readme) {
+        Ok(contents) => {
+            let re = Regex::new(r"C[A-Z2-7]{55}").unwrap();
+            if re.is_match(&contents) {
+                failures.push(format!(
+                    "hardcoded contract ID(s) in examples/{}/README.md",
+                    name
+                ));
+            }
+        }
+        Err(e) => {
+            failures.push(format!("cannot read examples/{}/README.md: {}", name, e));
+        }
+    }
+}
+
+/// Check 5: each example must have a `.gitignore` containing `target/`.
+fn check_example_gitignore(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+    let gitignore = example_dir.join(".gitignore");
+    if !gitignore.is_file() {
+        failures.push(format!("examples/{}: missing .gitignore", name));
+        return;
+    }
+
+    match fs::read_to_string(&gitignore) {
+        Ok(contents) => {
+            let re = Regex::new(r"(?m)^target/").unwrap();
+            if !re.is_match(&contents) {
+                failures.push(format!(
+                    "examples/{}: .gitignore does not ignore target/",
+                    name
+                ));
+            }
+        }
+        Err(e) => {
+            failures.push(format!(
+                "examples/{}: cannot read .gitignore: {}",
+                name, e
+            ));
+        }
+    }
+}
+
+/// Check 6: example `.gitignore` must NOT ignore `Cargo.lock`.
+fn check_example_gitignore_cargo_lock(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+    let gitignore = example_dir.join(".gitignore");
+    if !gitignore.is_file() {
+        // Already flagged by check_example_gitignore; don't double-report.
+        return;
+    }
+
+    match fs::read_to_string(&gitignore) {
+        Ok(contents) => {
+            let re = Regex::new(r"(?m)^Cargo\.lock$").unwrap();
+            if re.is_match(&contents) {
+                failures.push(format!(
+                    "examples/{}: .gitignore must not ignore Cargo.lock (examples are applications)",
+                    name,
+                ));
+            }
+        }
+        Err(e) => {
+            failures.push(format!(
+                "examples/{}: cannot read .gitignore: {}",
+                name, e
+            ));
+        }
+    }
+}
+
+/// Check 7: `Cargo.toml` must have a non-empty `description` field.
+fn check_cargo_toml_description(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+    let cargo_toml = example_dir.join("Cargo.toml");
+    if !cargo_toml.is_file() {
+        failures.push(format!("examples/{}: missing Cargo.toml", name));
+        return;
+    }
+
+    match fs::read_to_string(&cargo_toml) {
+        Ok(contents) => {
+            let re = Regex::new(r#"(?m)^description\s*=\s*"([^"]*)""#).unwrap();
+            if let Some(caps) = re.captures(&contents) {
+                let desc = &caps[1];
+                if desc.trim().is_empty() {
+                    failures.push(format!(
+                        "examples/{}: Cargo.toml description field is empty",
+                        name
+                    ));
+                }
+            } else {
+                failures.push(format!(
+                    "examples/{}: Cargo.toml is missing a description field",
+                    name
+                ));
+            }
+        }
+        Err(e) => {
+            failures.push(format!(
+                "examples/{}: cannot read Cargo.toml: {}",
+                name, e
+            ));
+        }
+    }
+}
+
+/// Check 8: `cargo metadata --no-deps` must succeed.
+fn check_cargo_metadata(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(example_dir)
+        .output();
+
+    match output {
+        Ok(out) => {
+            if !out.status.success() {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                failures.push(format!(
+                    "examples/{}: cargo metadata --no-deps FAILED:\n{}",
+                    name,
+                    indent_lines(stderr.trim(), "    ")
+                ));
+            }
+        }
+        Err(e) => {
+            failures.push(format!(
+                "examples/{}: cannot run cargo metadata: {}",
+                name, e
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Run `git ls-files <pattern>` from `cwd` and return stdout.
+fn run_git_ls_files(cwd: &Path, pattern: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["ls-files", pattern])
+        .current_dir(cwd)
+        .output()
+        .context("failed to run git ls-files")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git ls-files failed: {}", stderr.trim());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Indent every non-empty line by `prefix`.
+fn indent_lines(s: &str, prefix: &str) -> String {
+    s.lines()
+        .map(|l| format!("{}{}", prefix, l))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/cli/src/check.rs
+++ b/cli/src/check.rs
@@ -123,11 +123,7 @@ fn check_tracked_artifacts(repo_root: &Path, failures: &mut Vec<String>) {
 }
 
 /// Check 4: no hardcoded contract IDs (`C[A-Z2-7]{55}`) in example READMEs.
-pub fn check_readme_contract_ids(
-    example_dir: &Path,
-    name: &str,
-    failures: &mut Vec<String>,
-) {
+pub fn check_readme_contract_ids(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
     let readme = example_dir.join("README.md");
     if !readme.is_file() {
         return;
@@ -150,11 +146,7 @@ pub fn check_readme_contract_ids(
 }
 
 /// Check 5: each example must have a `.gitignore` containing `target/`.
-pub fn check_example_gitignore(
-    example_dir: &Path,
-    name: &str,
-    failures: &mut Vec<String>,
-) {
+pub fn check_example_gitignore(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
     let gitignore = example_dir.join(".gitignore");
     if !gitignore.is_file() {
         failures.push(format!("examples/{}: missing .gitignore", name));
@@ -172,20 +164,13 @@ pub fn check_example_gitignore(
             }
         }
         Err(e) => {
-            failures.push(format!(
-                "examples/{}: cannot read .gitignore: {}",
-                name, e
-            ));
+            failures.push(format!("examples/{}: cannot read .gitignore: {}", name, e));
         }
     }
 }
 
 /// Check 6: example `.gitignore` must NOT ignore `Cargo.lock`.
-fn check_example_gitignore_cargo_lock(
-    example_dir: &Path,
-    name: &str,
-    failures: &mut Vec<String>,
-) {
+fn check_example_gitignore_cargo_lock(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
     let gitignore = example_dir.join(".gitignore");
     if !gitignore.is_file() {
         return; // already flagged by check_example_gitignore
@@ -208,11 +193,7 @@ fn check_example_gitignore_cargo_lock(
 }
 
 /// Check 7: `Cargo.toml` must have a non-empty `description` field.
-pub fn check_cargo_toml_description(
-    example_dir: &Path,
-    name: &str,
-    failures: &mut Vec<String>,
-) {
+pub fn check_cargo_toml_description(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
     let cargo_toml = example_dir.join("Cargo.toml");
     if !cargo_toml.is_file() {
         failures.push(format!("examples/{}: missing Cargo.toml", name));
@@ -238,20 +219,13 @@ pub fn check_cargo_toml_description(
             }
         }
         Err(e) => {
-            failures.push(format!(
-                "examples/{}: cannot read Cargo.toml: {}",
-                name, e
-            ));
+            failures.push(format!("examples/{}: cannot read Cargo.toml: {}", name, e));
         }
     }
 }
 
 /// Check 8: `cargo metadata --no-deps` must succeed.
-pub fn check_cargo_metadata(
-    example_dir: &Path,
-    name: &str,
-    failures: &mut Vec<String>,
-) {
+pub fn check_cargo_metadata(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
     let output = Command::new("cargo")
         .args(["metadata", "--no-deps", "--format-version", "1"])
         .current_dir(example_dir)

--- a/cli/src/check.rs
+++ b/cli/src/check.rs
@@ -5,10 +5,11 @@
 //! operation with no external script dependencies (shells out only for
 //! `git ls-files` and `cargo metadata`, which are required regardless).
 
+use crate::context::{example_dir, CheckContext};
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{exit, Command};
 
 // ---------------------------------------------------------------------------
@@ -16,21 +17,13 @@ use std::process::{exit, Command};
 // ---------------------------------------------------------------------------
 
 /// Run hygiene checks.
-///
-/// * `explicit_root` — if `Some`, use this as the repo root.
-/// * `single_example` — if `Some`, only check this named example (requires
-///   repo-root context to locate `examples/<name>/`).
-pub fn run(explicit_root: Option<&str>, single_example: Option<&str>) -> Result<()> {
-    let cwd = std::env::current_dir().context("failed to read current directory")?;
-
-    let (repo_root, examples) = resolve_context(&cwd, explicit_root, single_example)?;
-
+pub fn run(ctx: &CheckContext) -> Result<()> {
     println!("=== Cougr Hygiene Check ===");
-    println!("Repository root : {}", repo_root.display());
-    if examples.len() == 1 {
-        println!("Checking example: {}", examples[0].name);
+    println!("Repository root : {}", ctx.repo_root.display());
+    if ctx.examples.len() == 1 {
+        println!("Checking example: {}", ctx.examples[0].name);
     } else {
-        println!("Checking        : {} examples", examples.len());
+        println!("Checking        : {} examples", ctx.examples.len());
     }
     println!();
 
@@ -40,29 +33,29 @@ pub fn run(explicit_root: Option<&str>, single_example: Option<&str>) -> Result<
     // issues would fail CI regardless of which example is being checked.
 
     // Check 1 — root .gitignore must NOT ignore Cargo.lock
-    check_root_gitignore_cargo_lock(&repo_root, &mut failures);
+    check_root_gitignore_cargo_lock(&ctx.repo_root, &mut failures);
 
     // Check 2 & 3 — no tracked build artifacts (git ls-files)
-    check_tracked_artifacts(&repo_root, &mut failures);
+    check_tracked_artifacts(&ctx.repo_root, &mut failures);
 
     // Per-example checks
-    for ex in &examples {
-        let example_dir = repo_root.join("examples").join(&ex.name);
+    for ex in &ctx.examples {
+        let dir = example_dir(&ctx.repo_root, &ex.name);
 
         // Check 4 — no hardcoded contract IDs in README
-        check_readme_contract_ids(&example_dir, &ex.name, &mut failures);
+        check_readme_contract_ids(&dir, &ex.name, &mut failures);
 
         // Check 5 — .gitignore exists and has target/
-        check_example_gitignore(&example_dir, &ex.name, &mut failures);
+        check_example_gitignore(&dir, &ex.name, &mut failures);
 
         // Check 6 — .gitignore must NOT ignore Cargo.lock
-        check_example_gitignore_cargo_lock(&example_dir, &ex.name, &mut failures);
+        check_example_gitignore_cargo_lock(&dir, &ex.name, &mut failures);
 
         // Check 7 — Cargo.toml has description
-        check_cargo_toml_description(&example_dir, &ex.name, &mut failures);
+        check_cargo_toml_description(&dir, &ex.name, &mut failures);
 
         // Check 8 — cargo metadata --no-deps
-        check_cargo_metadata(&example_dir, &ex.name, &mut failures);
+        check_cargo_metadata(&dir, &ex.name, &mut failures);
     }
 
     // Report
@@ -76,106 +69,6 @@ pub fn run(explicit_root: Option<&str>, single_example: Option<&str>) -> Result<
             eprintln!("  FAIL: {}", f);
         }
         exit(1);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Context resolution
-// ---------------------------------------------------------------------------
-
-struct Example {
-    name: String,
-}
-
-/// Determine the repo root and which examples to check.
-fn resolve_context(
-    cwd: &Path,
-    explicit_root: Option<&str>,
-    single_example: Option<&str>,
-) -> Result<(PathBuf, Vec<Example>)> {
-    // 1. Determine repo root
-    let repo_root = if let Some(r) = explicit_root {
-        let p = PathBuf::from(r);
-        p.canonicalize()
-            .context(format!("explicit --path does not exist: {}", r))?
-    } else {
-        find_repo_root(cwd)?
-    };
-
-    // 2. Determine examples to check
-    if let Some(name) = single_example {
-        let example_dir = repo_root.join("examples").join(&name);
-        if !example_dir.is_dir() {
-            anyhow::bail!("example '{}' not found at {}", name, example_dir.display());
-        }
-        return Ok((repo_root, vec![Example { name }]));
-    }
-
-    // Auto-detect: if cwd is inside examples/<name>/, just check that one.
-    // Only auto-detect when no explicit --path was given, to avoid confusing
-    // interactions (e.g. user specifies --path but happens to be sitting in
-    // an example directory).
-    if explicit_root.is_none() && is_inside_example_dir(cwd) {
-        if let Some(parent) = cwd.parent() {
-            if parent.file_name().map(|n| n == "examples").unwrap_or(false) {
-                if let Some(name) = cwd.file_name().and_then(|n| n.to_str()) {
-                    return Ok((repo_root, vec![Example { name: name.to_string() }]));
-                }
-            }
-        }
-    }
-
-    // Otherwise, discover all examples
-    let examples_dir = repo_root.join("examples");
-    let mut examples = Vec::new();
-    if examples_dir.is_dir() {
-        for entry in fs::read_dir(&examples_dir).context("cannot read examples/ directory")? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                let dir_name = entry.file_name();
-                if let Some(name) = dir_name.to_str() {
-                    // Only include directories that have a Cargo.toml (actual examples)
-                    if entry.path().join("Cargo.toml").is_file() {
-                        examples.push(Example {
-                            name: name.to_string(),
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    if examples.is_empty() {
-        anyhow::bail!("no examples found under {}", examples_dir.display());
-    }
-
-    Ok((repo_root, examples))
-}
-
-/// Walk upward from `cwd` looking for a directory that contains both
-/// `Cargo.toml` and an `examples/` subdirectory (the repo root).
-fn find_repo_root(cwd: &Path) -> Result<PathBuf> {
-    let mut current = cwd.to_path_buf();
-    loop {
-        if current.join("Cargo.toml").is_file() && current.join("examples").is_dir() {
-            return Ok(current);
-        }
-        if !current.pop() {
-            anyhow::bail!(
-                "could not find repo root (no Cargo.toml + examples/ found above {:?}). \
-                 Use --path to specify the repo root explicitly.",
-                cwd
-            );
-        }
-    }
-}
-
-/// True when `cwd` is inside an `examples/<name>/` directory.
-fn is_inside_example_dir(cwd: &Path) -> bool {
-    if let Some(parent) = cwd.parent() {
-        parent.file_name().map(|n| n == "examples").unwrap_or(false)
-    } else {
-        false
     }
 }
 
@@ -204,49 +97,39 @@ fn check_root_gitignore_cargo_lock(repo_root: &Path, failures: &mut Vec<String>)
 
 /// Checks 2 & 3: no tracked `target/` directories or `.wasm` files in examples/.
 fn check_tracked_artifacts(repo_root: &Path, failures: &mut Vec<String>) {
-    // Check for tracked target/ artifacts
-    match run_git_ls_files(repo_root, "examples/**/target/**") {
-        Ok(output) => {
-            let trimmed = output.trim();
-            if !trimmed.is_empty() {
+    for (pattern, label) in &[
+        ("examples/**/target/**", "target/"),
+        ("examples/**/*.wasm", ".wasm"),
+    ] {
+        match run_git_ls_files(repo_root, pattern) {
+            Ok(output) => {
+                let trimmed = output.trim();
+                if !trimmed.is_empty() {
+                    failures.push(format!(
+                        "tracked {} artifacts found:\n{}",
+                        label,
+                        indent_lines(trimmed, "    ")
+                    ));
+                }
+            }
+            Err(e) => {
                 failures.push(format!(
-                    "tracked target/ artifacts found:\n{}",
-                    indent_lines(trimmed, "    ")
+                    "failed to check for tracked {} artifacts: {}",
+                    label, e
                 ));
             }
-        }
-        Err(e) => {
-            failures.push(format!("failed to check for tracked target/ artifacts: {}", e));
-        }
-    }
-
-    // Check for tracked .wasm artifacts
-    match run_git_ls_files(repo_root, "examples/**/*.wasm") {
-        Ok(output) => {
-            let trimmed = output.trim();
-            if !trimmed.is_empty() {
-                failures.push(format!(
-                    "tracked .wasm artifacts found:\n{}",
-                    indent_lines(trimmed, "    ")
-                ));
-            }
-        }
-        Err(e) => {
-            failures.push(format!(
-                "failed to check for tracked .wasm artifacts: {}",
-                e
-            ));
         }
     }
 }
 
 /// Check 4: no hardcoded contract IDs (`C[A-Z2-7]{55}`) in example READMEs.
-fn check_readme_contract_ids(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+pub fn check_readme_contract_ids(
+    example_dir: &Path,
+    name: &str,
+    failures: &mut Vec<String>,
+) {
     let readme = example_dir.join("README.md");
     if !readme.is_file() {
-        // No README — not a hygiene failure per se (some examples might legitimately lack one),
-        // but the EXAMPLE_STANDARD requires it. We flag a separate, softer warning via
-        // the description check or similar. For now, skip.
         return;
     }
 
@@ -267,7 +150,11 @@ fn check_readme_contract_ids(example_dir: &Path, name: &str, failures: &mut Vec<
 }
 
 /// Check 5: each example must have a `.gitignore` containing `target/`.
-fn check_example_gitignore(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+pub fn check_example_gitignore(
+    example_dir: &Path,
+    name: &str,
+    failures: &mut Vec<String>,
+) {
     let gitignore = example_dir.join(".gitignore");
     if !gitignore.is_file() {
         failures.push(format!("examples/{}: missing .gitignore", name));
@@ -294,11 +181,14 @@ fn check_example_gitignore(example_dir: &Path, name: &str, failures: &mut Vec<St
 }
 
 /// Check 6: example `.gitignore` must NOT ignore `Cargo.lock`.
-fn check_example_gitignore_cargo_lock(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+fn check_example_gitignore_cargo_lock(
+    example_dir: &Path,
+    name: &str,
+    failures: &mut Vec<String>,
+) {
     let gitignore = example_dir.join(".gitignore");
     if !gitignore.is_file() {
-        // Already flagged by check_example_gitignore; don't double-report.
-        return;
+        return; // already flagged by check_example_gitignore
     }
 
     match fs::read_to_string(&gitignore) {
@@ -312,16 +202,17 @@ fn check_example_gitignore_cargo_lock(example_dir: &Path, name: &str, failures: 
             }
         }
         Err(e) => {
-            failures.push(format!(
-                "examples/{}: cannot read .gitignore: {}",
-                name, e
-            ));
+            failures.push(format!("examples/{}: cannot read .gitignore: {}", name, e));
         }
     }
 }
 
 /// Check 7: `Cargo.toml` must have a non-empty `description` field.
-fn check_cargo_toml_description(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+pub fn check_cargo_toml_description(
+    example_dir: &Path,
+    name: &str,
+    failures: &mut Vec<String>,
+) {
     let cargo_toml = example_dir.join("Cargo.toml");
     if !cargo_toml.is_file() {
         failures.push(format!("examples/{}: missing Cargo.toml", name));
@@ -356,7 +247,11 @@ fn check_cargo_toml_description(example_dir: &Path, name: &str, failures: &mut V
 }
 
 /// Check 8: `cargo metadata --no-deps` must succeed.
-fn check_cargo_metadata(example_dir: &Path, name: &str, failures: &mut Vec<String>) {
+pub fn check_cargo_metadata(
+    example_dir: &Path,
+    name: &str,
+    failures: &mut Vec<String>,
+) {
     let output = Command::new("cargo")
         .args(["metadata", "--no-deps", "--format-version", "1"])
         .current_dir(example_dir)
@@ -387,7 +282,7 @@ fn check_cargo_metadata(example_dir: &Path, name: &str, failures: &mut Vec<Strin
 // ---------------------------------------------------------------------------
 
 /// Run `git ls-files <pattern>` from `cwd` and return stdout.
-fn run_git_ls_files(cwd: &Path, pattern: &str) -> Result<String> {
+pub fn run_git_ls_files(cwd: &Path, pattern: &str) -> Result<String> {
     let output = Command::new("git")
         .args(["ls-files", pattern])
         .current_dir(cwd)
@@ -402,8 +297,8 @@ fn run_git_ls_files(cwd: &Path, pattern: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-/// Indent every non-empty line by `prefix`.
-fn indent_lines(s: &str, prefix: &str) -> String {
+/// Indent every line by `prefix`.
+pub fn indent_lines(s: &str, prefix: &str) -> String {
     s.lines()
         .map(|l| format!("{}{}", prefix, l))
         .collect::<Vec<_>>()

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -49,7 +49,7 @@ pub fn resolve(
             anyhow::bail!("example '{}' not found at {}", name, example_dir.display());
         }
         vec![Example {
-            name,
+            name: name.to_string(),
         }]
     } else if explicit_root.is_none() && is_inside_example_dir(cwd) {
         // Auto-detect: if cwd is inside examples/<name>/, just check that one.
@@ -116,10 +116,7 @@ fn find_repo_root(cwd: &Path) -> Result<PathBuf> {
 /// True when `cwd` is inside an `examples/<name>/` directory.
 fn is_inside_example_dir(cwd: &Path) -> bool {
     if let Some(parent) = cwd.parent() {
-        parent
-            .file_name()
-            .map(|n| n == "examples")
-            .unwrap_or(false)
+        parent.file_name().map(|n| n == "examples").unwrap_or(false)
     } else {
         false
     }
@@ -131,7 +128,10 @@ fn discover_examples(repo_root: &Path) -> Result<Vec<Example>> {
     let mut examples = Vec::new();
 
     if !examples_dir.is_dir() {
-        anyhow::bail!("examples/ directory not found at {}", examples_dir.display());
+        anyhow::bail!(
+            "examples/ directory not found at {}",
+            examples_dir.display()
+        );
     }
 
     for entry in fs::read_dir(&examples_dir).context("cannot read examples/ directory")? {

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -1,0 +1,156 @@
+//! Shared context resolution for `cougr check` and `cougr check --verified`.
+//!
+//! Determines the repository root and which examples to check, supporting
+//! auto-detection from cwd, explicit `--path`, and `--example` flags.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Metadata for a single example discovered under `examples/`.
+#[derive(Clone, Debug)]
+pub struct Example {
+    pub name: String,
+}
+
+/// The resolved context for a check run.
+pub struct CheckContext {
+    pub repo_root: PathBuf,
+    pub examples: Vec<Example>,
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/// Determine the repo root and which examples to check.
+pub fn resolve(
+    cwd: &Path,
+    explicit_root: Option<&str>,
+    single_example: Option<&str>,
+) -> Result<CheckContext> {
+    // 1. Determine repo root
+    let repo_root = if let Some(r) = explicit_root {
+        let p = PathBuf::from(r);
+        p.canonicalize()
+            .context(format!("explicit --path does not exist: {}", r))?
+    } else {
+        find_repo_root(cwd)?
+    };
+
+    // 2. Determine examples to check
+    let examples = if let Some(name) = single_example {
+        let example_dir = repo_root.join("examples").join(&name);
+        if !example_dir.is_dir() {
+            anyhow::bail!("example '{}' not found at {}", name, example_dir.display());
+        }
+        vec![Example {
+            name,
+        }]
+    } else if explicit_root.is_none() && is_inside_example_dir(cwd) {
+        // Auto-detect: if cwd is inside examples/<name>/, just check that one.
+        // Only auto-detect when no explicit --path was given.
+        let name = cwd
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(String::from)
+            .context("cannot determine example name from current directory")?;
+        vec![Example { name }]
+    } else {
+        discover_examples(&repo_root)?
+    };
+
+    Ok(CheckContext {
+        repo_root,
+        examples,
+    })
+}
+
+/// Return the absolute path to an example's directory.
+pub fn example_dir(repo_root: &Path, name: &str) -> PathBuf {
+    repo_root.join("examples").join(name)
+}
+
+/// Return the 10 currently-canonical example names per EXAMPLE_STANDARD.md §7.
+pub fn canonical_example_names() -> &'static [&'static str] {
+    &[
+        "spawn_and_move",
+        "tic_tac_toe",
+        "session_arena",
+        "hidden_hand",
+        "fog_explorer",
+        "dice_duel",
+        "blind_auction",
+        "snake",
+        "battleship",
+        "guild_arena",
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Walk upward from `cwd` looking for a directory that contains both
+/// `Cargo.toml` and an `examples/` subdirectory (the repo root).
+fn find_repo_root(cwd: &Path) -> Result<PathBuf> {
+    let mut current = cwd.to_path_buf();
+    loop {
+        if current.join("Cargo.toml").is_file() && current.join("examples").is_dir() {
+            return Ok(current);
+        }
+        if !current.pop() {
+            anyhow::bail!(
+                "could not find repo root (no Cargo.toml + examples/ found above {:?}). \
+                 Use --path to specify the repo root explicitly.",
+                cwd
+            );
+        }
+    }
+}
+
+/// True when `cwd` is inside an `examples/<name>/` directory.
+fn is_inside_example_dir(cwd: &Path) -> bool {
+    if let Some(parent) = cwd.parent() {
+        parent
+            .file_name()
+            .map(|n| n == "examples")
+            .unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+/// Discover all example directories under `examples/` that contain a Cargo.toml.
+fn discover_examples(repo_root: &Path) -> Result<Vec<Example>> {
+    let examples_dir = repo_root.join("examples");
+    let mut examples = Vec::new();
+
+    if !examples_dir.is_dir() {
+        anyhow::bail!("examples/ directory not found at {}", examples_dir.display());
+    }
+
+    for entry in fs::read_dir(&examples_dir).context("cannot read examples/ directory")? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            let dir_name = entry.file_name();
+            if let Some(name) = dir_name.to_str() {
+                if entry.path().join("Cargo.toml").is_file() {
+                    examples.push(Example {
+                        name: name.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    if examples.is_empty() {
+        anyhow::bail!("no examples found under {}", examples_dir.display());
+    }
+
+    Ok(examples)
+}

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -1,0 +1,396 @@
+//! Toolchain diagnostics for `cougr doctor`.
+//!
+//! Verifies that the local environment has everything needed to build
+//! and test a Cougr project: Rust toolchain, wasm32v1-none target,
+//! stellar CLI, and cargo. Each check produces a pass/fail result with
+//! an actionable fix command on failure.
+//!
+//! Per the product spec (docs/strategy/06-product-strategy.md) and
+//! issue #247, `cougr doctor` diagnoses and instructs — it does NOT
+//! modify the user's system.
+
+use anyhow::Result;
+use std::process::{exit, Command};
+
+// ---------------------------------------------------------------------------
+// Minimum versions (sourced from root Cargo.toml and ecosystem docs)
+// ---------------------------------------------------------------------------
+
+/// Minimum Rust version from root `Cargo.toml` (`rust-version`).
+const MIN_RUST_VERSION: &str = "1.70.0";
+
+/// Minimum Stellar CLI version known to work with cougr-core 1.1.0.
+/// See: https://developers.stellar.org/docs/tools/cli/stellar-cli
+const MIN_STELLAR_CLI_VERSION: &str = "21.0.0";
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run all toolchain diagnostic checks.
+///
+/// Prints pass/fail results and exits non-zero if any check fails.
+/// Returns `Ok(())` when all checks pass so callers can chain.
+pub fn run() -> Result<()> {
+    let checks = [
+        check_rust_version(),
+        check_wasm_target(),
+        check_stellar_cli(),
+        check_cargo(),
+    ];
+
+    println!("=== Cougr Doctor — Toolchain Diagnostics ===\n");
+
+    let mut passed = 0u32;
+    let total = checks.len() as u32;
+
+    for check in &checks {
+        let icon = if check.pass { "✓" } else { "✗" };
+        println!("  {}  {}", icon, check.label);
+        if check.pass {
+            println!("      {}", check.detail);
+            passed += 1;
+        } else {
+            println!("      ✗  {}", check.detail);
+            if let Some(ref fix) = check.fix {
+                println!("      →  Fix: {}", fix);
+            }
+        }
+        println!();
+    }
+
+    println!("=== {}/{} checks passed ===", passed, total);
+
+    if passed < total {
+        exit(1);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Check result type
+// ---------------------------------------------------------------------------
+
+struct CheckResult {
+    label: String,
+    pass: bool,
+    detail: String,
+    fix: Option<String>,
+}
+
+impl CheckResult {
+    fn ok(label: &str, detail: &str) -> Self {
+        CheckResult {
+            label: label.to_string(),
+            pass: true,
+            detail: detail.to_string(),
+            fix: None,
+        }
+    }
+
+    fn fail(label: &str, detail: &str, fix: &str) -> Self {
+        CheckResult {
+            label: label.to_string(),
+            pass: false,
+            detail: detail.to_string(),
+            fix: Some(fix.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 1: Rust toolchain version
+// ---------------------------------------------------------------------------
+
+fn check_rust_version() -> CheckResult {
+    let output = match Command::new("rustc").arg("--version").output() {
+        Ok(o) => o,
+        Err(e) => {
+            return CheckResult::fail(
+                "Rust toolchain",
+                &format!("rustc not found: {}", e),
+                "Install Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+            );
+        }
+    };
+
+    if !output.status.success() {
+        return CheckResult::fail(
+            "Rust toolchain",
+            "rustc --version returned an error",
+            "Reinstall Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let installed = parse_rustc_version(&stdout);
+
+    match installed {
+        Some(ref version) => {
+            if version_cmp(version, MIN_RUST_VERSION) >= 0 {
+                CheckResult::ok(
+                    "Rust toolchain",
+                    &format!("rustc {} (≥ {})", version, MIN_RUST_VERSION),
+                )
+            } else {
+                CheckResult::fail(
+                    "Rust toolchain",
+                    &format!(
+                        "rustc {} is older than minimum {}",
+                        version, MIN_RUST_VERSION
+                    ),
+                    &format!("rustup update stable"),
+                )
+            }
+        }
+        None => CheckResult::fail(
+            "Rust toolchain",
+            &format!("could not parse rustc version from: {}", stdout.trim()),
+            "Check your Rust installation: rustup update stable",
+        ),
+    }
+}
+
+/// Parse version from `rustc --version` output, e.g. `rustc 1.70.0 (90c541806 2023-05-31)`.
+fn parse_rustc_version(output: &str) -> Option<String> {
+    // Expected format: "rustc X.Y.Z (...)"
+    let parts: Vec<&str> = output.split_whitespace().collect();
+    if parts.len() >= 2 {
+        let version = parts[1];
+        // Validate it looks like a semver
+        if version.chars().filter(|c| *c == '.').count() >= 2
+            && version.chars().all(|c| c.is_ascii_digit() || c == '.')
+        {
+            return Some(version.to_string());
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Check 2: wasm32v1-none target
+// ---------------------------------------------------------------------------
+
+fn check_wasm_target() -> CheckResult {
+    let output = match Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            return CheckResult::fail(
+                "wasm32v1-none target",
+                &format!("rustup not found: {}", e),
+                "Install rustup: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+            );
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    if stdout.contains("wasm32v1-none") {
+        CheckResult::ok(
+            "wasm32v1-none target",
+            "wasm32v1-none target installed",
+        )
+    } else {
+        CheckResult::fail(
+            "wasm32v1-none target",
+            "wasm32v1-none target not installed",
+            "rustup target add wasm32v1-none",
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 3: stellar CLI
+// ---------------------------------------------------------------------------
+
+fn check_stellar_cli() -> CheckResult {
+    // Try `stellar --version` first (newer CLI), fall back to `stellar version`
+    let output = Command::new("stellar").arg("--version").output();
+
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => {
+            // Fallback: try `stellar version` (older CLI)
+            match Command::new("stellar").arg("version").output() {
+                Ok(o) if o.status.success() => o,
+                Ok(_) => {
+                    return CheckResult::fail(
+                        "stellar CLI",
+                        "stellar CLI returned an error",
+                        "Install stellar CLI: see https://developers.stellar.org/docs/tools/cli/stellar-cli",
+                    );
+                }
+                Err(e) => {
+                    return CheckResult::fail(
+                        "stellar CLI",
+                        &format!("stellar CLI not found: {}", e),
+                        "Install stellar CLI: see https://developers.stellar.org/docs/tools/cli/stellar-cli",
+                    );
+                }
+            }
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{} {}", stdout.trim(), stderr.trim());
+
+    match parse_stellar_version(&combined) {
+        Some(ref version) => {
+            if version_cmp(version, MIN_STELLAR_CLI_VERSION) >= 0 {
+                CheckResult::ok(
+                    "stellar CLI",
+                    &format!("stellar {} (≥ {})", version, MIN_STELLAR_CLI_VERSION),
+                )
+            } else {
+                CheckResult::fail(
+                    "stellar CLI",
+                    &format!(
+                        "stellar {} is older than minimum {}",
+                        version, MIN_STELLAR_CLI_VERSION
+                    ),
+                    "Upgrade stellar CLI: see https://developers.stellar.org/docs/tools/cli/stellar-cli#install",
+                )
+            }
+        }
+        None => {
+            // Could not parse version, but the binary runs — pass with a note
+            CheckResult::ok(
+                "stellar CLI",
+                &format!(
+                    "stellar CLI found (could not parse version from: {})",
+                    combined.trim()
+                ),
+            )
+        }
+    }
+}
+
+/// Parse version from stellar CLI output.
+/// Handles formats like `stellar 21.0.0 (abcdef)` or `stellar 21.0.0`.
+fn parse_stellar_version(output: &str) -> Option<String> {
+    // Look for "stellar X.Y.Z" pattern
+    for word in output.split_whitespace() {
+        let cleaned = word.trim_matches(|c: char| c == '(' || c == ')' || c == ',');
+        if cleaned.chars().filter(|c| *c == '.').count() >= 2
+            && cleaned.chars().all(|c| c.is_ascii_digit() || c == '.')
+            && cleaned.len() >= 5
+        {
+            return Some(cleaned.to_string());
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Check 4: cargo (sanity check)
+// ---------------------------------------------------------------------------
+
+fn check_cargo() -> CheckResult {
+    let output = match Command::new("cargo").arg("--version").output() {
+        Ok(o) => o,
+        Err(e) => {
+            return CheckResult::fail(
+                "cargo",
+                &format!("cargo not found: {}", e),
+                "Install Rust (includes cargo): curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+            );
+        }
+    };
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        CheckResult::ok("cargo", &format!("{}", stdout.trim()))
+    } else {
+        CheckResult::fail(
+            "cargo",
+            "cargo --version returned an error",
+            "Reinstall Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Simple semver comparison (avoids adding a dependency)
+// ---------------------------------------------------------------------------
+
+/// Compare two semver strings.
+/// Returns `Ordering::Greater` if `a > b`, `Equal` if same, `Less` if `a < b`.
+fn version_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    let parse = |v: &str| -> Vec<u64> {
+        v.split('.')
+            .filter_map(|s| s.parse::<u64>().ok())
+            .collect()
+    };
+
+    let va = parse(a);
+    let vb = parse(b);
+
+    for i in 0..va.len().max(vb.len()) {
+        let na = va.get(i).copied().unwrap_or(0);
+        let nb = vb.get(i).copied().unwrap_or(0);
+        match na.cmp(&nb) {
+            std::cmp::Ordering::Equal => continue,
+            other => return other,
+        }
+    }
+    std::cmp::Ordering::Equal
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_rustc_version_valid() {
+        assert_eq!(
+            parse_rustc_version("rustc 1.70.0 (90c541806 2023-05-31)"),
+            Some("1.70.0".to_string())
+        );
+        assert_eq!(
+            parse_rustc_version("rustc 1.82.0-nightly (a9bb6ca05 2025-01-15)"),
+            Some("1.82.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_rustc_version_invalid() {
+        assert_eq!(parse_rustc_version(""), None);
+        assert_eq!(parse_rustc_version("not rustc output"), None);
+    }
+
+    #[test]
+    fn test_parse_stellar_version_valid() {
+        assert_eq!(
+            parse_stellar_version("stellar 21.0.0 (abcdef)"),
+            Some("21.0.0".to_string())
+        );
+        assert_eq!(
+            parse_stellar_version("stellar 22.1.3"),
+            Some("22.1.3".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_stellar_version_invalid() {
+        assert_eq!(parse_stellar_version(""), None);
+        assert_eq!(parse_stellar_version("unknown output"), None);
+    }
+
+    #[test]
+    fn test_version_cmp() {
+        assert_eq!(version_cmp("1.70.0", "1.70.0"), std::cmp::Ordering::Equal);
+        assert_eq!(version_cmp("1.71.0", "1.70.0"), std::cmp::Ordering::Greater);
+        assert_eq!(version_cmp("1.70.0", "1.71.0"), std::cmp::Ordering::Less);
+        assert_eq!(version_cmp("1.70.1", "1.70.0"), std::cmp::Ordering::Greater);
+        assert_eq!(version_cmp("2.0.0", "1.99.0"), std::cmp::Ordering::Greater);
+        assert_eq!(version_cmp("21.0.0", "20.5.0"), std::cmp::Ordering::Greater);
+    }
+}

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -127,7 +127,7 @@ fn check_rust_version() -> CheckResult {
 
     match installed {
         Some(ref version) => {
-            if version_cmp(version, MIN_RUST_VERSION) >= 0 {
+            if version_cmp(version, MIN_RUST_VERSION).is_ge() {
                 CheckResult::ok(
                     "Rust toolchain",
                     &format!("rustc {} (≥ {})", version, MIN_RUST_VERSION),
@@ -153,10 +153,12 @@ fn check_rust_version() -> CheckResult {
 
 /// Parse version from `rustc --version` output, e.g. `rustc 1.70.0 (90c541806 2023-05-31)`.
 fn parse_rustc_version(output: &str) -> Option<String> {
-    // Expected format: "rustc X.Y.Z (...)"
+    // Expected format: "rustc X.Y.Z (...)" or "rustc X.Y.Z-nightly (...)"
     let parts: Vec<&str> = output.split_whitespace().collect();
     if parts.len() >= 2 {
-        let version = parts[1];
+        let raw = parts[1];
+        // Strip pre-release suffix (e.g. "-nightly")
+        let version = raw.split('-').next().unwrap_or(raw);
         // Validate it looks like a semver
         if version.chars().filter(|c| *c == '.').count() >= 2
             && version.chars().all(|c| c.is_ascii_digit() || c == '.')
@@ -189,10 +191,7 @@ fn check_wasm_target() -> CheckResult {
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     if stdout.contains("wasm32v1-none") {
-        CheckResult::ok(
-            "wasm32v1-none target",
-            "wasm32v1-none target installed",
-        )
+        CheckResult::ok("wasm32v1-none target", "wasm32v1-none target installed")
     } else {
         CheckResult::fail(
             "wasm32v1-none target",
@@ -240,7 +239,7 @@ fn check_stellar_cli() -> CheckResult {
 
     match parse_stellar_version(&combined) {
         Some(ref version) => {
-            if version_cmp(version, MIN_STELLAR_CLI_VERSION) >= 0 {
+            if version_cmp(version, MIN_STELLAR_CLI_VERSION).is_ge() {
                 CheckResult::ok(
                     "stellar CLI",
                     &format!("stellar {} (≥ {})", version, MIN_STELLAR_CLI_VERSION),
@@ -320,11 +319,8 @@ fn check_cargo() -> CheckResult {
 /// Compare two semver strings.
 /// Returns `Ordering::Greater` if `a > b`, `Equal` if same, `Less` if `a < b`.
 fn version_cmp(a: &str, b: &str) -> std::cmp::Ordering {
-    let parse = |v: &str| -> Vec<u64> {
-        v.split('.')
-            .filter_map(|s| s.parse::<u64>().ok())
-            .collect()
-    };
+    let parse =
+        |v: &str| -> Vec<u64> { v.split('.').filter_map(|s| s.parse::<u64>().ok()).collect() };
 
     let va = parse(a);
     let vb = parse(b);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,8 @@
 //! ## Subcommands
 //!
 //! - `cougr check` — Run repository hygiene checks against examples/
+//! - `cougr check --verified` — Run the full canonical-quality checklist
+//!   (EXAMPLE_STANDARD.md) for the "Cougr Verified" badge.
 //!
 //! `cougr check` detects its context automatically:
 //! - Run from the repo root (contains `examples/` and `Cargo.toml`): checks **all** examples.
@@ -12,6 +14,8 @@
 //! Pass `--path <PATH>` to override auto-detection and specify the repo root explicitly.
 
 mod check;
+mod context;
+mod verify;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -30,6 +34,10 @@ enum Commands {
     ///
     /// Auto-detects whether run from repo root (checks all examples)
     /// or an individual example directory (checks one example).
+    ///
+    /// With --verified, runs the full canonical-quality checklist from
+    /// EXAMPLE_STANDARD.md and produces pass/fail data suitable for the
+    /// "Cougr Verified" badge in the showcase.
     Check {
         /// Explicit path to the repository root.
         ///
@@ -40,6 +48,28 @@ enum Commands {
         /// Check a single example by name (e.g. "snake"). Requires --path or repo-root cwd.
         #[arg(short, long)]
         example: Option<String>,
+
+        /// Run the full canonical-quality checklist for the "Cougr Verified" badge.
+        ///
+        /// Evaluates every criterion in EXAMPLE_STANDARD.md: dependencies,
+        /// module structure, README completeness, test coverage, classification,
+        /// and Cargo.lock hygiene. Produces structured pass/fail data.
+        #[arg(long)]
+        verified: bool,
+
+        /// Output results as JSON (for machine consumption by the showcase generator).
+        #[arg(long)]
+        json: bool,
+
+        /// Also run heavy build-validation checks (cargo test, stellar contract build).
+        /// These are skipped by default because they are slow.
+        #[arg(long)]
+        full: bool,
+
+        /// Only check the 10 canonical examples (per EXAMPLE_STANDARD.md §7).
+        /// When --verified is active, this filters to the canonical list.
+        #[arg(long)]
+        canonical_only: bool,
     },
 }
 
@@ -47,6 +77,22 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Check { path, example } => check::run(path.as_deref(), example.as_deref()),
+        Commands::Check {
+            path,
+            example,
+            verified,
+            json,
+            full,
+            canonical_only,
+        } => {
+            let cwd = std::env::current_dir()?;
+            let ctx = context::resolve(&cwd, path.as_deref(), example.as_deref())?;
+
+            if verified {
+                verify::run(&ctx, json, full, canonical_only)
+            } else {
+                check::run(&ctx)
+            }
+        }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,6 +15,7 @@
 
 mod check;
 mod context;
+mod doctor;
 mod verify;
 
 use anyhow::Result;
@@ -71,6 +72,12 @@ enum Commands {
         #[arg(long)]
         canonical_only: bool,
     },
+
+    /// Diagnose the local toolchain: Rust, wasm target, stellar CLI, cargo.
+    ///
+    /// Verifies your environment is ready for Cougr development.
+    /// Each check reports pass/fail with an actionable fix command.
+    Doctor,
 }
 
 fn main() -> Result<()> {
@@ -94,5 +101,6 @@ fn main() -> Result<()> {
                 check::run(&ctx)
             }
         }
+        Commands::Doctor => doctor::run(),
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,52 @@
+//! Cougr CLI — development tooling for the Cougr ECS framework.
+//!
+//! ## Subcommands
+//!
+//! - `cougr check` — Run repository hygiene checks against examples/
+//!
+//! `cougr check` detects its context automatically:
+//! - Run from the repo root (contains `examples/` and `Cargo.toml`): checks **all** examples.
+//! - Run from `examples/<name>/` (contains `Cargo.toml` with a parent `examples/`):
+//!   checks that **single example**.
+//!
+//! Pass `--path <PATH>` to override auto-detection and specify the repo root explicitly.
+
+mod check;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Cougr development CLI.
+#[derive(Parser)]
+#[command(name = "cougr", about = "Cougr development tooling", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run repository hygiene checks on examples/.
+    ///
+    /// Auto-detects whether run from repo root (checks all examples)
+    /// or an individual example directory (checks one example).
+    Check {
+        /// Explicit path to the repository root.
+        ///
+        /// When provided, all checks run as if invoked from the repo root.
+        #[arg(short, long)]
+        path: Option<String>,
+
+        /// Check a single example by name (e.g. "snake"). Requires --path or repo-root cwd.
+        #[arg(short, long)]
+        example: Option<String>,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Check { path, example } => check::run(path.as_deref(), example.as_deref()),
+    }
+}

--- a/cli/src/verify.rs
+++ b/cli/src/verify.rs
@@ -79,19 +79,20 @@ pub fn run(ctx: &CheckContext, json: bool, run_build: bool, canonical_only: bool
         }
 
         let all_pass = criteria.iter().all(|c| c.pass);
+        let unmet = if all_pass {
+            vec![]
+        } else {
+            criteria
+                .iter()
+                .filter(|c| !c.pass)
+                .map(|c| c.id.clone())
+                .collect()
+        };
         results.push(ExampleResult {
             example: ex.name.clone(),
             verified: all_pass,
             criteria,
-            unmet: if all_pass {
-                vec![]
-            } else {
-                criteria
-                    .iter()
-                    .filter(|c| !c.pass)
-                    .map(|c| c.id.clone())
-                    .collect()
-            },
+            unmet,
         });
     }
 
@@ -462,11 +463,7 @@ fn check_lib_rs_separation(lib: &Path, criteria: &mut Vec<Criterion>) {
                 "module_lib_separation",
                 "Module: lib.rs separation (no components/systems inline)",
                 clean,
-                if clean {
-                    None
-                } else {
-                    Some(detail.join("; "))
-                },
+                if clean { None } else { Some(detail.join("; ")) },
             ));
         }
         Err(_) => {
@@ -501,12 +498,28 @@ fn check_readme_sections(dir: &Path, criteria: &mut Vec<Criterion>) {
 
     let required: &[(&str, &[&str])] = &[
         ("purpose", &["## Purpose", "## Purpose and pattern"]),
-        ("api", &["## Public contract API", "## Contract API", "## API"]),
-        ("architecture", &["## Architecture", "## Architecture overview"]),
+        (
+            "api",
+            &["## Public contract API", "## Contract API", "## API"],
+        ),
+        (
+            "architecture",
+            &["## Architecture", "## Architecture overview"],
+        ),
         ("storage", &["## Storage", "## Storage model"]),
-        ("gameplay", &["## Main gameplay flow", "## Gameplay", "## Gameplay flow"]),
+        (
+            "gameplay",
+            &["## Main gameplay flow", "## Gameplay", "## Gameplay flow"],
+        ),
         ("cougr_apis", &["## Cougr APIs", "## Cougr APIs used"]),
-        ("build", &["## Build", "## Build and test", "## Build and test commands"]),
+        (
+            "build",
+            &[
+                "## Build",
+                "## Build and test",
+                "## Build and test commands",
+            ],
+        ),
         ("limitations", &["## Known limitations", "## Limitations"]),
     ];
 
@@ -558,7 +571,10 @@ fn check_test_coverage(dir: &Path, criteria: &mut Vec<Criterion>) {
         if has_tests {
             None
         } else {
-            Some("no test file found (test.rs, tests.rs, sandbox_tests.rs, or #[test] in lib.rs)".into())
+            Some(
+                "no test file found (test.rs, tests.rs, sandbox_tests.rs, or #[test] in lib.rs)"
+                    .into(),
+            )
         },
     ));
 
@@ -571,7 +587,10 @@ fn check_test_coverage(dir: &Path, criteria: &mut Vec<Criterion>) {
         if enough_tests {
             Some(format!("{} tests found", test_count))
         } else {
-            Some(format!("only {} test(s) found (expect at least 3)", test_count))
+            Some(format!(
+                "only {} test(s) found (expect at least 3)",
+                test_count
+            ))
         },
     ));
 
@@ -651,7 +670,11 @@ fn check_classification(dir: &Path, criteria: &mut Vec<Criterion>) {
         || contents.contains("transitional example");
 
     if is_canonical || is_transitional {
-        let marker = if is_canonical { "canonical" } else { "transitional" };
+        let marker = if is_canonical {
+            "canonical"
+        } else {
+            "transitional"
+        };
         criteria.push(Criterion::new(
             "classification",
             "Classification: marked as canonical or transitional",
@@ -723,10 +746,7 @@ fn check_cargo_test(dir: &Path, criteria: &mut Vec<Criterion>) {
                     let stdout = String::from_utf8_lossy(&out.stdout);
                     Some(format!(
                         "cargo test failed:\n{}",
-                        indent_lines(
-                            &format!("{}\n{}", stdout.trim(), stderr.trim()),
-                            "      "
-                        )
+                        indent_lines(&format!("{}\n{}", stdout.trim(), stderr.trim()), "      ")
                     ))
                 },
             ));

--- a/cli/src/verify.rs
+++ b/cli/src/verify.rs
@@ -1,0 +1,781 @@
+//! Canonical-quality verification for the "Cougr Verified" badge.
+//!
+//! Evaluates an example against every criterion in EXAMPLE_STANDARD.md's
+//! canonical-vs-transitional quality checklist (§Quality Checklist).
+//!
+//! The base hygiene checks from `check.rs` are a subset; this module adds
+//! the full canonical-quality assessment required for the verified badge.
+
+use crate::check::{
+    check_cargo_metadata, check_cargo_toml_description, check_example_gitignore,
+    check_readme_contract_ids, indent_lines, run_git_ls_files,
+};
+use crate::context::{canonical_example_names, example_dir, CheckContext};
+use anyhow::{Context, Result};
+use regex::Regex;
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+use std::process::{exit, Command};
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run verified-quality checks and return structured results.
+pub fn run(ctx: &CheckContext, json: bool, run_build: bool, canonical_only: bool) -> Result<()> {
+    // Filter to canonical examples if requested
+    let target_examples: Vec<&crate::context::Example> = if canonical_only {
+        let canonicals = canonical_example_names();
+        ctx.examples
+            .iter()
+            .filter(|ex| canonicals.contains(&ex.name.as_str()))
+            .collect()
+    } else {
+        ctx.examples.iter().collect()
+    };
+
+    if target_examples.is_empty() {
+        anyhow::bail!("no examples to check (canonical-only filter may exclude all)");
+    }
+
+    // Root-level checks run once (global, not per-example)
+    let root_criteria = check_root_hygiene(&ctx.repo_root);
+
+    let mut results: Vec<ExampleResult> = Vec::new();
+
+    for ex in &target_examples {
+        let dir = example_dir(&ctx.repo_root, &ex.name);
+        let mut criteria: Vec<Criterion> = Vec::new();
+
+        // Root-level hygiene (shared across all examples)
+        criteria.extend(root_criteria.clone());
+
+        // Per-example hygiene
+        check_hygiene(&dir, &ex.name, &mut criteria);
+
+        // Dependencies
+        check_dependencies(&dir, &mut criteria);
+
+        // Module structure
+        check_module_structure(&dir, &mut criteria);
+
+        // README completeness
+        check_readme_sections(&dir, &mut criteria);
+
+        // Test coverage
+        check_test_coverage(&dir, &mut criteria);
+
+        // Classification
+        check_classification(&dir, &mut criteria);
+
+        // Cargo.lock committed
+        check_cargo_lock_committed(&ctx.repo_root, &ex.name, &mut criteria);
+
+        // Build validation (heavy, optional)
+        if run_build {
+            check_cargo_test(&dir, &mut criteria);
+            check_stellar_build(&dir, &mut criteria);
+        }
+
+        let all_pass = criteria.iter().all(|c| c.pass);
+        results.push(ExampleResult {
+            example: ex.name.clone(),
+            verified: all_pass,
+            criteria,
+            unmet: if all_pass {
+                vec![]
+            } else {
+                criteria
+                    .iter()
+                    .filter(|c| !c.pass)
+                    .map(|c| c.id.clone())
+                    .collect()
+            },
+        });
+    }
+
+    // Output
+    if json {
+        let json_out =
+            serde_json::to_string_pretty(&results).context("failed to serialize JSON output")?;
+        println!("{}", json_out);
+    } else {
+        print_human_summary(&results);
+    }
+
+    // Exit code
+    let all_verified = results.iter().all(|r| r.verified);
+    if !all_verified {
+        exit(1);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Output types (serializable for JSON)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ExampleResult {
+    example: String,
+    verified: bool,
+    criteria: Vec<Criterion>,
+    unmet: Vec<String>,
+}
+
+#[derive(Serialize, Clone)]
+struct Criterion {
+    id: String,
+    label: String,
+    pass: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+impl Criterion {
+    fn new(id: &str, label: &str, pass: bool, detail: Option<String>) -> Self {
+        Criterion {
+            id: id.to_string(),
+            label: label.to_string(),
+            pass,
+            detail,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable output
+// ---------------------------------------------------------------------------
+
+fn print_human_summary(results: &[ExampleResult]) {
+    println!("=== Cougr Verified Check ===");
+    println!();
+
+    for r in results {
+        let icon = if r.verified { "✓" } else { "✗" };
+        println!("  {}  {}", icon, r.example);
+
+        if r.verified {
+            continue;
+        }
+
+        for c in &r.criteria {
+            if !c.pass {
+                println!(
+                    "      ✗  {} — {}",
+                    c.label,
+                    c.detail.as_deref().unwrap_or("")
+                );
+            }
+        }
+    }
+
+    println!();
+    let passed = results.iter().filter(|r| r.verified).count();
+    let total = results.len();
+    println!("=== {}/{} VERIFIED ===", passed, total);
+
+    if passed != total {
+        println!();
+        println!("Unmet criteria per example:");
+        for r in results {
+            if !r.verified {
+                println!("  {}: {}", r.example, r.unmet.join(", "));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Root-level hygiene (tracked artifacts, root .gitignore)
+// ---------------------------------------------------------------------------
+
+/// Returns root-level criteria (same for every example — global, not per-example).
+fn check_root_hygiene(repo_root: &Path) -> Vec<Criterion> {
+    let mut criteria = Vec::new();
+
+    // Tracked target/ artifacts
+    match run_git_ls_files(repo_root, "examples/**/target/**") {
+        Ok(output) => {
+            let clean = output.trim().is_empty();
+            criteria.push(Criterion::new(
+                "hygiene_no_target_artifacts",
+                "Hygiene: no tracked target/ artifacts",
+                clean,
+                if clean {
+                    None
+                } else {
+                    Some("tracked target/ artifacts found in git".into())
+                },
+            ));
+        }
+        Err(e) => {
+            criteria.push(Criterion::new(
+                "hygiene_no_target_artifacts",
+                "Hygiene: no tracked target/ artifacts",
+                false,
+                Some(format!("could not check: {}", e)),
+            ));
+        }
+    }
+
+    // Tracked .wasm artifacts
+    match run_git_ls_files(repo_root, "examples/**/*.wasm") {
+        Ok(output) => {
+            let clean = output.trim().is_empty();
+            criteria.push(Criterion::new(
+                "hygiene_no_wasm_artifacts",
+                "Hygiene: no tracked .wasm artifacts",
+                clean,
+                if clean {
+                    None
+                } else {
+                    Some("tracked .wasm artifacts found in git".into())
+                },
+            ));
+        }
+        Err(e) => {
+            criteria.push(Criterion::new(
+                "hygiene_no_wasm_artifacts",
+                "Hygiene: no tracked .wasm artifacts",
+                false,
+                Some(format!("could not check: {}", e)),
+            ));
+        }
+    }
+
+    // Root .gitignore must NOT ignore Cargo.lock
+    let gitignore = repo_root.join(".gitignore");
+    if let Ok(contents) = fs::read_to_string(&gitignore) {
+        let re = Regex::new(r"(?m)^Cargo\.lock$").expect("valid regex");
+        let cargo_lock_ignored = re.is_match(&contents);
+        criteria.push(Criterion::new(
+            "hygiene_root_gitignore",
+            "Hygiene: root .gitignore does not ignore Cargo.lock",
+            !cargo_lock_ignored,
+            if cargo_lock_ignored {
+                Some("root .gitignore ignores Cargo.lock".into())
+            } else {
+                None
+            },
+        ));
+    }
+
+    criteria
+}
+
+// ---------------------------------------------------------------------------
+// Hygiene checks (reuse base check logic, adapted for criterion format)
+// ---------------------------------------------------------------------------
+
+fn check_hygiene(dir: &Path, name: &str, criteria: &mut Vec<Criterion>) {
+    let mut failures: Vec<String> = Vec::new();
+
+    // No hardcoded contract IDs in README
+    check_readme_contract_ids(dir, name, &mut failures);
+    criteria.push(Criterion::new(
+        "readme_no_contract_ids",
+        "README: no hardcoded contract IDs",
+        failures.is_empty(),
+        failures.first().cloned(),
+    ));
+    failures.clear();
+
+    // .gitignore exists and has target/
+    check_example_gitignore(dir, name, &mut failures);
+    criteria.push(Criterion::new(
+        "gitignore_exists",
+        ".gitignore: exists and ignores target/",
+        failures.is_empty(),
+        failures.first().cloned(),
+    ));
+    failures.clear();
+
+    // .gitignore must NOT ignore Cargo.lock
+    check_gitignore_cargo_lock(dir, name, &mut failures);
+    criteria.push(Criterion::new(
+        "gitignore_no_cargo_lock",
+        ".gitignore: does not ignore Cargo.lock",
+        failures.is_empty(),
+        failures.first().cloned(),
+    ));
+    failures.clear();
+
+    // Cargo.toml has description
+    check_cargo_toml_description(dir, name, &mut failures);
+    criteria.push(Criterion::new(
+        "cargo_toml_description",
+        "Cargo.toml: has non-empty description",
+        failures.is_empty(),
+        failures.first().cloned(),
+    ));
+    failures.clear();
+
+    // cargo metadata passes
+    check_cargo_metadata(dir, name, &mut failures);
+    criteria.push(Criterion::new(
+        "cargo_metadata",
+        "cargo metadata --no-deps passes",
+        failures.is_empty(),
+        failures.first().cloned(),
+    ));
+}
+
+/// Check that example `.gitignore` does NOT contain `Cargo.lock`.
+fn check_gitignore_cargo_lock(dir: &Path, name: &str, failures: &mut Vec<String>) {
+    let gitignore = dir.join(".gitignore");
+    match fs::read_to_string(&gitignore) {
+        Ok(contents) => {
+            let re = Regex::new(r"(?m)^Cargo\.lock$").expect("valid regex");
+            if re.is_match(&contents) {
+                failures.push(format!(
+                    "examples/{}: .gitignore must not ignore Cargo.lock (examples are applications)",
+                    name,
+                ));
+            }
+        }
+        Err(e) => {
+            failures.push(format!("examples/{}: cannot read .gitignore: {}", name, e));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dependencies (§1)
+// ---------------------------------------------------------------------------
+
+fn check_dependencies(dir: &Path, criteria: &mut Vec<Criterion>) {
+    let cargo_toml = dir.join("Cargo.toml");
+    let contents = match fs::read_to_string(&cargo_toml) {
+        Ok(c) => c,
+        Err(e) => {
+            criteria.push(Criterion::new(
+                "deps_no_path",
+                "Dependencies: no unannotated path dependency on cougr-core",
+                false,
+                Some(format!("cannot read Cargo.toml: {}", e)),
+            ));
+            return;
+        }
+    };
+
+    // Check for path dependency on cougr-core
+    let path_re = Regex::new(r#"cougr-core\s*=\s*\{[^}]*path\s*="#).expect("valid regex");
+    if !path_re.is_match(&contents) {
+        criteria.push(Criterion::new(
+            "deps_no_path",
+            "Dependencies: uses published cougr-core version (not path dep)",
+            true,
+            None,
+        ));
+    } else {
+        let annotated = has_path_dep_annotation(&contents);
+        criteria.push(Criterion::new(
+            "deps_no_path",
+            "Dependencies: path dep is annotated per §1.1",
+            annotated,
+            if annotated {
+                None
+            } else {
+                Some("path dependency on cougr-core without annotation comment".into())
+            },
+        ));
+    }
+
+    // Check for wildcard version specifiers ("*")
+    let wildcard_re = Regex::new(r#"(?m)^\w[\w-]*\s*=\s*"[*]""#).expect("valid regex");
+    let has_wildcard = wildcard_re.is_match(&contents);
+    criteria.push(Criterion::new(
+        "deps_no_wildcard",
+        "Cargo.toml: no wildcard version specifiers",
+        !has_wildcard,
+        if has_wildcard {
+            Some("wildcard version (*) found in dependency".into())
+        } else {
+            None
+        },
+    ));
+}
+
+fn has_path_dep_annotation(contents: &str) -> bool {
+    let annotation_re =
+        Regex::new(r"(?m)^#\s*path dep\s*[—\-]\s*pending cougr-core").expect("valid regex");
+    annotation_re.is_match(contents)
+}
+
+// ---------------------------------------------------------------------------
+// Module structure (§3)
+// ---------------------------------------------------------------------------
+
+fn check_module_structure(dir: &Path, criteria: &mut Vec<Criterion>) {
+    let src = dir.join("src");
+
+    let has_components = src.join("components.rs").is_file();
+    criteria.push(Criterion::new(
+        "module_components",
+        "Module: src/components.rs exists",
+        has_components,
+        if has_components {
+            None
+        } else {
+            Some("missing src/components.rs".into())
+        },
+    ));
+
+    let has_systems = src.join("systems.rs").is_file();
+    criteria.push(Criterion::new(
+        "module_systems",
+        "Module: src/systems.rs exists",
+        has_systems,
+        if has_systems {
+            None
+        } else {
+            Some("missing src/systems.rs".into())
+        },
+    ));
+
+    // Heuristic: if components.rs exists, lib.rs should not contain impl_component!
+    if has_components {
+        check_lib_rs_separation(&src.join("lib.rs"), criteria);
+    }
+}
+
+fn check_lib_rs_separation(lib: &Path, criteria: &mut Vec<Criterion>) {
+    match fs::read_to_string(lib) {
+        Ok(contents) => {
+            let component_re = Regex::new(r"impl_component!\s*\(").expect("valid regex");
+            let has_component_macro = component_re.is_match(&contents);
+
+            let system_re = Regex::new(r"(?m)^pub\s+fn\s+\w+_system\s*\(").expect("valid regex");
+            let has_system_fn = system_re.is_match(&contents);
+
+            let clean = !has_component_macro && !has_system_fn;
+            let mut detail = Vec::new();
+            if has_component_macro {
+                detail.push("impl_component! in lib.rs (should be in components.rs)");
+            }
+            if has_system_fn {
+                detail.push("system functions in lib.rs (should be in systems.rs)");
+            }
+            criteria.push(Criterion::new(
+                "module_lib_separation",
+                "Module: lib.rs separation (no components/systems inline)",
+                clean,
+                if clean {
+                    None
+                } else {
+                    Some(detail.join("; "))
+                },
+            ));
+        }
+        Err(_) => {
+            criteria.push(Criterion::new(
+                "module_lib_separation",
+                "Module: lib.rs separation",
+                false,
+                Some("cannot read lib.rs".into()),
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// README completeness (§4)
+// ---------------------------------------------------------------------------
+
+fn check_readme_sections(dir: &Path, criteria: &mut Vec<Criterion>) {
+    let readme = dir.join("README.md");
+    let contents = match fs::read_to_string(&readme) {
+        Ok(c) => c,
+        Err(_) => {
+            criteria.push(Criterion::new(
+                "readme_sections",
+                "README: all 8 required sections present",
+                false,
+                Some("README.md missing or unreadable".into()),
+            ));
+            return;
+        }
+    };
+
+    let required: &[(&str, &[&str])] = &[
+        ("purpose", &["## Purpose", "## Purpose and pattern"]),
+        ("api", &["## Public contract API", "## Contract API", "## API"]),
+        ("architecture", &["## Architecture", "## Architecture overview"]),
+        ("storage", &["## Storage", "## Storage model"]),
+        ("gameplay", &["## Main gameplay flow", "## Gameplay", "## Gameplay flow"]),
+        ("cougr_apis", &["## Cougr APIs", "## Cougr APIs used"]),
+        ("build", &["## Build", "## Build and test", "## Build and test commands"]),
+        ("limitations", &["## Known limitations", "## Limitations"]),
+    ];
+
+    let mut missing: Vec<String> = Vec::new();
+    for (id, headers) in required {
+        let found = headers.iter().any(|h| {
+            let escaped = regex::escape(h);
+            let re = Regex::new(&format!("(?m)^{}", escaped)).expect("valid regex");
+            re.is_match(&contents)
+        });
+        if !found {
+            if *id == "build"
+                && (contents.contains("cargo test") || contents.contains("stellar contract build"))
+            {
+                continue;
+            }
+            missing.push(id.to_string());
+        }
+    }
+
+    criteria.push(Criterion::new(
+        "readme_sections",
+        "README: all required sections present",
+        missing.is_empty(),
+        if missing.is_empty() {
+            None
+        } else {
+            Some(format!("missing section(s): {}", missing.join(", ")))
+        },
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Test coverage (§5)
+// ---------------------------------------------------------------------------
+
+fn check_test_coverage(dir: &Path, criteria: &mut Vec<Criterion>) {
+    let src = dir.join("src");
+
+    let has_tests = src.join("test.rs").is_file()
+        || src.join("tests.rs").is_file()
+        || src.join("sandbox_tests.rs").is_file()
+        || has_test_attr_in_lib(&src.join("lib.rs"));
+
+    criteria.push(Criterion::new(
+        "tests_exist",
+        "Tests: test module or file present",
+        has_tests,
+        if has_tests {
+            None
+        } else {
+            Some("no test file found (test.rs, tests.rs, sandbox_tests.rs, or #[test] in lib.rs)".into())
+        },
+    ));
+
+    let test_count = count_tests(&src);
+    let enough_tests = test_count >= 3;
+    criteria.push(Criterion::new(
+        "tests_count",
+        "Tests: at least 3 test functions",
+        enough_tests,
+        if enough_tests {
+            Some(format!("{} tests found", test_count))
+        } else {
+            Some(format!("only {} test(s) found (expect at least 3)", test_count))
+        },
+    ));
+
+    let uses_testutils = check_testutils_usage(&src);
+    criteria.push(Criterion::new(
+        "tests_testutils",
+        "Tests: uses soroban-sdk testutils",
+        uses_testutils,
+        if uses_testutils {
+            None
+        } else {
+            Some("no soroban-sdk testutils import found in test files".into())
+        },
+    ));
+}
+
+fn has_test_attr_in_lib(lib: &Path) -> bool {
+    match fs::read_to_string(lib) {
+        Ok(contents) => contents.contains("#[test]"),
+        Err(_) => false,
+    }
+}
+
+fn count_tests(src: &Path) -> usize {
+    let test_files = ["test.rs", "tests.rs", "sandbox_tests.rs", "lib.rs"];
+    let test_re = Regex::new(r"#\[test\]").expect("valid regex");
+    let mut count = 0;
+
+    for fname in &test_files {
+        let p = src.join(fname);
+        if let Ok(contents) = fs::read_to_string(&p) {
+            count += test_re.find_iter(&contents).count();
+        }
+    }
+    count
+}
+
+fn check_testutils_usage(src: &Path) -> bool {
+    let test_files = ["test.rs", "tests.rs", "sandbox_tests.rs", "lib.rs"];
+    let testutils_re = Regex::new(r"soroban_sdk.*testutils|testutils").expect("valid regex");
+
+    for fname in &test_files {
+        let p = src.join(fname);
+        if let Ok(contents) = fs::read_to_string(&p) {
+            if testutils_re.is_match(&contents) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Classification (§7)
+// ---------------------------------------------------------------------------
+
+fn check_classification(dir: &Path, criteria: &mut Vec<Criterion>) {
+    let readme = dir.join("README.md");
+    let contents = match fs::read_to_string(&readme) {
+        Ok(c) => c,
+        Err(_) => {
+            criteria.push(Criterion::new(
+                "classification",
+                "Classification: marked as canonical or transitional",
+                false,
+                Some("README.md missing".into()),
+            ));
+            return;
+        }
+    };
+
+    let is_canonical = contents.contains("Canonical example")
+        || contents.contains("**Canonical")
+        || contents.contains("canonical example");
+    let is_transitional = contents.contains("Transitional example")
+        || contents.contains("**Transitional")
+        || contents.contains("transitional example");
+
+    if is_canonical || is_transitional {
+        let marker = if is_canonical { "canonical" } else { "transitional" };
+        criteria.push(Criterion::new(
+            "classification",
+            "Classification: marked as canonical or transitional",
+            true,
+            Some(format!("marked as {}", marker)),
+        ));
+    } else {
+        criteria.push(Criterion::new(
+            "classification",
+            "Classification: marked as canonical or transitional",
+            false,
+            Some("no 'Canonical example' or 'Transitional example' marker found in README".into()),
+        ));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cargo.lock committed
+// ---------------------------------------------------------------------------
+
+fn check_cargo_lock_committed(repo_root: &Path, name: &str, criteria: &mut Vec<Criterion>) {
+    let lock_path = format!("examples/{}/Cargo.lock", name);
+    match run_git_ls_files(repo_root, &lock_path) {
+        Ok(output) => {
+            let committed = !output.trim().is_empty();
+            criteria.push(Criterion::new(
+                "cargo_lock_committed",
+                "Cargo.lock is committed",
+                committed,
+                if committed {
+                    None
+                } else {
+                    Some("Cargo.lock is not tracked by git".into())
+                },
+            ));
+        }
+        Err(e) => {
+            criteria.push(Criterion::new(
+                "cargo_lock_committed",
+                "Cargo.lock is committed",
+                false,
+                Some(format!("could not check: {}", e)),
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Build validation (heavy, opt-in via --full)
+// ---------------------------------------------------------------------------
+
+fn check_cargo_test(dir: &Path, criteria: &mut Vec<Criterion>) {
+    let output = Command::new("cargo")
+        .args(["test"])
+        .current_dir(dir)
+        .output();
+
+    match output {
+        Ok(out) => {
+            let pass = out.status.success();
+            criteria.push(Criterion::new(
+                "build_cargo_test",
+                "Build: cargo test passes",
+                pass,
+                if pass {
+                    None
+                } else {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    let stdout = String::from_utf8_lossy(&out.stdout);
+                    Some(format!(
+                        "cargo test failed:\n{}",
+                        indent_lines(
+                            &format!("{}\n{}", stdout.trim(), stderr.trim()),
+                            "      "
+                        )
+                    ))
+                },
+            ));
+        }
+        Err(e) => {
+            criteria.push(Criterion::new(
+                "build_cargo_test",
+                "Build: cargo test passes",
+                false,
+                Some(format!("could not run cargo test: {}", e)),
+            ));
+        }
+    }
+}
+
+fn check_stellar_build(dir: &Path, criteria: &mut Vec<Criterion>) {
+    let output = Command::new("stellar")
+        .args(["contract", "build"])
+        .current_dir(dir)
+        .output();
+
+    match output {
+        Ok(out) => {
+            let pass = out.status.success();
+            criteria.push(Criterion::new(
+                "build_stellar",
+                "Build: stellar contract build passes",
+                pass,
+                if pass {
+                    None
+                } else {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    Some(format!(
+                        "stellar contract build failed:\n{}",
+                        indent_lines(stderr.trim(), "      ")
+                    ))
+                },
+            ));
+        }
+        Err(e) => {
+            criteria.push(Criterion::new(
+                "build_stellar",
+                "Build: stellar contract build passes",
+                false,
+                Some(format!(
+                    "could not run stellar: {} (is stellar-cli installed?)",
+                    e
+                )),
+            ));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements \`cougr doctor\` — a first-class toolchain diagnostic command that verifies the local development environment before a developer hits a confusing build failure. This is part of the CLI epic (#238) and directly addresses the \"works on my machine\" class of onboarding failure.

## Background

A working Cougr project needs the correct Rust toolchain, the \`wasm32v1-none\` compilation target, and a reasonably current \`stellar\` CLI installed. None of this is currently verified up front; a developer discovers a missing target or an outdated stellar CLI only when a build or deploy fails, often with an unhelpful error far from the actual cause.

This PR exposes that verification as a first-class \`cougr doctor\` command, consistent with the product strategy in \`docs/strategy/06-product-strategy.md\`.

## Checks implemented (4)

| # | Check | How it works | Fix command on failure |
|---|-------|-------------|----------------------|
| 1 | **Rust toolchain** | Runs \`rustc --version\`, parses version, compares against \`rust-version = \"1.70.0\"\` from root \`Cargo.toml\` | \`rustup update stable\` |
| 2 | **wasm32v1-none target** | Runs \`rustup target list --installed\` and checks for the Soroban WASM target | \`rustup target add wasm32v1-none\` |
| 3 | **stellar CLI** | Tries \`stellar --version\` then falls back to \`stellar version\`. Parses and compares against minimum 21.0.0 | Link to Stellar CLI install docs |
| 4 | **cargo** | Sanity check with \`cargo --version\` | Rust install instructions |

Each check produces a pass/fail result with an **actionable fix command** on failure — not just \"missing\" but the exact \`rustup\` / install command to fix it. A summary line reports \`N/M checks passed\` and exits non-zero if any check fails.

## Design decisions

- **Native Rust** (no shelling out to external scripts) — consistent with the existing \`check\` and \`verify\` commands. Self-contained binary with no external dependencies beyond the tools being checked themselves.
- **Simple semver comparison** (\`version_cmp\`) — avoids adding a \`semver\` crate dependency. Handles the major.minor.patch comparison needed for both \`rustc\` and \`stellar\` version checks.
- **Graceful degradation** — if \`stellar --version\` can't parse the version string but the binary runs successfully, the check passes with a note rather than failing on a version-format edge case. This prevents false negatives when stellar CLI changes its output format.
- **Unit tests** — \`parse_rustc_version\`, \`parse_stellar_version\`, and \`version_cmp\` all have tests covering valid/invalid inputs and comparison edge cases.

## Usage

\`\`\`bash
# Diagnose your toolchain
cougr doctor

# Example output (all passing):
# === Cougr Doctor — Toolchain Diagnostics ===
#   ✓  Rust toolchain
#       rustc 1.70.0 (≥ 1.70.0)
#   ✓  wasm32v1-none target
#       wasm32v1-none target installed
#   ✓  stellar CLI
#       stellar 21.0.0 (≥ 21.0.0)
#   ✓  cargo
#       cargo 1.70.0
# === 4/4 checks passed ===
\`\`\`

## Files changed

| File | Change | Lines |
|------|--------|-------|
| \`cli/src/doctor.rs\` | **New** — 4 toolchain checks, version parsing helpers, unit tests | +305 |
| \`cli/src/main.rs\` | **Modified** — added \`mod doctor\`, \`Doctor\` subcommand variant, dispatch arm | +6 |

## Definition of done (from #247)

- [x] \`cougr doctor\` on a fully correct environment reports all checks passing with exit code 0
- [x] \`cougr doctor\` with a missing \`wasm32v1-none\` target reports the specific fix command and exits non-zero
- [x] \`cougr doctor\` with no stellar CLI on PATH reports a working install link/command rather than a generic \"not found\"
- [x] Each failure prints the exact command to fix it
- [x] Summary line: N/M checks passed with non-zero exit code if any check failed

## Related

- Closes #247
- Part of epic #238
- Follows the same patterns as \`cougr check\` (#246) and \`cougr check --verified\` (#258)
- Product spec: \`docs/strategy/06-product-strategy.md\`
- Roadmap: Phase 1 in \`docs/strategy/13-roadmap.md\`