### PR TITLE
Update PATTERNS.md

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -6,6 +6,29 @@ This document captures the recommended architectural patterns for new Soroban ga
 
 The goal is to standardize how teams structure worlds, systems, stages, and storage choices instead of relying on ad-hoc example interpretation.
 
+## Find a pattern by problem
+
+Start here if you know what you're trying to build but not which Cougr module answers it. Each row links to the module-level doc for full detail, and to a concrete, current example that demonstrates it.
+
+| I want... | Use | Example | Read more |
+|---|---|---|---|
+| **Fairness** (a roll, a draw, an outcome no one can predict or bias) | `circuits::FairDiceBuilder` — on-chain Groth16-verified randomness (Experimental) | [`dice_duel`](../examples/dice_duel) | [Hidden Information Guidance](#hidden-information-guidance) below, [PRIVACY_MODEL.md](./PRIVACY_MODEL.md) |
+| **Hidden information** (cards, ship positions, sealed bids — state some players shouldn't see) | `privacy::stable` commit-reveal + Merkle primitives | [`battleship`](../examples/battleship) (canonical), [`rock_paper_scissors`](../examples/rock_paper_scissors), [`hidden_hand`](../examples/hidden_hand), [`blind_auction`](../examples/blind_auction) | [Hidden Information Guidance](#hidden-information-guidance) below, [PRIVACY_MODEL.md](./PRIVACY_MODEL.md) |
+| **To gate an action behind a role** (admin-only, minter-only, etc.) | `AccessControl` — role-based authorization with per-role admin delegation | — | [STANDARDS_LAYER.md § AccessControl](./STANDARDS_LAYER.md#accesscontrol) |
+| **Off-chain-friendly real-time movement** (clients track state without polling) | `impl_component_observed!` — emits a `(COUGR, set, <component>)` event on every change | [`spawn_and_move`](../examples/spawn_and_move) (start here), [`snake`](../examples/snake) | [System Design](#system-design) and [Query Guidance](#query-guidance) below, `docs/ECS_CORE.md` |
+| **A passwordless sign-in** (Face ID / Touch ID instead of a seed phrase) | `secp256r1` passkey signer, composed through `AccountKernel` | [`guild_arena`](../examples/guild_arena) | [ACCOUNT_KERNEL.md § Signers](./ACCOUNT_KERNEL.md#signers) |
+| **A session players approve once, not per-transaction** | Session signer + `SessionPolicy` (scope, expiry, operation budget) | [`session_arena`](../examples/session_arena) | [ACCOUNT_KERNEL.md § Session Model](./ACCOUNT_KERNEL.md#session-model) |
+| **Account recovery if a device is lost** | `GuardianPolicy` + `ActiveDevicePolicy` | [`guild_arena`](../examples/guild_arena) | [ACCOUNT_KERNEL.md § Policies](./ACCOUNT_KERNEL.md#policies) |
+| **An emergency stop / pause switch** | `Pausable` | — | [STANDARDS_LAYER.md § Pausable](./STANDARDS_LAYER.md#pausable) |
+| **To serialize mutations / guard against reentrancy-like issues** | `ExecutionGuard` | — | [STANDARDS_LAYER.md § ExecutionGuard](./STANDARDS_LAYER.md#executionguard) |
+| **Delayed or timelocked execution** | `DelayedExecutionPolicy` | — | [STANDARDS_LAYER.md § DelayedExecutionPolicy](./STANDARDS_LAYER.md#delayedexecutionpolicy) |
+| **To batch several operations safely** | `BatchExecutor` | — | [STANDARDS_LAYER.md § BatchExecutor](./STANDARDS_LAYER.md#batchexecutor) |
+| **To know whether I even need ECS** | Direct contract model for small/config-driven contracts | — | [When Not To Use ECS](#when-not-to-use-ecs) below |
+| **To pick table vs. sparse storage** | Table for hot-loop state, sparse for infrequent markers | — | [Storage Guidance](#storage-guidance) below |
+| **A thin, explicit contract entrypoint / gameplay loop** | `GameApp` + explicit stage placement | [`spawn_and_move`](../examples/spawn_and_move), [`snake`](../examples/snake) | [Default Entry Point](#default-entry-point) and [Stage Layout](#stage-layout) below |
+
+Everything below this point is the module-level architectural guidance the table above links into — organized by Cougr's internal structure rather than by problem, for readers who already know which area they're working in.
+
 ## Default Entry Point
 
 Use `GameApp` as the default runtime entrypoint.


### PR DESCRIPTION
close #252 

docs(patterns): restructure PATTERNS.md into a problem-oriented guide

What changed

Restructured docs/PATTERNS.md in place — no companion file — so it leads with a "find a pattern by problem" index instead of requiring the reader to already know which internal module answers their question.

Added a top-level table mapping developer intent → concrete module/macro → canonical example → link to the deeper doc. Covers fairness, hidden information, role-gating, off-chain-friendly real-time movement, passwordless sign-in, sessions, account recovery, pause, reentrancy guarding, delayed execution, and batching.
Every row links out to STANDARDS_LAYER.md, ACCOUNT_KERNEL.md, or PRIVACY_MODEL.md (anchored to the specific section) and, where one exists, to a canonical example under examples/ (spawn_and_move, battleship, guild_arena, session_arena, dice_duel, etc.).
All 8 original sections — Default Entry Point, Stage Layout, System Design, Query Guidance, Hidden Information Guidance, Storage Guidance, Recommended Separation, When Not To Use ECS — are preserved verbatim below the table. Nothing was dropped or rewritten; the problem index just points into them.
Rewrite vs. companion page

Went with restructuring PATTERNS.md in place rather than adding a new file. The original was ~110 lines, so a separate companion page would have meant either duplicating content or maintaining two docs that could drift out of sync. A single file with a problem-oriented front half and a module-oriented reference half satisfies both audiences without a second source of truth.

Verification
Every problem-index entry checked against current source: modules referenced (AccessControl, Pausable, ExecutionGuard, DelayedExecutionPolicy, BatchExecutor, SessionPolicy, GuardianPolicy, ActiveDevicePolicy, secp256r1 passkey signer, privacy::stable, FairDiceBuilder) all exist in the current STANDARDS_LAYER.md, ACCOUNT_KERNEL.md, and PRIVACY_MODEL.md.
Examples linked (spawn_and_move, battleship, guild_arena, session_arena, dice_duel, rock_paper_scissors, hidden_hand, blind_auction, snake) all exist in examples/ and match their documented focus in examples/README.md.
Anchor links generated from each module doc's actual ### headers; recommend a click-through on the rendered PR preview since GitHub's backtick-anchor handling can be inconsistent.
No pattern from the original PATTERNS.md is unreachable — confirmed by diffing section headers against the restructured version.