### PR TITLE
Add Structured Example Metadata Catalog for Canonical Showcase Examples

### DIFF
--- a/examples/catalog.toml
+++ b/examples/catalog.toml
@@ -1,0 +1,73 @@
+# Cougr Example Catalog
+#
+# This file is the single source of truth for all example metadata.
+# It is consumed by the gallery generator, CI validation, and documentation tooling.
+#
+# Schema:
+#   [example.<name>]
+#   name             = string            # Directory name under examples/
+#   category         = string            # One of: arcade / board / puzzle / hidden-information / card / other
+#   maturity         = string            # canonical | transitional
+#   cougr_features   = list of strings   # Cougr APIs demonstrated (e.g. ecs, game-app, soroban-game, privacy, session-auth, zk-circuits, rich-components, auth, standards, commit-reveal)
+#   screenshot       = optional string   # Relative path to screenshot (populated by gallery generator)
+#   testnet_contract = optional string   # Deployed testnet contract ID (populated after deployment)
+
+[example.spawn_and_move]
+name = "spawn_and_move"
+category = "other"
+maturity = "canonical"
+cougr_features = ["soroban-game", "ecs"]
+
+[example.tic_tac_toe]
+name = "tic_tac_toe"
+category = "board"
+maturity = "canonical"
+cougr_features = ["soroban-game", "rich-components", "game-app"]
+
+[example.session_arena]
+name = "session_arena"
+category = "other"
+maturity = "canonical"
+cougr_features = ["soroban-game", "session-auth", "game-app"]
+
+[example.hidden_hand]
+name = "hidden_hand"
+category = "card"
+maturity = "canonical"
+cougr_features = ["soroban-game", "zk-circuits", "privacy"]
+
+[example.fog_explorer]
+name = "fog_explorer"
+category = "other"
+maturity = "canonical"
+cougr_features = ["soroban-game", "zk-circuits", "privacy"]
+
+[example.dice_duel]
+name = "dice_duel"
+category = "other"
+maturity = "canonical"
+cougr_features = ["soroban-game", "zk-circuits", "privacy"]
+
+[example.blind_auction]
+name = "blind_auction"
+category = "other"
+maturity = "canonical"
+cougr_features = ["soroban-game", "zk-circuits", "privacy"]
+
+[example.snake]
+name = "snake"
+category = "arcade"
+maturity = "canonical"
+cougr_features = ["game-app", "ecs"]
+
+[example.battleship]
+name = "battleship"
+category = "hidden-information"
+maturity = "canonical"
+cougr_features = ["privacy", "commit-reveal", "game-app", "ecs"]
+
+[example.guild_arena]
+name = "guild_arena"
+category = "other"
+maturity = "canonical"
+cougr_features = ["auth", "standards", "game-app"]

--- a/examples/catalog_broken.toml
+++ b/examples/catalog_broken.toml
@@ -1,0 +1,44 @@
+# Broken catalog fixture for validation testing
+# This file is intentionally malformed to test that validate_catalog.py catches:
+#  - Missing required fields (name omitted)
+#  - Invalid category
+#  - Invalid maturity
+#  - Nonexistent directory
+#  - Empty cougr_features
+#  - Nonexistent screenshot
+
+[example.missing_name]
+category = "arcade"
+maturity = "canonical"
+cougr_features = ["ecs"]
+
+[example.bad_category]
+name = "tic_tac_toe"
+category = "sports"
+maturity = "canonical"
+cougr_features = ["ecs"]
+
+[example.bad_maturity]
+name = "snake"
+category = "arcade"
+maturity = "obsolete"
+cougr_features = ["ecs"]
+
+[example.nonexistent_dir]
+name = "this_does_not_exist"
+category = "other"
+maturity = "canonical"
+cougr_features = ["ecs"]
+
+[example.empty_features]
+name = "spawn_and_move"
+category = "other"
+maturity = "canonical"
+cougr_features = []
+
+[example.missing_screenshot]
+name = "battleship"
+category = "hidden-information"
+maturity = "canonical"
+cougr_features = ["privacy"]
+screenshot = "screenshots/ghost.png"

--- a/scripts/validate_catalog.py
+++ b/scripts/validate_catalog.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Validate examples/catalog.toml against the filesystem and schema rules.
+
+Checks:
+  1. catalog.toml is valid TOML
+  2. Every entry has all required fields (name, category, maturity, cougr_features)
+  3. category is one of the allowed values
+  4. maturity is canonical or transitional
+  5. Every entry's name matches a directory under examples/
+  6. cougr_features is a non-empty list
+  7. If screenshot is set, the file exists
+  8. All 10 canonical examples from the standard are present
+"""
+
+import os
+import sys
+import tomllib
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CATALOG = sys.argv[1] if len(sys.argv) > 1 else os.path.join(REPO_ROOT, "examples", "catalog.toml")
+EXAMPLES_DIR = os.path.join(REPO_ROOT, "examples")
+
+VALID_CATEGORIES = {"arcade", "board", "puzzle", "hidden-information", "card", "other"}
+VALID_MATURITIES = {"canonical", "transitional"}
+REQUIRED_CANONICAL = [
+    "spawn_and_move",
+    "tic_tac_toe",
+    "session_arena",
+    "hidden_hand",
+    "fog_explorer",
+    "dice_duel",
+    "blind_auction",
+    "snake",
+    "battleship",
+    "guild_arena",
+]
+
+errors = []
+
+
+def fail(msg):
+    errors.append(msg)
+
+
+if not os.path.isfile(CATALOG):
+    fail(f"catalog.toml not found at {CATALOG}")
+    for e in errors:
+        print(f"FAIL: {e}")
+    sys.exit(1)
+
+with open(CATALOG, "rb") as f:
+    try:
+        data = tomllib.load(f)
+    except Exception as e:
+        fail(f"Invalid TOML in catalog.toml: {e}")
+        for e in errors:
+            print(f"FAIL: {e}")
+        sys.exit(1)
+
+# TOML [example.<name>] sections are parsed as a nested "example" table
+example_table = data.get("example", {})
+entries = {("example." + k): v for k, v in example_table.items()}
+if not entries:
+    fail("No [example.*] sections found in catalog.toml")
+
+# Check all required canonical examples are present
+canonical_names = set()
+for key, entry in entries.items():
+    if entry.get("maturity") == "canonical":
+        canonical_names.add(entry.get("name"))
+
+for cn in REQUIRED_CANONICAL:
+    if cn not in canonical_names:
+        fail(f"Missing required canonical example: {cn}")
+
+for key, entry in entries.items():
+    name = entry.get("name")
+
+    # Check required fields
+    for field in ["name", "category", "maturity", "cougr_features"]:
+        if field not in entry:
+            fail(f"{key}: missing required field \"{field}\"")
+
+    if not name:
+        continue
+
+    example_dir = os.path.join(EXAMPLES_DIR, name)
+
+    # Check example directory exists
+    if not os.path.isdir(example_dir):
+        fail(f'{key}: example directory "{name}" does not exist at examples/{name}')
+
+    category = entry.get("category")
+    if category and category not in VALID_CATEGORIES:
+        fail(f'{key}: invalid category "{category}" (must be one of: {", ".join(sorted(VALID_CATEGORIES))})')
+
+    maturity = entry.get("maturity")
+    if maturity and maturity not in VALID_MATURITIES:
+        fail(f'{key}: invalid maturity "{maturity}" (must be canonical or transitional)')
+
+    cougr_features = entry.get("cougr_features")
+    if cougr_features is not None:
+        if not isinstance(cougr_features, list):
+            fail(f"{key}: cougr_features must be a list")
+        elif len(cougr_features) == 0:
+            fail(f"{key}: cougr_features must be a non-empty list")
+
+    screenshot = entry.get("screenshot")
+    if screenshot:
+        screenshot_path = os.path.join(REPO_ROOT, screenshot)
+        if not os.path.isfile(screenshot_path):
+            fail(f'{key}: screenshot file "{screenshot}" not found')
+
+if errors:
+    for e in errors:
+        print(f"FAIL: {e}")
+    sys.exit(1)
+
+print("All catalog validation checks passed")

--- a/scripts/validate_catalog.sh
+++ b/scripts/validate_catalog.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# validate_catalog.sh
+#
+# Validates examples/catalog.toml against the filesystem and schema rules.
+# Delegates to validate_catalog.py (the canonical implementation).
+# Run from the repository root.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+exec python3 "$REPO_ROOT/scripts/validate_catalog.py"


### PR DESCRIPTION
##closed #255 

Create a structured metadata catalog for the project's canonical examples to replace the current prose-only catalog in examples/README.md with machine-readable data. This metadata will serve as the single source of truth for tooling such as the upcoming example gallery while remaining synchronized with the existing documentation.

The implementation should introduce a TOML-based schema (either a centralized examples/catalog.toml or individual metadata files per example, with the chosen approach justified in the PR) containing metadata fields such as example name, category, maturity, supported Cougr features, optional screenshot path, and optional testnet contract information.

Populate the catalog for all 10 canonical examples, ensuring consistency with examples/README.md, EXAMPLE_STANDARD.md, and each example's own README.md. Additionally, implement a validation check that verifies required fields are present and that every catalog entry references a valid example directory, with tests covering both successful validation and expected failures for invalid fixtures.