### PR TITLE
ci(cli): add CI and crates.io publish pipeline for cougr-cli

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,55 @@
+name: CLI CI
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'cougr-cli/**'
+      - '!cougr-cli/**/*.md'
+      - '.github/workflows/cli.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'cougr-cli/**'
+      - '!cougr-cli/**/*.md'
+      - '.github/workflows/cli.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: cli-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli:
+    name: CLI Validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: cougr-cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cougr-cli -> target
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Build
+        run: cargo build

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,168 @@
+name: Publish CLI Crate
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'cougr-cli-v*'
+    paths:
+      - 'cougr-cli/**'
+      - '!cougr-cli/**/*.md'
+      - '.github/workflows/publish-cli.yml'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish the current cougr-cli Cargo.toml version to crates.io'
+        required: true
+        type: boolean
+        default: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-cli-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    name: Package crate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: cougr-cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cougr-cli -> target
+
+      - name: Check package
+        run: cargo package
+
+  publish:
+    name: Publish to crates.io
+    needs: package
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/cougr-cli-v') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: cougr-cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cougr-cli -> target
+
+      - name: Read crate metadata
+        id: crate
+        run: |
+          metadata="$(cargo metadata --no-deps --format-version 1)"
+          echo "name=$(echo "$metadata" | jq -r '.packages[0].name')" >> "$GITHUB_OUTPUT"
+          echo "version=$(echo "$metadata" | jq -r '.packages[0].version')" >> "$GITHUB_OUTPUT"
+
+      - name: Check crates.io version
+        id: crates
+        run: |
+          # crates.io rejects requests with no descriptive User-Agent (403);
+          # see https://crates.io/data-access
+          response="$(curl -fsSL \
+            -H "User-Agent: cougr-cli-publish-workflow (+https://github.com/salazarsebas/Cougr)" \
+            "https://crates.io/api/v1/crates/${{ steps.crate.outputs.name }}")"
+          published=false
+
+          if echo "$response" | jq -e --arg version "${{ steps.crate.outputs.version }}" '.versions[]? | select(.num == $version)' >/dev/null; then
+            published=true
+          fi
+
+          echo "published=$published" >> "$GITHUB_OUTPUT"
+
+      - name: Publish crate
+        if: steps.crates.outputs.published != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: Skip already published version
+        if: steps.crates.outputs.published == 'true'
+        run: echo "${{ steps.crate.outputs.name }} ${{ steps.crate.outputs.version }} is already published on crates.io"
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/cougr-cli-v') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read crate version
+        id: crate
+        run: |
+          version="$(grep -m1 '^version' cougr-cli/Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=cougr-cli-v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.crate.outputs.tag }}" &>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract changelog section
+        if: steps.check.outputs.exists != 'true'
+        id: changelog
+        run: |
+          version="${{ steps.crate.outputs.version }}"
+          notes="$(awk "/^## $version/{found=1; next} found && /^## /{exit} found{print}" cougr-cli/CHANGELOG.md 2>/dev/null)"
+          if [ -z "$notes" ]; then
+            notes="See [CHANGELOG.md](cougr-cli/CHANGELOG.md) for details."
+          fi
+          {
+            echo "notes<<EOF"
+            echo "$notes"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag exists
+        if: steps.check.outputs.exists != 'true'
+        run: |
+          tag="${{ steps.crate.outputs.tag }}"
+          if ! git rev-parse "$tag" &>/dev/null; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "$tag"
+            git push origin "$tag"
+          fi
+
+      - name: Create release
+        if: steps.check.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.crate.outputs.tag }}" \
+            --title "${{ steps.crate.outputs.tag }}" \
+            --notes "${{ steps.changelog.outputs.notes }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/cli.yml`: fmt/clippy(`-D warnings`)/test/build for `cougr-cli`, path-scoped to `cougr-cli/**` so it doesn't run on unrelated changes (mirrors `core.yml`'s job shape, using a `working-directory` default like `example_reusable.yml` since `cougr-cli` isn't a workspace member yet).
- Adds `.github/workflows/publish-cli.yml`: package → publish-to-crates.io (with the same crates.io pre-check guard as `publish-crate.yml` to skip already-published versions) → GitHub Release, triggered on `main` pushes touching `cougr-cli/**` and on `cougr-cli-v*` tags (distinct tag prefix so CLI releases don't collide with `cougr-core`'s `v*` tags).
- No changes to `core.yml` or `publish-crate.yml` — `cougr-core`'s existing CI/publish behavior is untouched.

Note: `cougr-cli` itself doesn't exist yet (tracked by the other sub-issues of #238). These workflows are path-scoped to `cougr-cli/**` and simply won't trigger until that crate lands — same pattern as the per-example workflows before their example directories existed.

## Test plan
- [ ] Once `cougr-cli/` is added as a workspace member (per #238's other sub-issues), open a PR touching only `cougr-cli/**` and confirm `CLI CI` triggers while the full example matrix does not.
- [ ] Bump `cougr-cli/Cargo.toml`'s version on `main` and confirm `Publish CLI Crate` publishes to crates.io and cuts a GitHub Release tagged `cougr-cli-v<version>`.
- [x] Reviewed YAML structure against `core.yml`, `publish-crate.yml`, and `example_reusable.yml` for consistency.

Closes #248