### PR TITLE
feat(cli): implement 'cougr new' project generator with template selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`cougr-cli`** — new workspace member publishing the `cougr` binary
+- **`cougr new <name> [--template <name>]`** — scaffolds a Soroban game contract crate
+  following the canonical `lib.rs` / `components.rs` / `systems.rs` layout, with a
+  passing `test::GameHarness` suite and a dependency on the published `cougr-core`
+  release rather than a path dependency
+- **Four embedded templates**, each derived from a canonical example and compiled into
+  the binary so `cougr new` works offline: `starter` (`spawn_and_move`), `turn-based`
+  (`tic_tac_toe`), `hidden-info` (`hidden_hand`), `session-auth` (`session_arena`)
+- **CLI CI workflow** — lints and tests `cougr-cli`, then generates each template and
+  runs `cargo fmt`, `clippy`, `cargo test`, and a `wasm32v1-none` release build against it
+
 ## 1.1.0
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,7 +133,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest",
+ "digest 0.10.7",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -136,7 +186,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
@@ -186,12 +236,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -264,16 +329,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cougr-cli"
+version = "1.1.0"
+dependencies = [
+ "clap",
+ "rust-embed",
+ "tempfile",
+]
 
 [[package]]
 name = "cougr-core"
@@ -314,6 +440,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,9 +513,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -470,7 +614,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -512,10 +656,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -552,7 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -578,7 +733,7 @@ dependencies = [
  "ed25519",
  "rand_core",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -597,7 +752,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -614,6 +769,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "escape-bytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +789,12 @@ name = "ethnum"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -675,6 +846,17 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -755,7 +937,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -818,6 +1009,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,7 +1048,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -860,7 +1057,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -874,6 +1071,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -903,6 +1106,22 @@ name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "num-bigint"
@@ -956,6 +1175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,7 +1189,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1036,6 +1261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +1293,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1096,6 +1327,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,10 +1371,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schemars"
@@ -1246,8 +1534,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1256,7 +1555,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -1272,7 +1571,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -1339,7 +1638,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1350,7 +1649,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "sec1",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
@@ -1425,7 +1724,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "sha2",
+ "sha2 0.10.9",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
@@ -1440,7 +1739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24718fac3af127fc6910eb6b1d3ccd8403201b6ef0aca73b5acabe4bc3dd42ed"
 dependencies = [
  "base64",
- "sha2",
+ "sha2 0.10.9",
  "stellar-xdr",
  "thiserror",
  "wasmparser",
@@ -1455,7 +1754,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2",
+ "sha2 0.10.9",
  "soroban-spec",
  "stellar-xdr",
  "syn 2.0.117",
@@ -1539,7 +1838,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "stellar-strkey 0.0.13",
 ]
 
@@ -1575,6 +1874,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1630,15 +1953,27 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -1655,6 +1990,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1774,6 +2119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +2188,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "cli",
     "internal/cougr-core-circuits",
     "internal/cougr-core-session",
     "internal/cougr-core-test",
@@ -21,6 +22,7 @@ categories = ["game-engines", "data-structures", "wasm"]
 rust-version = "1.70.0"
 exclude = [
     ".github/**",
+    "cli/**",
     "examples/**",
     "public/**",
     "research/**",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ cougr-core = "1.1.0"
 soroban-sdk = "25.1.0"
 ```
 
+Or scaffold a whole project with the CLI:
+
+```bash
+cargo install cougr-cli
+
+cougr new my-game --template starter
+cd my-game
+cargo test
+```
+
+`cougr new` generates a contract crate following the canonical
+`lib.rs` / `components.rs` / `systems.rs` layout with a passing `GameHarness`
+test suite. Four templates are available — `starter`, `turn-based`,
+`hidden-info`, and `session-auth` — each derived from a canonical example. See
+[`cli/README.md`](cli/README.md).
+
 ## Quick start — your first on-chain game in 30 lines
 
 ```toml
@@ -278,6 +294,7 @@ pause.pause(&env);
 | Path | Purpose |
 |---|---|
 | `src/` | Core framework |
+| `cli/` | `cougr-cli` — the `cougr` binary and its embedded project templates |
 | `examples/spawn_and_move/` | Canonical starter — spawn + movement with ECS events |
 | `examples/tic_tac_toe/` | Turn-based game with rich components and address ownership |
 | `examples/*/` | 20+ standalone game contracts (asteroids, chess, battleship …) |

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cougr-cli"
+version = "1.1.0"
+edition = "2021"
+description = "Command-line tooling for Cougr — scaffold Soroban game contracts wired to cougr-core"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/salazarsebas/Cougr"
+homepage = "https://github.com/salazarsebas/Cougr"
+keywords = ["cli", "soroban", "stellar", "game", "scaffold"]
+categories = ["command-line-utilities", "development-tools", "game-development"]
+rust-version = "1.82.0"
+include = ["src/**", "templates/**", "tests/**", "build.rs", "README.md"]
+
+[[bin]]
+name = "cougr"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4.6", features = ["derive"] }
+# `debug-embed` keeps the templates compiled into the binary in debug builds
+# too, so `cougr new` behaves identically for contributors and end users.
+rust-embed = { version = "8.12", features = ["debug-embed"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,67 @@
+# cougr-cli
+
+Command-line tooling for [Cougr](https://github.com/salazarsebas/Cougr), the ECS
+framework for on-chain games on Stellar/Soroban.
+
+```bash
+cargo install cougr-cli
+
+cougr new my-game --template starter
+cd my-game
+cargo test
+```
+
+## `cougr new`
+
+```
+cougr new <NAME> [--template <TEMPLATE>] [--path <DIR>]
+```
+
+Scaffolds a Soroban contract crate wired to `cougr-core`, following the
+`lib.rs` / `components.rs` / `systems.rs` layout defined by
+[`EXAMPLE_STANDARD.md`](../examples/EXAMPLE_STANDARD.md), with a passing
+`GameHarness` test suite. The generated crate depends on the published
+`cougr-core` release, so it builds outside this repository.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--template`, `-t` | `starter` | Which starting point to generate |
+| `--path` | current directory | Where to create the project directory |
+
+### Templates
+
+Each template is derived from a canonical example, so the code you get is the
+same code the framework's own reference projects run.
+
+| Template | Based on | What you get |
+| --- | --- | --- |
+| `starter` | `examples/spawn_and_move` | Spawn entities and move them around a 2D world, with observed components emitting indexed events |
+| `turn-based` | `examples/tic_tac_toe` | Two players alternating on a board, with rich `Address`/`Vec` components |
+| `hidden-info` | `examples/hidden_hand` | Hidden hands verified with Groth16 proofs via `circuits::hidden_cards` |
+| `session-auth` | `examples/session_arena` | Approve a session once, play without wallet prompts, fall back to owner auth on expiry |
+
+Templates are embedded in the binary at compile time, so `cougr new` works
+offline.
+
+## Development
+
+```bash
+cargo test -p cougr-cli                 # unit and CLI tests
+cargo test -p cougr-cli -- --ignored    # generate all 4 templates and cargo test each
+```
+
+Template sources live in [`templates/`](templates/). Files there use two naming
+conventions that the CLI undoes when writing a project:
+
+* `Cargo.toml.tmpl` → `Cargo.toml`. Cargo skips subdirectories containing a
+  manifest when packaging a crate, which would drop the template manifests from
+  the published binary.
+* `gitignore` → `.gitignore`, so the file ships as content instead of applying
+  to this repository.
+
+Inside a template, `{{crate_name}}`, `{{module_name}}`, `{{ContractName}}`,
+`{{description}}`, `{{template_id}}`, `{{source_example}}`,
+`{{cougr_core_version}}`, and `{{soroban_sdk_version}}` are substituted at
+generation time. `cargo test -p cougr-cli` fails if a placeholder survives, if a
+template drops a file from the canonical layout, if a manifest reaches for a
+path dependency, or if a test module stops using `GameHarness`.

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,9 @@
+//! Rebuild the CLI whenever an embedded template changes.
+//!
+//! `rust-embed` bakes `templates/` into the binary through a derive macro,
+//! which Cargo cannot see as an input on its own. Without this, editing a
+//! template leaves a stale copy compiled into `cougr`.
+
+fn main() {
+    println!("cargo:rerun-if-changed=templates");
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod new;

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -1,0 +1,165 @@
+//! `cougr new <name> [--template <name>]`.
+//!
+//! Renders one embedded template into a fresh directory and prints the two
+//! commands that take the developer from generated source to a green test run
+//! and a WASM artifact.
+
+use std::fs;
+use std::path::Path;
+
+use crate::error::CliError;
+use crate::name::ProjectName;
+use crate::template::{RenderedFile, Template};
+
+pub fn run(raw_name: &str, template: Template, parent: Option<&Path>) -> Result<(), CliError> {
+    let name = ProjectName::parse(raw_name)?;
+
+    let parent = match parent {
+        Some(dir) => dir.to_path_buf(),
+        None => std::env::current_dir()
+            .map_err(|err| CliError::io("resolve the current directory", ".", err))?,
+    };
+    let target = parent.join(name.crate_name());
+
+    if target.exists() {
+        return Err(CliError::TargetExists { path: target });
+    }
+
+    let files = template.render(&name)?;
+
+    fs::create_dir_all(&target)
+        .map_err(|err| CliError::io("create the project directory", &target, err))?;
+
+    // A half-written project is worse than none: on any write failure, remove
+    // the tree so a retry does not trip the "already exists" check above.
+    if let Err(err) = write_all(&target, &files) {
+        let _ = fs::remove_dir_all(&target);
+        return Err(err);
+    }
+
+    report_success(&target, name.crate_name(), template, &files);
+    Ok(())
+}
+
+fn write_all(target: &Path, files: &[RenderedFile]) -> Result<(), CliError> {
+    for file in files {
+        let path = target.join(&file.path);
+        if let Some(dir) = path.parent() {
+            fs::create_dir_all(dir)
+                .map_err(|err| CliError::io("create the directory", dir, err))?;
+        }
+        fs::write(&path, &file.contents)
+            .map_err(|err| CliError::io("write the file", &path, err))?;
+    }
+    Ok(())
+}
+
+fn report_success(target: &Path, crate_name: &str, template: Template, files: &[RenderedFile]) {
+    println!(
+        "Created `{crate_name}` from the `{}` template (based on examples/{}).",
+        template.id(),
+        template.source_example()
+    );
+    println!();
+    println!("  {}/", target.display());
+    for file in files {
+        println!("    {}", file.path);
+    }
+    println!();
+    println!("Next steps:");
+    println!("  cd {crate_name}");
+    println!("  cargo test                # run the GameHarness test suite");
+    println!("  stellar contract build    # compile the contract to WASM");
+    println!();
+    println!("`stellar contract build` needs the Stellar CLI and the wasm32v1-none target:");
+    println!("  rustup target add wasm32v1-none");
+    println!("  cargo install --locked stellar-cli");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("create temp dir")
+    }
+
+    #[test]
+    fn generates_the_canonical_layout_on_disk() {
+        let dir = tempdir();
+        run("demo", Template::Starter, Some(dir.path())).unwrap();
+
+        let project = dir.path().join("demo");
+        for expected in [
+            "Cargo.toml",
+            "README.md",
+            ".gitignore",
+            "src/lib.rs",
+            "src/components.rs",
+            "src/systems.rs",
+            "src/test.rs",
+        ] {
+            assert!(project.join(expected).is_file(), "missing {expected}");
+        }
+    }
+
+    #[test]
+    fn substitutes_the_project_name_into_the_manifest_and_lib() {
+        let dir = tempdir();
+        run("tower-siege", Template::TurnBased, Some(dir.path())).unwrap();
+
+        let project = dir.path().join("tower-siege");
+        let manifest = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+        assert!(manifest.contains("name = \"tower-siege\""));
+
+        let lib = fs::read_to_string(project.join("src/lib.rs")).unwrap();
+        assert!(lib.contains("pub struct TowerSiege;"));
+        assert!(lib.contains("tower-siege"), "module doc names the project");
+    }
+
+    #[test]
+    fn refuses_to_overwrite_an_existing_directory() {
+        let dir = tempdir();
+        fs::create_dir(dir.path().join("demo")).unwrap();
+
+        let err = run("demo", Template::Starter, Some(dir.path())).unwrap_err();
+        assert!(matches!(err, CliError::TargetExists { .. }));
+    }
+
+    #[test]
+    fn rejects_an_invalid_name_before_touching_the_filesystem() {
+        let dir = tempdir();
+        let err = run("../escape", Template::Starter, Some(dir.path())).unwrap_err();
+
+        assert!(matches!(err, CliError::InvalidName { .. }));
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn every_template_writes_a_complete_project() {
+        for template in [
+            Template::Starter,
+            Template::TurnBased,
+            Template::HiddenInfo,
+            Template::SessionAuth,
+        ] {
+            let dir = tempdir();
+            run("demo", template, Some(dir.path())).unwrap();
+            let project = dir.path().join("demo");
+
+            let manifest = fs::read_to_string(project.join("Cargo.toml")).unwrap();
+            assert!(
+                manifest.contains("cougr-core = \""),
+                "{} manifest must depend on cougr-core",
+                template.id()
+            );
+            assert!(
+                fs::read_to_string(project.join("src/test.rs"))
+                    .unwrap()
+                    .contains("GameHarness"),
+                "{} must ship a GameHarness test",
+                template.id()
+            );
+        }
+    }
+}

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,0 +1,93 @@
+//! Error type for the CLI.
+//!
+//! Every variant carries enough context to print an actionable message: what
+//! went wrong, and — through [`CliError::hint`] — what the user can do about
+//! it. Nothing in the command path is allowed to panic on user input.
+
+use std::fmt;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum CliError {
+    /// The project name is not usable as a Rust crate name.
+    InvalidName { name: String, reason: String },
+
+    /// The target directory already exists.
+    TargetExists { path: PathBuf },
+
+    /// A filesystem operation failed.
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// A template file could not be read out of the embedded bundle. This is a
+    /// packaging bug rather than a user error, but it must not panic either.
+    MissingTemplateAsset {
+        template: &'static str,
+        file: String,
+    },
+}
+
+impl CliError {
+    pub fn io(action: &'static str, path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        CliError::Io {
+            action,
+            path: path.into(),
+            source,
+        }
+    }
+
+    /// A one-line suggestion printed under the error, when one applies.
+    pub fn hint(&self) -> Option<String> {
+        match self {
+            CliError::InvalidName { .. } => Some(
+                "crate names start with a letter and use letters, digits, `_` or `-` \
+                 (for example: `my-game` or `dungeon_crawl`)"
+                    .to_string(),
+            ),
+            CliError::TargetExists { path } => Some(format!(
+                "pick a different name, or remove `{}` first",
+                path.display()
+            )),
+            CliError::Io { .. } => None,
+            CliError::MissingTemplateAsset { .. } => Some(
+                "this is a bug in cougr-cli — please report it at \
+                 https://github.com/salazarsebas/Cougr/issues"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CliError::InvalidName { name, reason } => {
+                write!(f, "`{name}` is not a valid project name: {reason}")
+            }
+            CliError::TargetExists { path } => {
+                write!(f, "target directory `{}` already exists", path.display())
+            }
+            CliError::Io {
+                action,
+                path,
+                source,
+            } => write!(f, "failed to {action} `{}`: {source}", path.display()),
+            CliError::MissingTemplateAsset { template, file } => write!(
+                f,
+                "template `{template}` is missing the embedded file `{file}`"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CliError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CliError::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,73 @@
+//! `cougr` — command-line tooling for the Cougr ECS framework.
+//!
+//! Currently exposes a single command, [`cougr new`](commands::new), which
+//! scaffolds a Soroban game contract wired to `cougr-core` from one of four
+//! embedded templates.
+
+mod commands;
+mod error;
+mod name;
+mod template;
+
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+use crate::error::CliError;
+use crate::template::Template;
+
+#[derive(Parser)]
+#[command(
+    name = "cougr",
+    version,
+    about = "Tooling for building on-chain games with cougr-core",
+    propagate_version = true
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Create a new Cougr game contract crate.
+    New {
+        /// Name of the project. Becomes the crate name and the directory name.
+        name: String,
+
+        /// Starting point for the generated project.
+        #[arg(short, long, value_enum, default_value_t = Template::Starter)]
+        template: Template,
+
+        /// Directory to create the project in. Defaults to the current directory.
+        #[arg(long, value_name = "DIR")]
+        path: Option<std::path::PathBuf>,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Command::New {
+            name,
+            template,
+            path,
+        } => commands::new::run(&name, template, path.as_deref()),
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            report(&err);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn report(err: &CliError) {
+    eprintln!("error: {err}");
+    if let Some(hint) = err.hint() {
+        eprintln!("  help: {hint}");
+    }
+}

--- a/cli/src/name.rs
+++ b/cli/src/name.rs
@@ -1,0 +1,184 @@
+//! Project-name validation and the case conversions the templates need.
+//!
+//! A single user-supplied name drives three different identifiers in the
+//! generated crate: the Cargo package name, the Rust module/library name, and
+//! the `#[contract]` struct name. [`ProjectName`] derives all three once so the
+//! rest of the CLI never has to re-guess them.
+
+use crate::error::CliError;
+
+/// Rust keywords that cannot be used as a library target name. `cargo` rejects
+/// these outright, so catching them here turns a confusing downstream build
+/// failure into an immediate, readable error.
+const RUST_KEYWORDS: &[&str] = &[
+    "abstract", "as", "async", "await", "become", "box", "break", "const", "continue", "crate",
+    "do", "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in",
+    "let", "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub", "ref",
+    "return", "self", "static", "struct", "super", "trait", "true", "try", "type", "typeof",
+    "unsafe", "unsized", "use", "virtual", "where", "while", "yield",
+];
+
+/// Names Cargo refuses outright (`test` collides with the built-in test crate)
+/// or that would shadow the framework the generated project depends on.
+const RESERVED_NAMES: &[&str] = &["cougr", "cougr-core", "cougr_core", "cougr-cli", "test"];
+
+/// The longest name crates.io accepts.
+const MAX_NAME_LEN: usize = 64;
+
+/// A validated project name plus its derived spellings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectName {
+    /// The name exactly as typed — used for the Cargo package and directory.
+    crate_name: String,
+    /// `snake_case` form — the Rust library/module identifier.
+    module_name: String,
+    /// `PascalCase` form — the `#[contract]` struct identifier.
+    type_name: String,
+}
+
+impl ProjectName {
+    /// Validate `input` and derive the module and type spellings from it.
+    pub fn parse(input: &str) -> Result<Self, CliError> {
+        let invalid = |reason: &str| CliError::InvalidName {
+            name: input.to_string(),
+            reason: reason.to_string(),
+        };
+
+        if input.is_empty() {
+            return Err(invalid("it is empty"));
+        }
+        if input.len() > MAX_NAME_LEN {
+            return Err(invalid(&format!(
+                "it is {} characters long, the maximum is {MAX_NAME_LEN}",
+                input.len()
+            )));
+        }
+
+        let first = input.chars().next().expect("checked non-empty above");
+        if !first.is_ascii_alphabetic() {
+            return Err(invalid("it must start with an ASCII letter"));
+        }
+
+        if let Some(bad) = input
+            .chars()
+            .find(|c| !c.is_ascii_alphanumeric() && *c != '_' && *c != '-')
+        {
+            return Err(invalid(&format!("`{bad}` is not allowed in a crate name")));
+        }
+
+        let module_name = input.replace('-', "_").to_ascii_lowercase();
+
+        if RUST_KEYWORDS.contains(&module_name.as_str()) {
+            return Err(invalid("it is a Rust keyword"));
+        }
+        let lowered = input.to_ascii_lowercase();
+        if RESERVED_NAMES.contains(&lowered.as_str()) {
+            return Err(invalid("that name is reserved and cannot be a crate name"));
+        }
+
+        Ok(ProjectName {
+            type_name: pascal_case(&module_name),
+            crate_name: input.to_string(),
+            module_name,
+        })
+    }
+
+    /// Cargo package name and generated directory name.
+    pub fn crate_name(&self) -> &str {
+        &self.crate_name
+    }
+
+    /// `snake_case` Rust identifier for the library target.
+    pub fn module_name(&self) -> &str {
+        &self.module_name
+    }
+
+    /// `PascalCase` Rust identifier for the `#[contract]` struct.
+    pub fn type_name(&self) -> &str {
+        &self.type_name
+    }
+}
+
+/// Convert a `snake_case` identifier to `PascalCase`.
+fn pascal_case(snake: &str) -> String {
+    let mut out = String::with_capacity(snake.len());
+    for word in snake.split('_').filter(|w| !w.is_empty()) {
+        let mut chars = word.chars();
+        if let Some(first) = chars.next() {
+            out.extend(first.to_uppercase());
+            out.push_str(chars.as_str());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_all_three_spellings() {
+        let name = ProjectName::parse("dungeon-crawl").unwrap();
+        assert_eq!(name.crate_name(), "dungeon-crawl");
+        assert_eq!(name.module_name(), "dungeon_crawl");
+        assert_eq!(name.type_name(), "DungeonCrawl");
+    }
+
+    #[test]
+    fn single_word_names_are_capitalised() {
+        let name = ProjectName::parse("demo").unwrap();
+        assert_eq!(name.module_name(), "demo");
+        assert_eq!(name.type_name(), "Demo");
+    }
+
+    #[test]
+    fn mixed_case_input_is_normalised() {
+        let name = ProjectName::parse("MyGame").unwrap();
+        assert_eq!(name.crate_name(), "MyGame");
+        assert_eq!(name.module_name(), "mygame");
+        assert_eq!(name.type_name(), "Mygame");
+    }
+
+    #[test]
+    fn digits_are_allowed_after_the_first_character() {
+        let name = ProjectName::parse("arena2").unwrap();
+        assert_eq!(name.type_name(), "Arena2");
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        assert!(matches!(
+            ProjectName::parse(""),
+            Err(CliError::InvalidName { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_leading_digit() {
+        assert!(ProjectName::parse("2fast").is_err());
+    }
+
+    #[test]
+    fn rejects_path_separators_and_spaces() {
+        assert!(ProjectName::parse("../escape").is_err());
+        assert!(ProjectName::parse("my game").is_err());
+        assert!(ProjectName::parse("a/b").is_err());
+    }
+
+    #[test]
+    fn rejects_rust_keywords() {
+        assert!(ProjectName::parse("move").is_err());
+        assert!(ProjectName::parse("crate").is_err());
+    }
+
+    #[test]
+    fn rejects_reserved_names() {
+        assert!(ProjectName::parse("cougr").is_err());
+        assert!(ProjectName::parse("cougr-core").is_err());
+    }
+
+    #[test]
+    fn rejects_overlong_names() {
+        assert!(ProjectName::parse(&"a".repeat(MAX_NAME_LEN + 1)).is_err());
+    }
+}

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -1,0 +1,290 @@
+//! The embedded template layer.
+//!
+//! The four templates are derived from the canonical examples named in
+//! `examples/EXAMPLE_STANDARD.md` and are compiled into the binary with
+//! `rust-embed`, so `cougr new` works with no network access and no checkout of
+//! this repository.
+//!
+//! Template files carry two spelling conventions that [`output_path`] undoes on
+//! write:
+//!
+//! * `Cargo.toml.tmpl` → `Cargo.toml`, because Cargo skips subdirectories that
+//!   contain a manifest when packaging a crate, which would drop the template
+//!   manifests from the published `cougr-cli`.
+//! * `gitignore` → `.gitignore`, because a real dotfile in `templates/` would be
+//!   applied to this repository rather than shipped as content.
+
+use std::borrow::Cow;
+
+use clap::ValueEnum;
+use rust_embed::RustEmbed;
+
+use crate::error::CliError;
+use crate::name::ProjectName;
+
+#[derive(RustEmbed)]
+#[folder = "templates/"]
+struct Assets;
+
+/// The `cougr-core` release generated projects depend on, pinned to the current
+/// major/minor. `cougr-cli` and `cougr-core` share a release cadence, so this is
+/// this crate's own `major.minor`; the `core_version_tracks_cli_version` test
+/// fails if the two ever drift apart.
+pub const COUGR_CORE_VERSION: &str = "1.1";
+
+/// The `soroban-sdk` release every canonical example is validated against.
+pub const SOROBAN_SDK_VERSION: &str = "25.1.0";
+
+/// A curated starting point, each backed by one canonical example.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Template {
+    /// Spawn entities and move them around a 2D world (from `spawn_and_move`).
+    Starter,
+    /// Two-player turn-based board game (from `tic_tac_toe`).
+    TurnBased,
+    /// Hidden information verified with ZK proofs (from `hidden_hand`).
+    HiddenInfo,
+    /// Approve a session once, then play without wallet prompts (from `session_arena`).
+    SessionAuth,
+}
+
+impl Template {
+    /// Directory name inside `templates/`, and the value accepted by `--template`.
+    pub fn id(self) -> &'static str {
+        match self {
+            Template::Starter => "starter",
+            Template::TurnBased => "turn-based",
+            Template::HiddenInfo => "hidden-info",
+            Template::SessionAuth => "session-auth",
+        }
+    }
+
+    /// The canonical example this template was derived from.
+    pub fn source_example(self) -> &'static str {
+        match self {
+            Template::Starter => "spawn_and_move",
+            Template::TurnBased => "tic_tac_toe",
+            Template::HiddenInfo => "hidden_hand",
+            Template::SessionAuth => "session_arena",
+        }
+    }
+
+    /// One-line summary, reused as the generated crate's `description`.
+    pub fn summary(self) -> &'static str {
+        match self {
+            Template::Starter => "spawn entities and move them around a 2D world on Soroban",
+            Template::TurnBased => "a two-player turn-based board game on Soroban",
+            Template::HiddenInfo => "a hidden-information game with ZK-verified deals on Soroban",
+            Template::SessionAuth => "a session-key game loop with no per-move wallet prompts",
+        }
+    }
+
+    /// Every file in this template, sorted, as `(output path, rendered bytes)`.
+    pub fn render(self, name: &ProjectName) -> Result<Vec<RenderedFile>, CliError> {
+        let prefix = format!("{}/", self.id());
+
+        let mut sources: Vec<Cow<'static, str>> = Assets::iter()
+            .filter(|path| path.starts_with(&prefix))
+            .collect();
+        sources.sort();
+
+        if sources.is_empty() {
+            return Err(CliError::MissingTemplateAsset {
+                template: self.id(),
+                file: format!("{prefix}*"),
+            });
+        }
+
+        let mut files = Vec::with_capacity(sources.len());
+        for source in sources {
+            let asset = Assets::get(&source).ok_or_else(|| CliError::MissingTemplateAsset {
+                template: self.id(),
+                file: source.to_string(),
+            })?;
+
+            let relative = source
+                .strip_prefix(&prefix)
+                .expect("filtered on this prefix above");
+
+            files.push(RenderedFile {
+                path: output_path(relative),
+                contents: self.substitute(&String::from_utf8_lossy(&asset.data), name),
+            });
+        }
+
+        Ok(files)
+    }
+
+    /// Replace every `{{placeholder}}` a template may contain.
+    fn substitute(self, body: &str, name: &ProjectName) -> String {
+        body.replace("{{crate_name}}", name.crate_name())
+            .replace("{{module_name}}", name.module_name())
+            .replace("{{ContractName}}", name.type_name())
+            .replace("{{description}}", self.summary())
+            .replace("{{template_id}}", self.id())
+            .replace("{{source_example}}", self.source_example())
+            .replace("{{cougr_core_version}}", COUGR_CORE_VERSION)
+            .replace("{{soroban_sdk_version}}", SOROBAN_SDK_VERSION)
+    }
+}
+
+/// A single file to write into the generated project.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedFile {
+    /// Path relative to the project root, using `/` separators.
+    pub path: String,
+    pub contents: String,
+}
+
+/// Map a template-relative path to its path in the generated project.
+fn output_path(relative: &str) -> String {
+    let stripped = relative.strip_suffix(".tmpl").unwrap_or(relative);
+    match stripped.rsplit_once('/') {
+        Some((dir, "gitignore")) => format!("{dir}/.gitignore"),
+        None if stripped == "gitignore" => ".gitignore".to_string(),
+        _ => stripped.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: [Template; 4] = [
+        Template::Starter,
+        Template::TurnBased,
+        Template::HiddenInfo,
+        Template::SessionAuth,
+    ];
+
+    /// Truncate a semver string to its `major.minor` prefix.
+    fn major_minor(version: &str) -> &str {
+        match version.match_indices('.').nth(1) {
+            Some((idx, _)) => &version[..idx],
+            None => version,
+        }
+    }
+
+    #[test]
+    fn core_version_tracks_cli_version() {
+        assert_eq!(COUGR_CORE_VERSION, major_minor(env!("CARGO_PKG_VERSION")));
+        assert_eq!(major_minor("2.0.13"), "2.0");
+        assert_eq!(major_minor("10.24.0-rc.1"), "10.24");
+    }
+
+    #[test]
+    fn manifests_and_dotfiles_are_renamed_on_write() {
+        assert_eq!(output_path("Cargo.toml.tmpl"), "Cargo.toml");
+        assert_eq!(output_path("gitignore"), ".gitignore");
+        assert_eq!(output_path("src/lib.rs"), "src/lib.rs");
+        assert_eq!(output_path("nested/gitignore"), "nested/.gitignore");
+    }
+
+    #[test]
+    fn every_template_ships_the_canonical_layout() {
+        let name = ProjectName::parse("demo").unwrap();
+        for template in ALL {
+            let paths: Vec<_> = template
+                .render(&name)
+                .unwrap()
+                .into_iter()
+                .map(|f| f.path)
+                .collect();
+            for required in [
+                "Cargo.toml",
+                "README.md",
+                ".gitignore",
+                "src/lib.rs",
+                "src/components.rs",
+                "src/systems.rs",
+                "src/test.rs",
+            ] {
+                assert!(
+                    paths.iter().any(|p| p == required),
+                    "template `{}` is missing `{required}` (has {paths:?})",
+                    template.id()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_placeholder_survives_rendering() {
+        let name = ProjectName::parse("demo").unwrap();
+        for template in ALL {
+            for file in template.render(&name).unwrap() {
+                assert!(
+                    !file.contents.contains("{{"),
+                    "template `{}` left a placeholder in `{}`",
+                    template.id(),
+                    file.path
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn generated_manifests_use_the_published_crate() {
+        let name = ProjectName::parse("my-game").unwrap();
+        for template in ALL {
+            let manifest = template
+                .render(&name)
+                .unwrap()
+                .into_iter()
+                .find(|f| f.path == "Cargo.toml")
+                .expect("every template has a manifest");
+
+            assert!(manifest.contents.contains("name = \"my-game\""));
+            assert!(
+                manifest
+                    .contents
+                    .contains(&format!("cougr-core = \"{COUGR_CORE_VERSION}\"")),
+                "`{}` must depend on the published cougr-core",
+                template.id()
+            );
+            assert!(
+                !manifest.contents.contains("path ="),
+                "`{}` must not use a path dependency",
+                template.id()
+            );
+        }
+    }
+
+    #[test]
+    fn generated_tests_use_the_game_harness() {
+        let name = ProjectName::parse("demo").unwrap();
+        for template in ALL {
+            let test = template
+                .render(&name)
+                .unwrap()
+                .into_iter()
+                .find(|f| f.path == "src/test.rs")
+                .expect("every template has a test module");
+            assert!(
+                test.contents.contains("cougr_core::test::GameHarness"),
+                "`{}` must test through GameHarness",
+                template.id()
+            );
+        }
+    }
+
+    #[test]
+    fn contract_type_name_follows_the_project_name() {
+        let name = ProjectName::parse("dungeon-crawl").unwrap();
+        let lib = Template::Starter
+            .render(&name)
+            .unwrap()
+            .into_iter()
+            .find(|f| f.path == "src/lib.rs")
+            .unwrap();
+        assert!(lib.contents.contains("pub struct DungeonCrawl;"));
+    }
+
+    #[test]
+    fn template_ids_are_stable() {
+        assert_eq!(
+            ALL.map(Template::id),
+            ["starter", "turn-based", "hidden-info", "session-auth"]
+        );
+    }
+}

--- a/cli/templates/hidden-info/Cargo.toml.tmpl
+++ b/cli/templates/hidden-info/Cargo.toml.tmpl
@@ -1,0 +1,34 @@
+[package]
+name = "{{crate_name}}"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "{{description}}"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "{{soroban_sdk_version}}"
+cougr-core = "{{cougr_core_version}}"
+
+[dev-dependencies]
+soroban-sdk = { version = "{{soroban_sdk_version}}", features = ["testutils"] }
+cougr-core = { version = "{{cougr_core_version}}", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true
+
+[workspace]

--- a/cli/templates/hidden-info/README.md
+++ b/cli/templates/hidden-info/README.md
@@ -1,0 +1,101 @@
+# {{crate_name}}
+
+{{description}}
+
+Generated with `cougr new --template {{template_id}}`, based on the canonical
+[`{{source_example}}`](https://github.com/salazarsebas/Cougr/tree/main/examples/{{source_example}})
+example.
+
+> **Experimental**: `cougr_core::circuits` is an experimental API. The circuit
+> spec ships with the Cougr development verification key — replace it with your
+> own trusted-setup key via `GameCircuitSpec::with_verification_key` before any
+> real deployment.
+
+## Purpose and pattern
+
+Players take a seat at a table, then prove — without revealing a card — that the
+hand they hold was really dealt from the committed deck. The contract never
+learns the hand: it checks a Groth16 proof against public commitments and counts
+the deals that verified. This is the reference shape for poker, deck-builders,
+and anything else where players hold private state the chain must still trust.
+
+## Public contract API
+
+| Function | Parameters | Returns | Description |
+| --- | --- | --- | --- |
+| `init_table` | `deck_size: u32`, `hand_size: u32` | `TableConfig` | Open a table and freeze the circuit layout |
+| `join_table` | `player: Address` | `u32` | Take a seat; returns the zero-based seat number |
+| `seat_of` | `player: Address` | `Option<u32>` | The seat a player joined with |
+| `table` | — | `Option<TableConfig>` | The frozen table configuration |
+| `verify_deal` | `player: Address`, `deck_root: BytesN<32>`, `hand_commitment: BytesN<32>`, `proof: Groth16Proof` | `bool` | Verify a deal proof for that player's seat |
+| `deals_verified` | `player: Address` | `u32` | Deals that player has proven so far |
+
+## Architecture overview
+
+```
+lib.rs         contract entrypoints — seat lookup, proof verification, counters
+  ├─ components.rs   TableConfig, DealsVerified, storage keys, seat → entity map
+  └─ systems.rs      validate_config(), circuit_for(), verify_deal() — pure rules
+```
+
+The seat number is the hinge of the whole design. It is a public input to the
+circuit, so a proof is bound to one seat: replaying another player's proof under
+your own address fails verification rather than being caught by an extra check.
+
+## Storage model
+
+| Storage | Contents | Why |
+| --- | --- | --- |
+| Instance — `table` | `TableConfig` | One tiny value read by every call |
+| Instance — `(seat, Address)` | Seat number | Direct address → seat lookup, no scan |
+| Instance — `world` | `SimpleWorld` with a `DealsVerified` per seat | Per-seat gameplay counters live in the ECS |
+
+Deck order and hands are deliberately **not** stored. Only the deck root and
+hand commitment appear on chain, and only as arguments to a verification call.
+
+## Main gameplay flow
+
+1. A host calls `init_table(52, 5)`, freezing the circuit layout.
+2. Each player calls `join_table` and receives seat `0`, `1`, `2`, …
+3. Off chain, the dealer commits to a shuffled deck and produces a Merkle root
+   plus, per player, a hand commitment and a Groth16 proof.
+4. A player submits `verify_deal` with the deck root, their hand commitment, and
+   the proof. The contract rebuilds the circuit spec and verifies.
+5. On success the seat's `DealsVerified` counter increases; on failure the call
+   returns `false` and nothing is written.
+
+## Cougr APIs used
+
+| API | Why |
+| --- | --- |
+| `circuits::hidden_cards` | Pre-built public-input layout for a hidden-card deal — no hand-rolled circuit wiring |
+| `zk::Groth16Proof` | Proof accepted directly as a contract argument |
+| `impl_component!` | `DealsVerified` is a single scalar per seat |
+| `SorobanGame` / `impl_soroban_game!` | Removes hand-written world load/save boilerplate |
+| `test::GameHarness`, `circuits::test_fixtures` | Real pipeline proofs in an integration test |
+
+## Build and test
+
+```bash
+cargo test
+stellar contract build
+```
+
+`stellar contract build` needs the WASM target and the Stellar CLI:
+
+```bash
+rustup target add wasm32v1-none
+cargo install --locked stellar-cli
+```
+
+The build writes `target/wasm32v1-none/release/{{module_name}}.wasm`, which is
+what you deploy with `stellar contract deploy`.
+
+## Known limitations
+
+* Ships the Cougr development verification key. Anyone who holds that proving
+  key can forge a proof — swap in your own before deploying.
+* Nobody is bound to committing the deck: `verify_deal` trusts whatever
+  `deck_root` the caller passes. A real game stores the root at deal time.
+* Seats are never released, and there is no cap on how many players can join.
+* Groth16 verification is expensive. Budget for it before adding per-turn proofs.

--- a/cli/templates/hidden-info/gitignore
+++ b/cli/templates/hidden-info/gitignore
@@ -1,0 +1,4 @@
+target/
+*.wasm
+.soroban/
+**/*.rs.bk

--- a/cli/templates/hidden-info/src/components.rs
+++ b/cli/templates/hidden-info/src/components.rs
@@ -1,0 +1,45 @@
+//! Table state and storage keys for {{crate_name}}.
+//!
+//! A hidden-information game keeps the interesting state *off* chain: the deck
+//! order and every player's hand stay with their owners. What the contract
+//! stores is the public shape of the table, who is sitting at it, and how many
+//! deals each seat has proven — everything a proof is checked against, and
+//! nothing that would leak a hand.
+
+use cougr_core::impl_component;
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+
+/// Public parameters of the table, frozen at `init_table` so every later proof
+/// is verified against the same circuit layout.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TableConfig {
+    pub deck_size: u32,
+    pub hand_size: u32,
+}
+
+/// How many deals a seat has proven. One component per seated player.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DealsVerified {
+    pub count: u32,
+}
+
+impl_component!(DealsVerified, "deals", Sparse, { count: u32 });
+
+/// Instance-storage key holding the [`TableConfig`].
+pub fn table_key() -> Symbol {
+    symbol_short!("table")
+}
+
+/// Instance-storage key mapping a player to their seat number.
+pub fn seat_key(env: &Env, player: &Address) -> (Symbol, Address) {
+    (Symbol::new(env, "seat"), player.clone())
+}
+
+/// ECS entity that holds a seat's components.
+///
+/// Seats are zero-based for the circuit; `SimpleWorld` entity IDs start at one.
+pub fn seat_entity(seat: u32) -> u32 {
+    seat + 1
+}

--- a/cli/templates/hidden-info/src/lib.rs
+++ b/cli/templates/hidden-info/src/lib.rs
@@ -1,0 +1,154 @@
+//! {{crate_name}} — a Cougr game contract generated from the `{{template_id}}` template.
+//!
+//! Players take a seat at a table, then prove — without revealing a single card
+//! — that the hand they hold was really dealt from the committed deck. The
+//! contract never learns the hand: it checks a Groth16 proof against the public
+//! commitments and counts the deals that verified.
+//!
+//! Demonstrates:
+//!   - `circuits::hidden_cards` — pre-built hidden-card circuit spec
+//!   - `zk::Groth16Proof`       — proof submitted as a contract argument
+//!   - `SorobanGame`            — standard world load/save
+//!   - `impl_soroban_game!`     — wires the trait to a `#[contract]` struct
+
+#![no_std]
+
+pub mod components;
+pub mod systems;
+#[cfg(test)]
+mod test;
+
+use components::{seat_entity, seat_key, table_key, DealsVerified, TableConfig};
+use systems::{validate_config, verify_deal, TableError};
+
+use cougr_core::game::SorobanGame;
+use cougr_core::impl_soroban_game;
+use cougr_core::zk::Groth16Proof;
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+
+#[contract]
+#[derive(Clone)]
+pub struct {{ContractName}};
+
+// Generates `load_world` / `save_world` against the "world" instance-storage key.
+impl_soroban_game!({{ContractName}}, "world");
+
+#[contractimpl]
+impl {{ContractName}} {
+    /// Open a table with a fixed deck and hand size.
+    ///
+    /// The configuration is frozen here: every later proof is checked against
+    /// the circuit layout these two numbers select. Panics if the table shape
+    /// is outside what the circuit supports.
+    pub fn init_table(env: Env, deck_size: u32, hand_size: u32) -> TableConfig {
+        let config = TableConfig {
+            deck_size,
+            hand_size,
+        };
+
+        match validate_config(&config) {
+            Ok(()) => {}
+            Err(TableError::DeckSizeOutOfRange) => panic!("deck size out of range"),
+            Err(TableError::HandSizeOutOfRange) => panic!("hand size out of range"),
+            Err(TableError::UnsupportedLayout) => panic!("unsupported circuit layout"),
+        }
+
+        env.storage().instance().set(&table_key(), &config);
+        config
+    }
+
+    /// Take a seat at the table, returning the zero-based seat number.
+    ///
+    /// The seat number is what the circuit binds a hand to, so a player proves
+    /// against the seat they joined with. Joining twice returns the same seat.
+    pub fn join_table(env: Env, player: Address) -> u32 {
+        player.require_auth();
+        Self::require_table(&env);
+
+        if let Some(seat) = Self::seat_of(env.clone(), player.clone()) {
+            return seat;
+        }
+
+        let mut world = {{ContractName}}::load_world(&env);
+        let entity = world.spawn_entity();
+        world.set_typed(&env, entity, &DealsVerified { count: 0 });
+        {{ContractName}}::save_world(&env, &world);
+
+        let seat = entity - 1;
+        env.storage()
+            .instance()
+            .set(&seat_key(&env, &player), &seat);
+        seat
+    }
+
+    /// The seat `player` joined with, or `None` if they never sat down.
+    pub fn seat_of(env: Env, player: Address) -> Option<u32> {
+        env.storage().instance().get(&seat_key(&env, &player))
+    }
+
+    /// The frozen table configuration, or `None` before `init_table`.
+    pub fn table(env: Env) -> Option<TableConfig> {
+        env.storage().instance().get(&table_key())
+    }
+
+    /// Verify that `player`'s hand was dealt from the committed deck.
+    ///
+    /// Returns `false` for a proof that does not check out — only a missing
+    /// table or an unseated player is treated as a caller error.
+    pub fn verify_deal(
+        env: Env,
+        player: Address,
+        deck_root: BytesN<32>,
+        hand_commitment: BytesN<32>,
+        proof: Groth16Proof,
+    ) -> bool {
+        let config = Self::require_table(&env);
+        let seat = Self::seat_of(env.clone(), player)
+            .unwrap_or_else(|| panic!("player has not joined the table"));
+
+        let verified = verify_deal(&env, &config, seat, &deck_root, &hand_commitment, &proof);
+        if verified {
+            Self::record_deal(&env, seat);
+        }
+        verified
+    }
+
+    /// How many deals `player` has proven so far.
+    pub fn deals_verified(env: Env, player: Address) -> u32 {
+        let Some(seat) = Self::seat_of(env.clone(), player) else {
+            return 0;
+        };
+        let world = {{ContractName}}::load_world(&env);
+        world
+            .get_typed::<DealsVerified>(&env, seat_entity(seat))
+            .map(|deals| deals.count)
+            .unwrap_or(0)
+    }
+
+    // ─── Internal helpers ─────────────────────────────────────────────────────
+
+    fn require_table(env: &Env) -> TableConfig {
+        env.storage()
+            .instance()
+            .get(&table_key())
+            .unwrap_or_else(|| panic!("table not initialised"))
+    }
+
+    fn record_deal(env: &Env, seat: u32) {
+        let mut world = {{ContractName}}::load_world(env);
+        let entity = seat_entity(seat);
+        let count = world
+            .get_typed::<DealsVerified>(env, entity)
+            .map(|deals| deals.count)
+            .unwrap_or(0);
+
+        world.set_typed(
+            env,
+            entity,
+            &DealsVerified {
+                count: count.saturating_add(1),
+            },
+        );
+        {{ContractName}}::save_world(env, &world);
+    }
+}

--- a/cli/templates/hidden-info/src/systems.rs
+++ b/cli/templates/hidden-info/src/systems.rs
@@ -1,0 +1,65 @@
+//! Circuit wiring and table rules for {{crate_name}}.
+//!
+//! `cougr_core::circuits::hidden_cards` builds a `GameCircuitSpec` — the public
+//! input layout and verification key for a hidden-card deal. Rebuilding it from
+//! the stored [`TableConfig`] on every call, rather than caching a spec, keeps
+//! one source of truth for what a valid proof must satisfy.
+
+use cougr_core::circuits::{hidden_cards, GameCircuitSpec};
+use cougr_core::zk::Groth16Proof;
+use soroban_sdk::{BytesN, Env};
+
+use crate::components::TableConfig;
+
+/// Largest table this contract accepts. The circuit itself covers a wider
+/// range; capping it here keeps proof verification inside a predictable
+/// resource budget.
+pub const MAX_DECK_SIZE: u32 = 64;
+
+/// Why a table configuration is not usable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TableError {
+    /// `deck_size` is zero or above [`MAX_DECK_SIZE`].
+    DeckSizeOutOfRange,
+    /// `hand_size` is zero, or larger than the deck it is drawn from.
+    HandSizeOutOfRange,
+    /// The circuit builder rejected these parameters.
+    UnsupportedLayout,
+}
+
+/// Validate table parameters before they are frozen into storage.
+pub fn validate_config(config: &TableConfig) -> Result<(), TableError> {
+    if config.deck_size == 0 || config.deck_size > MAX_DECK_SIZE {
+        return Err(TableError::DeckSizeOutOfRange);
+    }
+    if config.hand_size == 0 || config.hand_size > config.deck_size {
+        return Err(TableError::HandSizeOutOfRange);
+    }
+    Ok(())
+}
+
+/// Build the hidden-cards circuit spec for `config`.
+pub fn circuit_for(env: &Env, config: &TableConfig) -> Result<GameCircuitSpec, TableError> {
+    validate_config(config)?;
+    hidden_cards(env, config.deck_size, config.hand_size).map_err(|_| TableError::UnsupportedLayout)
+}
+
+/// Check that `proof` shows `hand_commitment` was dealt to `seat` from the deck
+/// committed to by `deck_root`.
+///
+/// A proof that does not verify is a `false`, not an error: an opponent
+/// submitting a bad proof is ordinary gameplay, not a contract fault.
+pub fn verify_deal(
+    env: &Env,
+    config: &TableConfig,
+    seat: u32,
+    deck_root: &BytesN<32>,
+    hand_commitment: &BytesN<32>,
+    proof: &Groth16Proof,
+) -> bool {
+    let Ok(spec) = circuit_for(env, config) else {
+        return false;
+    };
+    spec.verify_hidden_hand(env, proof, deck_root, hand_commitment, seat)
+        .unwrap_or(false)
+}

--- a/cli/templates/hidden-info/src/test.rs
+++ b/cli/templates/hidden-info/src/test.rs
@@ -1,0 +1,160 @@
+//! Integration tests for {{crate_name}}.
+//!
+//! These run through `cougr_core::test::GameHarness`, the sandbox the canonical
+//! examples use. The proof and commitments come from
+//! `cougr_core::circuits::test_fixtures`, which ships the artifacts produced by
+//! the Circom pipeline — the fixture hand belongs to seat `2` of a 52-card,
+//! 5-card-hand table, so the tests seat three players before proving.
+
+use crate::components::TableConfig;
+use crate::systems::{validate_config, TableError, MAX_DECK_SIZE};
+use crate::{{ContractName}};
+use crate::{{ContractName}}Client;
+use cougr_core::circuits::{test_fixtures, CircuitId};
+use cougr_core::test::{GameHarness, PlayerSlot};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env};
+
+const DECK_SIZE: u32 = 52;
+const HAND_SIZE: u32 = 5;
+/// Seat the pipeline fixture proof was generated for.
+const PROVING_SEAT: u32 = 2;
+
+/// A harness with three seated players and an initialised table.
+fn seated_table() -> GameHarness {
+    let env = Env::default();
+    let mut harness = GameHarness::new(env, {{ContractName}});
+    harness.mock_players(3);
+    harness.mock_all_auths();
+
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    client.init_table(&DECK_SIZE, &HAND_SIZE);
+    for slot in 0..3 {
+        client.join_table(harness.player(PlayerSlot(slot)));
+    }
+
+    harness
+}
+
+/// The deck root and hand commitment the fixture proof was built from.
+fn fixture_commitments(env: &Env) -> (BytesN<32>, BytesN<32>) {
+    let public = test_fixtures::pipeline_public_inputs(env, CircuitId::HiddenCards);
+    (
+        BytesN::from_array(env, &public[0].bytes.to_array()),
+        BytesN::from_array(env, &public[1].bytes.to_array()),
+    )
+}
+
+#[test]
+fn init_table_freezes_the_configuration() {
+    let harness = seated_table();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let expected = TableConfig {
+        deck_size: DECK_SIZE,
+        hand_size: HAND_SIZE,
+    };
+    assert_eq!(client.table(), Some(expected));
+}
+
+#[test]
+#[should_panic(expected = "hand size out of range")]
+fn a_hand_larger_than_the_deck_is_rejected() {
+    let env = Env::default();
+    let harness = GameHarness::new(env, {{ContractName}});
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    client.init_table(&10, &11);
+}
+
+#[test]
+#[should_panic(expected = "deck size out of range")]
+fn an_oversized_deck_is_rejected() {
+    let env = Env::default();
+    let harness = GameHarness::new(env, {{ContractName}});
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    client.init_table(&(MAX_DECK_SIZE + 1), &5);
+}
+
+#[test]
+fn seats_are_handed_out_in_join_order() {
+    let harness = seated_table();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    for slot in 0..3u32 {
+        let player = harness.player(PlayerSlot(slot));
+        assert_eq!(client.seat_of(player), Some(slot));
+    }
+}
+
+#[test]
+fn joining_twice_keeps_the_same_seat() {
+    let harness = seated_table();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    let player = harness.player(PlayerSlot(1));
+
+    assert_eq!(client.join_table(player), 1);
+    assert_eq!(client.seat_of(player), Some(1));
+}
+
+#[test]
+fn a_valid_deal_proof_verifies_and_is_counted() {
+    let harness = seated_table();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    let player = harness.player(PlayerSlot(PROVING_SEAT));
+    let (deck_root, hand) = fixture_commitments(harness.env());
+    let proof = test_fixtures::pipeline_proof(harness.env(), CircuitId::HiddenCards);
+
+    assert!(client.verify_deal(player, &deck_root, &hand, &proof));
+    assert_eq!(client.deals_verified(player), 1);
+}
+
+#[test]
+fn a_tampered_hand_commitment_does_not_verify() {
+    let harness = seated_table();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    let player = harness.player(PlayerSlot(PROVING_SEAT));
+    let (deck_root, _) = fixture_commitments(harness.env());
+    let proof = test_fixtures::pipeline_proof(harness.env(), CircuitId::HiddenCards);
+    let forged = BytesN::from_array(harness.env(), &[0u8; 32]);
+
+    assert!(!client.verify_deal(player, &deck_root, &forged, &proof));
+    assert_eq!(client.deals_verified(player), 0);
+}
+
+#[test]
+fn a_proof_for_another_seat_does_not_verify() {
+    let harness = seated_table();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    let other_seat = harness.player(PlayerSlot(0));
+    let (deck_root, hand) = fixture_commitments(harness.env());
+    let proof = test_fixtures::pipeline_proof(harness.env(), CircuitId::HiddenCards);
+
+    assert!(!client.verify_deal(other_seat, &deck_root, &hand, &proof));
+}
+
+#[test]
+#[should_panic(expected = "player has not joined the table")]
+fn an_unseated_player_cannot_submit_a_deal() {
+    let harness = seated_table();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    let stranger = Address::generate(harness.env());
+    let (deck_root, hand) = fixture_commitments(harness.env());
+    let proof = test_fixtures::pipeline_proof(harness.env(), CircuitId::HiddenCards);
+
+    client.verify_deal(&stranger, &deck_root, &hand, &proof);
+}
+
+#[test]
+fn validate_config_rejects_an_empty_deck() {
+    let config = TableConfig {
+        deck_size: 0,
+        hand_size: 1,
+    };
+
+    assert_eq!(
+        validate_config(&config),
+        Err(TableError::DeckSizeOutOfRange)
+    );
+}

--- a/cli/templates/session-auth/Cargo.toml.tmpl
+++ b/cli/templates/session-auth/Cargo.toml.tmpl
@@ -1,0 +1,34 @@
+[package]
+name = "{{crate_name}}"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "{{description}}"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "{{soroban_sdk_version}}"
+cougr-core = "{{cougr_core_version}}"
+
+[dev-dependencies]
+soroban-sdk = { version = "{{soroban_sdk_version}}", features = ["testutils"] }
+cougr-core = { version = "{{cougr_core_version}}", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true
+
+[workspace]

--- a/cli/templates/session-auth/README.md
+++ b/cli/templates/session-auth/README.md
@@ -1,0 +1,102 @@
+# {{crate_name}}
+
+{{description}}
+
+Generated with `cougr new --template {{template_id}}`, based on the canonical
+[`{{source_example}}`](https://github.com/salazarsebas/Cougr/tree/main/examples/{{source_example}})
+example.
+
+> **Beta**: `cougr_core::session` is a Beta API. Expect the surface to move
+> before 2.0.
+
+## Purpose and pattern
+
+Approve once, then play. The owner answers a single wallet prompt to create a
+scoped session key; every move after that is authorized by the session instead
+of the wallet. When a session expires mid-game the contract falls back to direct
+owner auth rather than dropping the move. This is the pattern behind any game
+that cannot ask for a signature on every turn.
+
+## Public contract API
+
+| Function | Parameters | Returns | Description |
+| --- | --- | --- | --- |
+| `approve_session` | `owner: Address`, `max_taps: u32`, `expires_in: u64` | `ActiveSession` | The one wallet prompt: mint a scoped session key |
+| `tap` | `owner: Address`, `key_id: BytesN<32>` | `u32` | Play a turn on the session; returns the new score |
+| `fallback_tap` | `owner: Address`, `key_id: BytesN<32>` | `u32` | Play a turn, falling back to owner auth if the session is stale |
+| `renew_session` | `owner: Address`, `key_id: BytesN<32>`, `expires_in: u64` | `ActiveSession` | Extend the session; same key ID |
+| `session_state` | `owner: Address`, `key_id: BytesN<32>` | `Option<ActiveSession>` | Expiry, remaining budget, renewal hint |
+| `score` | `owner: Address` | `u32` | Taps played so far |
+
+## Architecture overview
+
+```
+lib.rs         contract entrypoints — auth, then gameplay state
+  ├─ components.rs   Score component, player → entity storage key
+  └─ systems.rs      session policy: allowed action, budget, lifetime, intent window
+```
+
+`systems.rs` is where a session's powers are defined — one allowed action, a
+hard operation budget, an expiry, and a short intent window. Widening what a
+session key can do is a visible edit to that file, not a change buried in an
+entrypoint.
+
+## Storage model
+
+| Storage | Contents | Why |
+| --- | --- | --- |
+| Instance — session keys | Managed by `SessionManager` / `SessionStorage` | Scope, nonce, and expiry per key |
+| Instance — `(player, Address)` | The player's ECS entity ID | Direct address → entity lookup, no scan |
+| Instance — `world` | `SimpleWorld` with one `Score` per player | Gameplay state stays in the ECS |
+
+## Main gameplay flow
+
+1. The owner calls `approve_session(owner, 10, 3600)` and signs once. A session
+   key is minted, scoped to the `tap` action with a budget of 10 operations.
+2. The client stores the returned `key_id` and calls `tap` for each move. Each
+   call builds a signed intent, the kernel checks scope, nonce, and expiry, and
+   the tap counter increases — no wallet prompt.
+3. When `session_state` reports `needs_renewal`, the client calls
+   `renew_session`, which re-prompts the owner once and keeps the same key ID.
+4. If a session lapses before renewal, `fallback_tap` authorizes the same move
+   through direct owner auth so the turn is not lost.
+
+## Cougr APIs used
+
+| API | Why |
+| --- | --- |
+| `session::SessionManager` | Whole lifecycle — approve, execute, renew, fallback — in one facade |
+| `accounts::SessionBuilder` | Declarative scope: allowed action, budget, expiry |
+| `accounts::SignedIntent` / `ReplayProtection` | Nonce-protected intents for the fallback path |
+| `session::ActiveSession` | Client-facing view of expiry and remaining budget |
+| `impl_component!` | `Score` is one scalar per player |
+| `SorobanGame` / `impl_soroban_game!` | Removes hand-written world load/save boilerplate |
+| `test::GameHarness`, `test::MockSession` | Session flows exercised in an integration test |
+
+## Build and test
+
+```bash
+cargo test
+stellar contract build
+```
+
+`stellar contract build` needs the WASM target and the Stellar CLI:
+
+```bash
+rustup target add wasm32v1-none
+cargo install --locked stellar-cli
+```
+
+The build writes `target/wasm32v1-none/release/{{module_name}}.wasm`, which is
+what you deploy with `stellar contract deploy`.
+
+## Known limitations
+
+* Sessions are scoped to a single action. A real game scopes several, and should
+  keep the budget proportional to how long a session lives.
+* There is no `revoke` entrypoint. `SessionManager::revoke` exists — wire it up
+  before letting players sign in from shared devices.
+* `fallback_tap` silently falls back. Production clients should surface that the
+  session lapsed so the player knows to renew.
+* Session keys here are held by the client. Pair with `Secp256r1Storage` and a
+  passkey signer for a hardware-backed flow.

--- a/cli/templates/session-auth/gitignore
+++ b/cli/templates/session-auth/gitignore
@@ -1,0 +1,4 @@
+target/
+*.wasm
+.soroban/
+**/*.rs.bk

--- a/cli/templates/session-auth/src/components.rs
+++ b/cli/templates/session-auth/src/components.rs
@@ -1,0 +1,22 @@
+//! ECS components and storage keys for {{crate_name}}.
+//!
+//! The gameplay state a session protects is deliberately tiny — a tap counter —
+//! so the interesting part stays visible: who is allowed to act, for how long,
+//! and how many times.
+
+use cougr_core::impl_component;
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+/// How many times a player has acted through their session.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Score {
+    pub taps: u32,
+}
+
+impl_component!(Score, "score", Sparse, { taps: u32 });
+
+/// Instance-storage key mapping a player to their ECS entity.
+pub fn player_key(env: &Env, player: &Address) -> (Symbol, Address) {
+    (Symbol::new(env, "player"), player.clone())
+}

--- a/cli/templates/session-auth/src/lib.rs
+++ b/cli/templates/session-auth/src/lib.rs
@@ -1,0 +1,192 @@
+//! {{crate_name}} — a Cougr game contract generated from the `{{template_id}}` template.
+//!
+//! Approve once, then play. The owner signs a single wallet prompt to create a
+//! scoped session key; every move after that is authorized by the session
+//! instead of the wallet. When the session runs out the contract falls back to
+//! direct owner auth rather than dropping the move.
+//!
+//! Flow: `approve_session` → `tap` many times → `renew_session` before expiry →
+//! `fallback_tap` once the session is stale.
+//!
+//! Demonstrates:
+//!   - `session::SessionManager` — session lifecycle (approve, renew, execute)
+//!   - `accounts::SessionBuilder` — scoping a key to one action and a budget
+//!   - `SorobanGame` — standard world load/save for the gameplay state
+
+#![no_std]
+
+pub mod components;
+pub mod systems;
+#[cfg(test)]
+mod test;
+
+use components::{player_key, Score};
+use systems::{intent_deadline, tap_action, tap_scope, validate_request, SessionPolicyError};
+
+use cougr_core::accounts::{ReplayProtection, SessionStorage, SignedIntent};
+use cougr_core::game::SorobanGame;
+use cougr_core::impl_soroban_game;
+use cougr_core::session::{ActiveSession, SessionManager};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+
+#[contract]
+#[derive(Clone)]
+pub struct {{ContractName}};
+
+// Generates `load_world` / `save_world` against the "world" instance-storage key.
+impl_soroban_game!({{ContractName}}, "world");
+
+#[contractimpl]
+impl {{ContractName}} {
+    /// One-time owner approval that mints a scoped session key.
+    ///
+    /// This is the only call that prompts the wallet. The returned
+    /// [`ActiveSession`] carries the key ID every later call needs, plus the
+    /// expiry and remaining budget a client can render.
+    pub fn approve_session(
+        env: Env,
+        owner: Address,
+        max_taps: u32,
+        expires_in: u64,
+    ) -> ActiveSession {
+        owner.require_auth();
+
+        match validate_request(max_taps, expires_in) {
+            Ok(()) => {}
+            Err(SessionPolicyError::BudgetOutOfRange) => panic!("tap budget out of range"),
+            Err(SessionPolicyError::LifetimeOutOfRange) => panic!("session lifetime out of range"),
+        }
+
+        let scope = tap_scope(&env, max_taps, expires_in);
+        let key = SessionManager::approve(&env, &owner, scope).expect("session approved");
+        let status =
+            SessionManager::status(&env, &owner, &key.key_id).expect("session status readable");
+
+        ActiveSession::from_status(&status, key.scope.expires_at)
+    }
+
+    /// Play a turn, authorized by the session key — no wallet prompt.
+    ///
+    /// Panics if the session is missing, expired, revoked, or out of budget.
+    /// Use [`fallback_tap`](Self::fallback_tap) when a client should keep
+    /// playing through an expiry instead.
+    pub fn tap(env: Env, owner: Address, key_id: BytesN<32>) -> u32 {
+        let session = SessionStorage::load(&env, &owner, &key_id).expect("session missing");
+
+        SessionManager::execute_action(
+            &env,
+            &owner,
+            &session,
+            tap_action(&env),
+            intent_deadline(&env),
+        )
+        .expect("session authorizes the tap");
+
+        Self::award_tap(&env, &owner)
+    }
+
+    /// Play a turn, trying the session first and falling back to direct owner
+    /// auth when it is expired, revoked, or out of budget.
+    pub fn fallback_tap(env: Env, owner: Address, key_id: BytesN<32>) -> u32 {
+        let session = SessionStorage::load(&env, &owner, &key_id).expect("session missing");
+        let action = tap_action(&env);
+        let deadline = intent_deadline(&env);
+
+        let session_intent = SignedIntent::session(
+            &env,
+            owner.clone(),
+            &key_id,
+            action.clone(),
+            session.next_nonce,
+            deadline,
+        );
+        let direct_intent = SignedIntent::direct(
+            &env,
+            owner.clone(),
+            action,
+            ReplayProtection::next_account_nonce(&env, &owner),
+            deadline,
+        );
+
+        SessionManager::fallback_execute(&env, &session_intent, &direct_intent)
+            .expect("session or owner authorizes the tap");
+
+        Self::award_tap(&env, &owner)
+    }
+
+    /// Extend a session's lifetime. The owner re-signs; the key ID is unchanged.
+    pub fn renew_session(
+        env: Env,
+        owner: Address,
+        key_id: BytesN<32>,
+        expires_in: u64,
+    ) -> ActiveSession {
+        owner.require_auth();
+
+        if expires_in == 0 || expires_in > systems::MAX_SESSION_LIFETIME {
+            panic!("session lifetime out of range");
+        }
+
+        let expires_at = env.ledger().timestamp().saturating_add(expires_in);
+        let key =
+            SessionManager::renew(&env, &owner, &key_id, expires_at).expect("session renewed");
+        let status =
+            SessionManager::status(&env, &owner, &key.key_id).expect("session status readable");
+
+        ActiveSession::from_status(&status, key.scope.expires_at)
+    }
+
+    /// Current health of a session: expiry, remaining budget, renewal hint.
+    pub fn session_state(env: Env, owner: Address, key_id: BytesN<32>) -> Option<ActiveSession> {
+        let status = SessionManager::status(&env, &owner, &key_id).ok()?;
+        let session = SessionStorage::load(&env, &owner, &key_id)?;
+        Some(ActiveSession::from_status(
+            &status,
+            session.scope.expires_at,
+        ))
+    }
+
+    /// How many taps `owner` has played.
+    pub fn score(env: Env, owner: Address) -> u32 {
+        let Some(entity) = Self::entity_of(&env, &owner) else {
+            return 0;
+        };
+        let world = {{ContractName}}::load_world(&env);
+        world
+            .get_typed::<Score>(&env, entity)
+            .map(|score| score.taps)
+            .unwrap_or(0)
+    }
+
+    // ─── Internal helpers ─────────────────────────────────────────────────────
+
+    fn entity_of(env: &Env, owner: &Address) -> Option<u32> {
+        env.storage().instance().get(&player_key(env, owner))
+    }
+
+    /// Credit one tap to `owner`, creating their entity on first play.
+    fn award_tap(env: &Env, owner: &Address) -> u32 {
+        let mut world = {{ContractName}}::load_world(env);
+
+        let entity = match Self::entity_of(env, owner) {
+            Some(entity) => entity,
+            None => {
+                let entity = world.spawn_entity();
+                env.storage()
+                    .instance()
+                    .set(&player_key(env, owner), &entity);
+                entity
+            }
+        };
+
+        let taps = world
+            .get_typed::<Score>(env, entity)
+            .map(|score| score.taps)
+            .unwrap_or(0)
+            .saturating_add(1);
+
+        world.set_typed(env, entity, &Score { taps });
+        {{ContractName}}::save_world(env, &world);
+        taps
+    }
+}

--- a/cli/templates/session-auth/src/systems.rs
+++ b/cli/templates/session-auth/src/systems.rs
@@ -1,0 +1,71 @@
+//! Session policy and gameplay rules for {{crate_name}}.
+//!
+//! Everything that decides *what a session key is allowed to do* lives here, in
+//! one place: the action name, the operation budget, the lifetime, and how long
+//! a single signed intent stays valid. Widening a session's powers should be a
+//! visible edit to this file, not a change buried in a contract entrypoint.
+
+use cougr_core::accounts::{GameAction, SessionBuilder, SessionScope};
+use soroban_sdk::{symbol_short, Bytes, Env, Symbol};
+
+/// The only action a session key may authorize.
+pub fn tap_action_name() -> Symbol {
+    symbol_short!("tap")
+}
+
+/// How long a single signed intent stays valid, in seconds.
+///
+/// Short by design: an intent is signed and submitted in one round trip, so a
+/// wide window only helps someone replaying a captured message.
+pub const INTENT_WINDOW: u64 = 60;
+
+/// Longest session lifetime the contract will approve or renew to, in seconds.
+pub const MAX_SESSION_LIFETIME: u64 = 86_400;
+
+/// Largest operation budget a single session may carry.
+pub const MAX_SESSION_OPERATIONS: u32 = 10_000;
+
+/// Why a requested session is not acceptable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionPolicyError {
+    /// `max_operations` is zero or above [`MAX_SESSION_OPERATIONS`].
+    BudgetOutOfRange,
+    /// `expires_in` is zero or above [`MAX_SESSION_LIFETIME`].
+    LifetimeOutOfRange,
+}
+
+/// Check a requested session against the contract's policy.
+pub fn validate_request(max_operations: u32, expires_in: u64) -> Result<(), SessionPolicyError> {
+    if max_operations == 0 || max_operations > MAX_SESSION_OPERATIONS {
+        return Err(SessionPolicyError::BudgetOutOfRange);
+    }
+    if expires_in == 0 || expires_in > MAX_SESSION_LIFETIME {
+        return Err(SessionPolicyError::LifetimeOutOfRange);
+    }
+    Ok(())
+}
+
+/// Build the scope a session key is created with.
+///
+/// The scope is the whole security story: one allowed action, a hard operation
+/// budget, and an expiry. A key that leaks can do nothing else.
+pub fn tap_scope(env: &Env, max_operations: u32, expires_in: u64) -> SessionScope {
+    SessionBuilder::new(env)
+        .allow_action(tap_action_name())
+        .max_operations(max_operations)
+        .expires_in(expires_in)
+        .build_scope()
+}
+
+/// The gameplay action a tap authorizes.
+pub fn tap_action(env: &Env) -> GameAction {
+    GameAction {
+        system_name: tap_action_name(),
+        data: Bytes::new(env),
+    }
+}
+
+/// Deadline for an intent signed at the current ledger time.
+pub fn intent_deadline(env: &Env) -> u64 {
+    env.ledger().timestamp().saturating_add(INTENT_WINDOW)
+}

--- a/cli/templates/session-auth/src/test.rs
+++ b/cli/templates/session-auth/src/test.rs
@@ -1,0 +1,159 @@
+//! Integration tests for {{crate_name}}.
+//!
+//! These run through `cougr_core::test::GameHarness`, the sandbox the canonical
+//! examples use. `env.mock_all_auths()` stands in for the one wallet prompt a
+//! real owner would answer at `approve_session`; every `tap` after that is
+//! authorized by the session key, not the wallet.
+
+use crate::components::Score;
+use crate::systems::{validate_request, SessionPolicyError, MAX_SESSION_LIFETIME};
+use crate::{{ContractName}};
+use crate::{{ContractName}}Client;
+use cougr_core::test::{GameHarness, MockSession};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env};
+
+const TAP_BUDGET: u32 = 10;
+const SESSION_LIFETIME: u64 = 10_000;
+
+/// A harness with mocked auth and one owner address.
+fn arena() -> (GameHarness, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let harness = GameHarness::new(env, {{ContractName}});
+    let owner = Address::generate(harness.env());
+
+    (harness, owner)
+}
+
+#[test]
+fn approving_a_session_reports_its_budget() {
+    let (harness, owner) = arena();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let session = client.approve_session(&owner, &TAP_BUDGET, &SESSION_LIFETIME);
+
+    assert_eq!(session.operations_remaining, TAP_BUDGET);
+    assert!(!session.needs_renewal);
+    assert!(session.expires_at >= SESSION_LIFETIME);
+}
+
+#[test]
+fn taps_need_no_further_owner_approval() {
+    let (harness, owner) = arena();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let session = client.approve_session(&owner, &TAP_BUDGET, &SESSION_LIFETIME);
+    client.tap(&owner, &session.key_id);
+    client.tap(&owner, &session.key_id);
+    client.tap(&owner, &session.key_id);
+
+    assert_eq!(client.score(&owner), 3);
+}
+
+#[test]
+fn scores_are_tracked_per_player() {
+    let (harness, owner) = arena();
+    let other = Address::generate(harness.env());
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let owner_session = client.approve_session(&owner, &TAP_BUDGET, &SESSION_LIFETIME);
+    let other_session = client.approve_session(&other, &TAP_BUDGET, &SESSION_LIFETIME);
+
+    client.tap(&owner, &owner_session.key_id);
+    client.tap(&other, &other_session.key_id);
+    client.tap(&other, &other_session.key_id);
+
+    assert_eq!(client.score(&owner), 1);
+    assert_eq!(client.score(&other), 2);
+}
+
+#[test]
+fn an_unknown_player_has_no_score() {
+    let (harness, _) = arena();
+    let stranger = Address::generate(harness.env());
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    assert_eq!(client.score(&stranger), 0);
+}
+
+#[test]
+fn session_state_tracks_the_remaining_budget() {
+    let (harness, owner) = arena();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let session = client.approve_session(&owner, &TAP_BUDGET, &SESSION_LIFETIME);
+    client.tap(&owner, &session.key_id);
+
+    let state = client.session_state(&owner, &session.key_id).unwrap();
+    assert!(state.operations_remaining < TAP_BUDGET);
+}
+
+#[test]
+fn renewing_extends_the_play_window() {
+    let (harness, owner) = arena();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let session = client.approve_session(&owner, &TAP_BUDGET, &100);
+    let renewed = client.renew_session(&owner, &session.key_id, &20_000);
+
+    assert!(renewed.expires_at > session.expires_at);
+    assert_eq!(renewed.key_id, session.key_id);
+}
+
+#[test]
+fn fallback_tap_keeps_playing_after_the_session_expires() {
+    let (harness, owner) = arena();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let session = client.approve_session(&owner, &TAP_BUDGET, &50);
+    harness.env().ledger().with_mut(|ledger| {
+        ledger.timestamp = 10_000;
+    });
+
+    assert_eq!(client.fallback_tap(&owner, &session.key_id), 1);
+}
+
+#[test]
+#[should_panic(expected = "tap budget out of range")]
+fn a_zero_tap_budget_is_rejected() {
+    let (harness, owner) = arena();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    client.approve_session(&owner, &0, &SESSION_LIFETIME);
+}
+
+#[test]
+#[should_panic(expected = "session lifetime out of range")]
+fn an_overlong_session_is_rejected() {
+    let (harness, owner) = arena();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    client.approve_session(&owner, &TAP_BUDGET, &(MAX_SESSION_LIFETIME + 1));
+}
+
+#[test]
+fn mock_session_matches_the_manager_flow() {
+    let (harness, owner) = arena();
+
+    harness.as_contract(|| {
+        let mock = MockSession::approve(harness.env(), &owner, &["tap"], 3, 5_000);
+        let status = mock.status(harness.env());
+
+        assert!(status.active);
+        assert_eq!(status.remaining_operations, 3);
+    });
+}
+
+#[test]
+fn validate_request_rejects_an_empty_budget() {
+    assert_eq!(
+        validate_request(0, SESSION_LIFETIME),
+        Err(SessionPolicyError::BudgetOutOfRange)
+    );
+}
+
+#[test]
+fn score_component_defaults_to_zero_taps() {
+    assert_eq!(Score { taps: 0 }.taps, 0);
+}

--- a/cli/templates/starter/Cargo.toml.tmpl
+++ b/cli/templates/starter/Cargo.toml.tmpl
@@ -1,0 +1,34 @@
+[package]
+name = "{{crate_name}}"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "{{description}}"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "{{soroban_sdk_version}}"
+cougr-core = "{{cougr_core_version}}"
+
+[dev-dependencies]
+soroban-sdk = { version = "{{soroban_sdk_version}}", features = ["testutils"] }
+cougr-core = { version = "{{cougr_core_version}}", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true
+
+[workspace]

--- a/cli/templates/starter/README.md
+++ b/cli/templates/starter/README.md
@@ -1,0 +1,86 @@
+# {{crate_name}}
+
+{{description}}
+
+Generated with `cougr new --template {{template_id}}`, based on the canonical
+[`{{source_example}}`](https://github.com/salazarsebas/Cougr/tree/main/examples/{{source_example}})
+example.
+
+## Purpose and pattern
+
+A player enters the world with `spawn` and walks around it one step at a time
+with `move_entity`. It is the smallest complete Cougr game: typed ECS components
+stored in a `SimpleWorld`, persisted through `SorobanGame`, with position changes
+published as indexed Soroban events for off-chain clients.
+
+## Public contract API
+
+| Function | Parameters | Returns | Description |
+| --- | --- | --- | --- |
+| `spawn` | — | `u32` | Create a new entity at the origin and return its ID |
+| `move_entity` | `entity_id: u32`, `direction: u32` | — | Move one step; `0` N, `1` E, `2` S, `3` W |
+| `position` | `entity_id: u32` | `Option<Position>` | Current position, or `None` if unspawned |
+| `moves` | `entity_id: u32` | `Option<Moves>` | Remaining move budget and last direction |
+| `entity_count` | — | `u32` | Number of entities spawned so far |
+
+## Architecture overview
+
+```
+lib.rs         contract entrypoints — load world, call a rule, save world
+  ├─ components.rs   Position (observed), Moves (plain), direction constants
+  └─ systems.rs      step() — pure movement rule, no storage access
+```
+
+Each entrypoint follows the same three beats: `load_world`, apply a pure rule
+from `systems.rs`, `save_world`. Because the rules never touch storage they can
+be tested directly, and the contract functions stay short enough to audit.
+
+## Storage model
+
+The entire `SimpleWorld` lives in **instance storage** under the `"world"` key,
+wired up by `impl_soroban_game!({{ContractName}}, "world")`. One entity's
+`Position` and `Moves` are two component tables inside that world, so a whole
+game state is a single read and a single write per call.
+
+## Main gameplay flow
+
+1. A client calls `spawn` and stores the returned entity ID.
+2. The entity is placed at `(0, 0)` with a budget of 1,000 moves, and a
+   `(COUGR, set, position)` event is emitted.
+3. The client calls `move_entity` with a direction; the position shifts by one
+   and the budget drops by one, emitting another position event.
+4. `position`, `moves`, and `entity_count` read state back without a write.
+
+## Cougr APIs used
+
+| API | Why |
+| --- | --- |
+| `impl_component_observed!` | `Position` changes must reach indexers without polling |
+| `impl_component!` | `Moves` is read on demand, so it does not need events |
+| `SorobanGame` / `impl_soroban_game!` | Removes hand-written world load/save boilerplate |
+| `SimpleWorld` | Typed component storage for a growing entity population |
+| `test::GameHarness`, `Scenario`, `WorldFixture` | Sandbox for full-round integration tests |
+
+## Build and test
+
+```bash
+cargo test
+stellar contract build
+```
+
+`stellar contract build` needs the WASM target and the Stellar CLI:
+
+```bash
+rustup target add wasm32v1-none
+cargo install --locked stellar-cli
+```
+
+The build writes `target/wasm32v1-none/release/{{module_name}}.wasm`, which is
+what you deploy with `stellar contract deploy`.
+
+## Known limitations
+
+* No authorization: any caller can move any entity. Add `require_auth` and an
+  owner component before putting this on a public network.
+* The world is unbounded — entities can walk arbitrarily far from the origin.
+* The move budget is fixed at spawn and cannot be topped up.

--- a/cli/templates/starter/gitignore
+++ b/cli/templates/starter/gitignore
@@ -1,0 +1,4 @@
+target/
+*.wasm
+.soroban/
+**/*.rs.bk

--- a/cli/templates/starter/src/components.rs
+++ b/cli/templates/starter/src/components.rs
@@ -1,0 +1,40 @@
+//! ECS components for {{crate_name}}.
+//!
+//! `Position` is declared with `impl_component_observed!` so every change emits
+//! an indexed `(COUGR, set, position)` Soroban event — off-chain clients can
+//! follow movement from the event stream instead of polling. `Moves` uses the
+//! plain `impl_component!` macro because the move budget is only ever read back
+//! through an explicit contract call.
+
+use cougr_core::{impl_component, impl_component_observed};
+use soroban_sdk::contracttype;
+
+/// World-space position of an entity.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Position {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl_component_observed!(Position, "position", Table, { x: i32, y: i32 });
+
+/// Remaining move budget and the last direction taken.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Moves {
+    pub remaining: u32,
+    pub last_direction: u32,
+}
+
+impl_component!(Moves, "moves", Sparse, { remaining: u32, last_direction: u32 });
+
+// ─── Directions ───────────────────────────────────────────────────────────────
+
+pub const NORTH: u32 = 0; // +y
+pub const EAST: u32 = 1; // +x
+pub const SOUTH: u32 = 2; // −y
+pub const WEST: u32 = 3; // −x
+
+/// Moves granted to a freshly spawned entity.
+pub const DEFAULT_MOVE_BUDGET: u32 = 1_000;

--- a/cli/templates/starter/src/lib.rs
+++ b/cli/templates/starter/src/lib.rs
@@ -1,0 +1,104 @@
+//! {{crate_name}} — a Cougr game contract generated from the `{{template_id}}` template.
+//!
+//! A player calls `spawn` to enter the world and receives an entity ID, then
+//! calls `move_entity` to walk one step in one of four directions. Every
+//! position change emits an indexed Soroban event.
+//!
+//! Demonstrates:
+//!   - `impl_component_observed!` — ECS component plus indexer-friendly events
+//!   - `impl_component!`          — private ECS component, no events
+//!   - `SorobanGame`              — standard world load/save
+//!   - `impl_soroban_game!`       — wires the trait to a `#[contract]` struct
+
+#![no_std]
+
+pub mod components;
+pub mod systems;
+#[cfg(test)]
+mod test;
+
+use components::{Moves, Position, DEFAULT_MOVE_BUDGET, NORTH};
+use systems::{step, MoveError};
+
+use cougr_core::game::SorobanGame;
+use cougr_core::impl_soroban_game;
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+#[derive(Clone)]
+pub struct {{ContractName}};
+
+// Generates `load_world` / `save_world` against the "world" instance-storage key.
+impl_soroban_game!({{ContractName}}, "world");
+
+#[contractimpl]
+impl {{ContractName}} {
+    /// Spawn a new player entity at the world origin.
+    ///
+    /// Returns the entity ID the caller passes to every subsequent call, and
+    /// emits a `(COUGR, set, position)` event so indexers register the spawn.
+    pub fn spawn(env: Env) -> u32 {
+        let mut world = {{ContractName}}::load_world(&env);
+
+        let entity = world.spawn_entity();
+        world.set_typed_observed(&env, entity, &Position { x: 0, y: 0 });
+        world.set_typed(
+            &env,
+            entity,
+            &Moves {
+                remaining: DEFAULT_MOVE_BUDGET,
+                last_direction: NORTH,
+            },
+        );
+
+        {{ContractName}}::save_world(&env, &world);
+        entity
+    }
+
+    /// Move an entity one step in `direction`.
+    ///
+    /// Directions: `0` = North (+y), `1` = East (+x), `2` = South (−y),
+    /// `3` = West (−x).
+    ///
+    /// Panics if the entity does not exist, has no moves left, or the direction
+    /// is out of range.
+    pub fn move_entity(env: Env, entity_id: u32, direction: u32) {
+        let mut world = {{ContractName}}::load_world(&env);
+
+        let position = world
+            .get_typed::<Position>(&env, entity_id)
+            .unwrap_or_else(|| panic!("entity not found"));
+        let moves = world
+            .get_typed::<Moves>(&env, entity_id)
+            .unwrap_or_else(|| panic!("entity not found"));
+
+        let (position, moves) = match step(&position, &moves, direction) {
+            Ok(next) => next,
+            Err(MoveError::InvalidDirection) => panic!("invalid direction"),
+            Err(MoveError::NoMovesRemaining) => panic!("no moves remaining"),
+        };
+
+        world.set_typed_observed(&env, entity_id, &position);
+        world.set_typed(&env, entity_id, &moves);
+
+        {{ContractName}}::save_world(&env, &world);
+    }
+
+    /// Current position of `entity_id`, or `None` if it never spawned.
+    pub fn position(env: Env, entity_id: u32) -> Option<Position> {
+        let world = {{ContractName}}::load_world(&env);
+        world.get_typed::<Position>(&env, entity_id)
+    }
+
+    /// Remaining move budget of `entity_id`, or `None` if it never spawned.
+    pub fn moves(env: Env, entity_id: u32) -> Option<Moves> {
+        let world = {{ContractName}}::load_world(&env);
+        world.get_typed::<Moves>(&env, entity_id)
+    }
+
+    /// Total number of entities spawned so far.
+    pub fn entity_count(env: Env) -> u32 {
+        let world = {{ContractName}}::load_world(&env);
+        world.next_entity_id().saturating_sub(1)
+    }
+}

--- a/cli/templates/starter/src/systems.rs
+++ b/cli/templates/starter/src/systems.rs
@@ -1,0 +1,49 @@
+//! Game rules for {{crate_name}}.
+//!
+//! Systems here are pure: they take the current component values and return the
+//! next ones. Keeping storage access in `lib.rs` means the rules can be unit
+//! tested without an `Env`, and it keeps the contract entrypoints readable.
+
+use crate::components::{Moves, Position, EAST, NORTH, SOUTH, WEST};
+
+/// Outcome of attempting a single step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MoveError {
+    /// The direction is outside the `NORTH..=WEST` range.
+    InvalidDirection,
+    /// The entity has spent its whole move budget.
+    NoMovesRemaining,
+}
+
+/// Apply one step in `direction`, returning the updated components.
+///
+/// The move budget is decremented on success; callers persist the result.
+pub fn step(
+    position: &Position,
+    moves: &Moves,
+    direction: u32,
+) -> Result<(Position, Moves), MoveError> {
+    if direction > WEST {
+        return Err(MoveError::InvalidDirection);
+    }
+    if moves.remaining == 0 {
+        return Err(MoveError::NoMovesRemaining);
+    }
+
+    let mut next = position.clone();
+    match direction {
+        NORTH => next.y += 1,
+        EAST => next.x += 1,
+        SOUTH => next.y -= 1,
+        WEST => next.x -= 1,
+        _ => return Err(MoveError::InvalidDirection),
+    }
+
+    Ok((
+        next,
+        Moves {
+            remaining: moves.remaining - 1,
+            last_direction: direction,
+        },
+    ))
+}

--- a/cli/templates/starter/src/test.rs
+++ b/cli/templates/starter/src/test.rs
@@ -1,0 +1,127 @@
+//! Integration tests for {{crate_name}}.
+//!
+//! These run through `cougr_core::test::GameHarness`, the sandbox the canonical
+//! examples use: it registers the contract in a fresh `Env`, hands back the
+//! contract ID for the generated client, and pairs with `Scenario` for
+//! multi-turn play and `WorldFixture` for injecting pre-built world state.
+
+use crate::components::{Moves, Position, EAST, NORTH, SOUTH};
+use crate::systems::{step, MoveError};
+use crate::{{ContractName}};
+use crate::{{ContractName}}Client;
+use cougr_core::test::{GameHarness, Scenario, SnapshotAssert, WorldFixture};
+use soroban_sdk::Env;
+
+fn harness() -> GameHarness {
+    GameHarness::new(Env::default(), {{ContractName}})
+}
+
+#[test]
+fn spawn_places_the_entity_at_the_origin() {
+    let harness = harness();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let id = client.spawn();
+    let position = client.position(&id).unwrap();
+
+    assert_eq!((position.x, position.y), (0, 0));
+    assert_eq!(client.entity_count(), 1);
+}
+
+#[test]
+fn moving_updates_position_and_spends_the_budget() {
+    let harness = harness();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let id = client.spawn();
+    let budget = client.moves(&id).unwrap().remaining;
+
+    client.move_entity(&id, &NORTH);
+    client.move_entity(&id, &EAST);
+
+    let position = client.position(&id).unwrap();
+    assert_eq!((position.x, position.y), (1, 1));
+    assert_eq!(client.moves(&id).unwrap().remaining, budget - 2);
+    assert_eq!(client.moves(&id).unwrap().last_direction, EAST);
+}
+
+#[test]
+#[should_panic(expected = "invalid direction")]
+fn moving_in_an_unknown_direction_is_rejected() {
+    let harness = harness();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let id = client.spawn();
+    client.move_entity(&id, &99);
+}
+
+#[test]
+#[should_panic(expected = "entity not found")]
+fn moving_an_unspawned_entity_is_rejected() {
+    let harness = harness();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    client.move_entity(&404, &NORTH);
+}
+
+#[test]
+fn entities_move_independently() {
+    let harness = harness();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let first = client.spawn();
+    let second = client.spawn();
+    client.move_entity(&first, &NORTH);
+
+    assert_eq!(client.position(&first).unwrap(), Position { x: 0, y: 1 });
+    assert_eq!(client.position(&second).unwrap(), Position { x: 0, y: 0 });
+}
+
+#[test]
+fn scenario_runs_a_multi_turn_walk() {
+    let harness = harness();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    let id = client.spawn();
+
+    Scenario::new("walk a triangle")
+        .turns(3)
+        .run(&harness, |_player, turn, h| {
+            let client = {{ContractName}}Client::new(h.env(), h.contract_id());
+            match turn.0 {
+                0 => client.move_entity(&id, &NORTH),
+                1 => client.move_entity(&id, &EAST),
+                _ => client.move_entity(&id, &SOUTH),
+            }
+        });
+
+    assert_eq!(client.position(&id).unwrap(), Position { x: 1, y: 0 });
+}
+
+#[test]
+fn fixture_injects_a_pre_built_world() {
+    let harness = harness();
+
+    let mut fixture = WorldFixture::empty(harness.env());
+    fixture.spawn_entity();
+    fixture.spawn_entity();
+    fixture.inject::<{{ContractName}}>(&harness);
+
+    SnapshotAssert::assert_entity_count(
+        WorldFixture::read_from_contract::<{{ContractName}}>(&harness).world(),
+        2,
+    );
+}
+
+#[test]
+fn step_reports_an_exhausted_move_budget() {
+    let position = Position { x: 0, y: 0 };
+    let spent = Moves {
+        remaining: 0,
+        last_direction: NORTH,
+    };
+
+    assert_eq!(
+        step(&position, &spent, NORTH),
+        Err(MoveError::NoMovesRemaining)
+    );
+}

--- a/cli/templates/turn-based/Cargo.toml.tmpl
+++ b/cli/templates/turn-based/Cargo.toml.tmpl
@@ -1,0 +1,34 @@
+[package]
+name = "{{crate_name}}"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "{{description}}"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "{{soroban_sdk_version}}"
+cougr-core = "{{cougr_core_version}}"
+
+[dev-dependencies]
+soroban-sdk = { version = "{{soroban_sdk_version}}", features = ["testutils"] }
+cougr-core = { version = "{{cougr_core_version}}", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true
+
+[workspace]

--- a/cli/templates/turn-based/README.md
+++ b/cli/templates/turn-based/README.md
@@ -1,0 +1,98 @@
+# {{crate_name}}
+
+{{description}}
+
+Generated with `cougr new --template {{template_id}}`, based on the canonical
+[`{{source_example}}`](https://github.com/salazarsebas/Cougr/tree/main/examples/{{source_example}})
+example.
+
+## Purpose and pattern
+
+Two players alternate placing marks on a 3×3 board until one lines up three or
+the board fills. It is the reference shape for any turn-based game on Cougr:
+exactly one match per contract instance, an explicit turn owner, and every move
+validated before it is written to storage.
+
+## Public contract API
+
+| Function | Parameters | Returns | Description |
+| --- | --- | --- | --- |
+| `init_game` | `player_x: Address`, `player_o: Address` | `GameState` | Start a fresh match, discarding previous state |
+| `make_move` | `player: Address`, `position: u32` | `MoveResult` | Place the caller's mark at `0`–`8` |
+| `get_state` | — | `GameState` | Full board, players, turn, and status |
+| `is_valid_move` | `position: u32` | `bool` | Whether that cell is playable right now |
+| `get_winner` | — | `Option<Address>` | Winner's address, or `None` while running or drawn |
+| `reset_game` | — | `GameState` | Clear the board, keep the same players |
+
+`MoveResult.status` and `GameState.status` use the constants in
+`components.rs`: `0` in progress, `1` X wins, `2` O wins, `3` draw.
+
+## Architecture overview
+
+```
+lib.rs         contract entrypoints — load world, validate, write, save world
+  ├─ components.rs   Board + Players (rich), TurnState (plain), status constants
+  └─ systems.rs      validate_move(), advance(), detect_status() — pure rules
+```
+
+`make_move` never applies a rule itself: it loads the world, asks
+`systems::validate_move` whether the move is legal, and only then writes. An
+illegal move returns `success: false` with a short reason code instead of
+panicking, so a client can display the rejection without losing state.
+
+## Storage model
+
+The whole `SimpleWorld` lives in **instance storage** under the `"world"` key,
+wired by `impl_soroban_game!({{ContractName}}, "world")`. Because there is one
+match per instance, all three components hang off a single fixed entity
+(`GAME_ENTITY`), so any call is one storage read and at most one write.
+
+`Board` and `Players` are declared with `impl_rich_component!` because `Vec` and
+`Address` need an XDR codec; `TurnState` is fixed-size scalars and uses the
+cheaper `impl_component!`.
+
+## Main gameplay flow
+
+1. Someone calls `init_game` with both player addresses — X moves first.
+2. X calls `make_move`; the contract checks the match is running, the cell is in
+   range and empty, and the caller owns the turn.
+3. The mark is written, the move count increases, and `detect_status` re-checks
+   all eight lines.
+4. Turn ownership flips while the status is still "in progress"; once a player
+   wins or the board fills, further moves are rejected with `gameover`.
+5. `reset_game` clears the board and keeps both players for a rematch.
+
+## Cougr APIs used
+
+| API | Why |
+| --- | --- |
+| `impl_rich_component!` | `Board` (`Vec<u32>`) and `Players` (`Address`) need XDR storage |
+| `impl_component!` | `TurnState` is three scalars — no codec required |
+| `SorobanGame` / `impl_soroban_game!` | Removes hand-written world load/save boilerplate |
+| `SimpleWorld` | Holds all three components under one entity |
+| `test::GameHarness`, `Scenario` | Drives alternating turns in an integration test |
+
+## Build and test
+
+```bash
+cargo test
+stellar contract build
+```
+
+`stellar contract build` needs the WASM target and the Stellar CLI:
+
+```bash
+rustup target add wasm32v1-none
+cargo install --locked stellar-cli
+```
+
+The build writes `target/wasm32v1-none/release/{{module_name}}.wasm`, which is
+what you deploy with `stellar contract deploy`.
+
+## Known limitations
+
+* `make_move` calls `require_auth` on the acting player, but `init_game` and
+  `reset_game` are open to any caller — add access control before deploying.
+* One match per contract instance. A lobby of concurrent games needs one entity
+  per match instead of the fixed `GAME_ENTITY`.
+* No draw offers, resignations, timeouts, or stakes.

--- a/cli/templates/turn-based/gitignore
+++ b/cli/templates/turn-based/gitignore
@@ -1,0 +1,4 @@
+target/
+*.wasm
+.soroban/
+**/*.rs.bk

--- a/cli/templates/turn-based/src/components.rs
+++ b/cli/templates/turn-based/src/components.rs
@@ -1,0 +1,91 @@
+//! ECS components for {{crate_name}}.
+//!
+//! `Board` and `Players` hold `Vec` and `Address` fields, which need an XDR
+//! codec — that is exactly what `impl_rich_component!` provides, replacing the
+//! hand-written serialize/deserialize pairs an older Soroban contract would
+//! carry. `TurnState` is all fixed-size scalars, so the cheaper
+//! `impl_component!` is enough.
+
+use cougr_core::{impl_component, impl_rich_component};
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+/// The single entity every game's state hangs off.
+///
+/// This contract hosts exactly one match at a time, so a fixed entity ID is
+/// simpler than a dynamic entity population.
+pub const GAME_ENTITY: u32 = 1;
+
+/// Number of cells on the board.
+pub const CELL_COUNT: u32 = 9;
+
+// ─── Cell markers ─────────────────────────────────────────────────────────────
+
+pub const EMPTY: u32 = 0;
+pub const MARK_X: u32 = 1;
+pub const MARK_O: u32 = 2;
+
+// ─── Game status ──────────────────────────────────────────────────────────────
+
+pub const IN_PROGRESS: u32 = 0;
+pub const X_WINS: u32 = 1;
+pub const O_WINS: u32 = 2;
+pub const DRAW: u32 = 3;
+
+// ─── Components ───────────────────────────────────────────────────────────────
+
+/// Board cells, indexed left-to-right then top-to-bottom.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Board {
+    pub cells: Vec<u32>,
+}
+
+impl_rich_component!(Board, "board");
+
+impl Board {
+    /// An empty board.
+    pub fn new(env: &Env) -> Self {
+        let mut cells = Vec::new(env);
+        for _ in 0..CELL_COUNT {
+            cells.push_back(EMPTY);
+        }
+        Self { cells }
+    }
+}
+
+/// Both players' addresses.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Players {
+    pub player_x: Address,
+    pub player_o: Address,
+}
+
+impl_rich_component!(Players, "players");
+
+/// Whose turn it is and whether the match has ended.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TurnState {
+    pub is_x_turn: bool,
+    pub move_count: u32,
+    /// One of `IN_PROGRESS`, `X_WINS`, `O_WINS`, `DRAW`.
+    pub status: u32,
+}
+
+impl_component!(TurnState, "turnst", Table, {
+    is_x_turn: bool,
+    move_count: u32,
+    status: u32
+});
+
+impl TurnState {
+    /// Opening turn state: X to move, nothing played yet.
+    pub fn opening() -> Self {
+        Self {
+            is_x_turn: true,
+            move_count: 0,
+            status: IN_PROGRESS,
+        }
+    }
+}

--- a/cli/templates/turn-based/src/lib.rs
+++ b/cli/templates/turn-based/src/lib.rs
@@ -1,0 +1,202 @@
+//! {{crate_name}} — a Cougr game contract generated from the `{{template_id}}` template.
+//!
+//! Two players alternate placing marks on a 3×3 board until one of them lines
+//! up three or the board fills. It is the reference shape for any turn-based
+//! game: one match per contract instance, an explicit turn owner, and moves
+//! validated before they are written.
+//!
+//! Demonstrates:
+//!   - `impl_rich_component!` — components holding `Address` and `Vec` fields
+//!   - `impl_component!`      — fixed-size turn state
+//!   - `SorobanGame`          — standard world load/save
+//!   - `impl_soroban_game!`   — wires the trait to a `#[contract]` struct
+
+#![no_std]
+
+pub mod components;
+pub mod systems;
+#[cfg(test)]
+mod test;
+
+use components::{Board, Players, TurnState, GAME_ENTITY, O_WINS, X_WINS};
+use systems::{advance, mark_for_turn, validate_move, MoveError};
+
+use cougr_core::game::SorobanGame;
+use cougr_core::impl_soroban_game;
+use cougr_core::simple_world::SimpleWorld;
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec};
+
+// ─── API return types ─────────────────────────────────────────────────────────
+
+/// Everything a client needs to render the match.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GameState {
+    pub cells: Vec<u32>,
+    pub player_x: Address,
+    pub player_o: Address,
+    pub is_x_turn: bool,
+    pub move_count: u32,
+    pub status: u32,
+}
+
+/// Result of a `make_move` call: whether it landed, the resulting state, and a
+/// short reason code when it did not.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MoveResult {
+    pub success: bool,
+    pub game_state: GameState,
+    pub message: Symbol,
+}
+
+// ─── Contract ────────────────────────────────────────────────────────────────
+
+#[contract]
+#[derive(Clone)]
+pub struct {{ContractName}};
+
+// Generates `load_world` / `save_world` against the "world" instance-storage key.
+impl_soroban_game!({{ContractName}}, "world");
+
+#[contractimpl]
+impl {{ContractName}} {
+    /// Start a new match between `player_x` and `player_o`, discarding any
+    /// previous state.
+    pub fn init_game(env: Env, player_x: Address, player_o: Address) -> GameState {
+        let mut world = SimpleWorld::new(&env);
+        let entity = world.spawn_entity();
+        debug_assert_eq!(entity, GAME_ENTITY);
+
+        world.set_rich(&env, GAME_ENTITY, &Board::new(&env));
+        world.set_rich(&env, GAME_ENTITY, &Players { player_x, player_o });
+        world.set_typed(&env, GAME_ENTITY, &TurnState::opening());
+
+        {{ContractName}}::save_world(&env, &world);
+        Self::read_state(&env, &world)
+    }
+
+    /// Place the caller's mark at `position` (`0`–`8`).
+    ///
+    /// Returns `success: false` with a reason code rather than panicking, so a
+    /// client can show the rejection without losing the current state.
+    pub fn make_move(env: Env, player: Address, position: u32) -> MoveResult {
+        player.require_auth();
+
+        let mut world = {{ContractName}}::load_world(&env);
+        let players = Self::players(&env, &world);
+        let turn = Self::turn(&env, &world);
+        let mut board = Self::board(&env, &world);
+
+        let is_player_x = player == players.player_x;
+        let is_player_o = player == players.player_o;
+
+        if let Err(err) = validate_move(&board, &turn, position, is_player_x, is_player_o) {
+            return Self::rejected(&env, &world, err);
+        }
+
+        board.cells.set(position, mark_for_turn(&turn));
+        let turn = advance(&turn, &board.cells);
+
+        world.set_rich(&env, GAME_ENTITY, &board);
+        world.set_typed(&env, GAME_ENTITY, &turn);
+        {{ContractName}}::save_world(&env, &world);
+
+        MoveResult {
+            success: true,
+            game_state: Self::read_state(&env, &world),
+            message: symbol_short!("ok"),
+        }
+    }
+
+    /// Current state of the match.
+    pub fn get_state(env: Env) -> GameState {
+        let world = {{ContractName}}::load_world(&env);
+        Self::read_state(&env, &world)
+    }
+
+    /// Whether `position` is playable right now, ignoring who is calling.
+    pub fn is_valid_move(env: Env, position: u32) -> bool {
+        let world = {{ContractName}}::load_world(&env);
+        let turn = match world.get_typed::<TurnState>(&env, GAME_ENTITY) {
+            Some(turn) => turn,
+            None => return false,
+        };
+        let board = match world.get_rich::<Board>(&env, GAME_ENTITY) {
+            Some(board) => board,
+            None => return false,
+        };
+        // The turn owner is the only caller who could legally play, so checking
+        // against them answers "is this cell playable" without an address.
+        validate_move(&board, &turn, position, turn.is_x_turn, !turn.is_x_turn).is_ok()
+    }
+
+    /// The winner's address, or `None` while the match is running or drawn.
+    pub fn get_winner(env: Env) -> Option<Address> {
+        let world = {{ContractName}}::load_world(&env);
+        let turn = world.get_typed::<TurnState>(&env, GAME_ENTITY)?;
+        let players = world.get_rich::<Players>(&env, GAME_ENTITY)?;
+        match turn.status {
+            X_WINS => Some(players.player_x),
+            O_WINS => Some(players.player_o),
+            _ => None,
+        }
+    }
+
+    /// Clear the board and keep the same two players.
+    pub fn reset_game(env: Env) -> GameState {
+        let world = {{ContractName}}::load_world(&env);
+        let players = Self::players(&env, &world);
+        Self::init_game(env, players.player_x, players.player_o)
+    }
+
+    // ─── Internal helpers ─────────────────────────────────────────────────────
+
+    fn board(env: &Env, world: &SimpleWorld) -> Board {
+        world
+            .get_rich::<Board>(env, GAME_ENTITY)
+            .unwrap_or_else(|| panic!("game not initialised"))
+    }
+
+    fn players(env: &Env, world: &SimpleWorld) -> Players {
+        world
+            .get_rich::<Players>(env, GAME_ENTITY)
+            .unwrap_or_else(|| panic!("game not initialised"))
+    }
+
+    fn turn(env: &Env, world: &SimpleWorld) -> TurnState {
+        world
+            .get_typed::<TurnState>(env, GAME_ENTITY)
+            .unwrap_or_else(|| panic!("game not initialised"))
+    }
+
+    fn read_state(env: &Env, world: &SimpleWorld) -> GameState {
+        let board = Self::board(env, world);
+        let players = Self::players(env, world);
+        let turn = Self::turn(env, world);
+
+        GameState {
+            cells: board.cells,
+            player_x: players.player_x,
+            player_o: players.player_o,
+            is_x_turn: turn.is_x_turn,
+            move_count: turn.move_count,
+            status: turn.status,
+        }
+    }
+
+    fn rejected(env: &Env, world: &SimpleWorld, err: MoveError) -> MoveResult {
+        let message = match err {
+            MoveError::GameOver => symbol_short!("gameover"),
+            MoveError::OutOfBounds => symbol_short!("bounds"),
+            MoveError::Occupied => symbol_short!("occupied"),
+            MoveError::NotYourTurn => symbol_short!("notturn"),
+            MoveError::NotAPlayer => symbol_short!("notplay"),
+        };
+        MoveResult {
+            success: false,
+            game_state: Self::read_state(env, world),
+            message,
+        }
+    }
+}

--- a/cli/templates/turn-based/src/systems.rs
+++ b/cli/templates/turn-based/src/systems.rs
@@ -1,0 +1,107 @@
+//! Game rules for {{crate_name}}.
+//!
+//! Turn validation and win detection live here as pure functions over component
+//! values. `lib.rs` owns storage; this module owns the rules, so a rule change
+//! never risks touching persistence and can be tested on its own.
+
+use soroban_sdk::Vec;
+
+use crate::components::{
+    Board, TurnState, CELL_COUNT, DRAW, EMPTY, IN_PROGRESS, MARK_O, MARK_X, O_WINS, X_WINS,
+};
+
+/// Every winning line on the board: three rows, three columns, two diagonals.
+const LINES: [[u32; 3]; 8] = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+];
+
+/// Why a proposed move is not legal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MoveError {
+    /// The match already has a winner or ended in a draw.
+    GameOver,
+    /// The cell index is outside the board.
+    OutOfBounds,
+    /// The cell already holds a mark.
+    Occupied,
+    /// It is the other player's turn.
+    NotYourTurn,
+    /// The caller is neither of the two registered players.
+    NotAPlayer,
+}
+
+/// Mark the given player places this turn.
+pub fn mark_for_turn(turn: &TurnState) -> u32 {
+    if turn.is_x_turn {
+        MARK_X
+    } else {
+        MARK_O
+    }
+}
+
+/// Check that `position` is a legal move for the player to move right now.
+pub fn validate_move(
+    board: &Board,
+    turn: &TurnState,
+    position: u32,
+    is_player_x: bool,
+    is_player_o: bool,
+) -> Result<(), MoveError> {
+    if turn.status != IN_PROGRESS {
+        return Err(MoveError::GameOver);
+    }
+    if position >= CELL_COUNT {
+        return Err(MoveError::OutOfBounds);
+    }
+    if !is_player_x && !is_player_o {
+        return Err(MoveError::NotAPlayer);
+    }
+    if turn.is_x_turn != is_player_x {
+        return Err(MoveError::NotYourTurn);
+    }
+    if board.cells.get(position).unwrap_or(MARK_X) != EMPTY {
+        return Err(MoveError::Occupied);
+    }
+    Ok(())
+}
+
+/// Turn state after a legal move has been written to `cells`.
+pub fn advance(turn: &TurnState, cells: &Vec<u32>) -> TurnState {
+    let move_count = turn.move_count + 1;
+    let status = detect_status(cells, move_count);
+    TurnState {
+        is_x_turn: if status == IN_PROGRESS {
+            !turn.is_x_turn
+        } else {
+            turn.is_x_turn
+        },
+        move_count,
+        status,
+    }
+}
+
+/// Win/draw detection over the current cells.
+///
+/// Returns `IN_PROGRESS`, `X_WINS`, `O_WINS`, or `DRAW`.
+pub fn detect_status(cells: &Vec<u32>, move_count: u32) -> u32 {
+    for line in LINES.iter() {
+        let a = cells.get(line[0]).unwrap_or(EMPTY);
+        let b = cells.get(line[1]).unwrap_or(EMPTY);
+        let c = cells.get(line[2]).unwrap_or(EMPTY);
+        if a != EMPTY && a == b && b == c {
+            return if a == MARK_X { X_WINS } else { O_WINS };
+        }
+    }
+    if move_count >= CELL_COUNT {
+        DRAW
+    } else {
+        IN_PROGRESS
+    }
+}

--- a/cli/templates/turn-based/src/test.rs
+++ b/cli/templates/turn-based/src/test.rs
@@ -1,0 +1,171 @@
+//! Integration tests for {{crate_name}}.
+//!
+//! These run through `cougr_core::test::GameHarness`, the sandbox the canonical
+//! examples use: it registers the contract in a fresh `Env`, mints player
+//! addresses, and pairs with `Scenario` to drive alternating turns.
+
+use crate::components::{DRAW, IN_PROGRESS, MARK_O, MARK_X, X_WINS};
+use crate::systems::{detect_status, validate_move, MoveError};
+use crate::{{ContractName}};
+use crate::{{ContractName}}Client;
+use cougr_core::test::{GameHarness, PlayerSlot, Scenario};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{symbol_short, Address, Env};
+
+/// A harness with two authorized players and an initialised match.
+fn started_game() -> (GameHarness, Address, Address) {
+    let env = Env::default();
+    let mut harness = GameHarness::new(env, {{ContractName}});
+    harness.mock_players(2);
+    harness.mock_all_auths();
+
+    let player_x = harness.player(PlayerSlot(0)).clone();
+    let player_o = harness.player(PlayerSlot(1)).clone();
+
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    client.init_game(&player_x, &player_o);
+
+    (harness, player_x, player_o)
+}
+
+#[test]
+fn init_game_starts_with_an_empty_board() {
+    let (harness, player_x, _) = started_game();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let state = client.get_state();
+    assert_eq!(state.cells.len(), 9);
+    assert!(state.cells.iter().all(|cell| cell == 0));
+    assert_eq!(state.player_x, player_x);
+    assert!(state.is_x_turn);
+    assert_eq!(state.status, IN_PROGRESS);
+}
+
+#[test]
+fn players_alternate_marks() {
+    let (harness, player_x, player_o) = started_game();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    assert!(client.make_move(&player_x, &0).success);
+    assert!(client.make_move(&player_o, &4).success);
+
+    let state = client.get_state();
+    assert_eq!(state.cells.get(0).unwrap(), MARK_X);
+    assert_eq!(state.cells.get(4).unwrap(), MARK_O);
+    assert_eq!(state.move_count, 2);
+    assert!(state.is_x_turn);
+}
+
+#[test]
+fn playing_out_of_turn_is_rejected() {
+    let (harness, _, player_o) = started_game();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let result = client.make_move(&player_o, &0);
+    assert!(!result.success);
+    assert_eq!(result.message, symbol_short!("notturn"));
+    assert_eq!(result.game_state.move_count, 0);
+}
+
+#[test]
+fn occupied_cells_and_out_of_range_positions_are_rejected() {
+    let (harness, player_x, player_o) = started_game();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    client.make_move(&player_x, &0);
+
+    assert_eq!(
+        client.make_move(&player_o, &0).message,
+        symbol_short!("occupied")
+    );
+    assert_eq!(
+        client.make_move(&player_o, &99).message,
+        symbol_short!("bounds")
+    );
+}
+
+#[test]
+fn a_third_address_cannot_play() {
+    let (harness, _, _) = started_game();
+    let stranger = Address::generate(harness.env());
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    let result = client.make_move(&stranger, &0);
+    assert!(!result.success);
+    assert_eq!(result.message, symbol_short!("notplay"));
+}
+
+#[test]
+fn scenario_plays_a_winning_column_for_x() {
+    let (harness, _, _) = started_game();
+
+    // X takes the left column while O answers in the middle one.
+    let moves = [0u32, 1, 3, 4, 6];
+    Scenario::new("x wins the left column")
+        .players(2)
+        .turns(moves.len() as u32)
+        .run(&harness, |slot, turn, h| {
+            let client = {{ContractName}}Client::new(h.env(), h.contract_id());
+            let player = h.player(slot).clone();
+            let result = client.make_move(&player, &moves[turn.0 as usize]);
+            assert!(result.success, "move {} was rejected", turn.0);
+        });
+
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+    let winner = client.get_winner();
+
+    assert_eq!(client.get_state().status, X_WINS);
+    assert_eq!(winner, Some(harness.player(PlayerSlot(0)).clone()));
+}
+
+#[test]
+fn moves_after_the_game_ends_are_rejected() {
+    let (harness, player_x, player_o) = started_game();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    for (index, position) in [0u32, 1, 3, 4, 6].iter().enumerate() {
+        let player = if index % 2 == 0 { &player_x } else { &player_o };
+        assert!(client.make_move(player, position).success);
+    }
+
+    assert_eq!(
+        client.make_move(&player_o, &2).message,
+        symbol_short!("gameover")
+    );
+    assert!(!client.is_valid_move(&2));
+}
+
+#[test]
+fn reset_game_clears_the_board_and_keeps_the_players() {
+    let (harness, player_x, player_o) = started_game();
+    let client = {{ContractName}}Client::new(harness.env(), harness.contract_id());
+
+    client.make_move(&player_x, &0);
+    let state = client.reset_game();
+
+    assert_eq!(state.move_count, 0);
+    assert!(state.cells.iter().all(|cell| cell == 0));
+    assert_eq!(state.player_x, player_x);
+    assert_eq!(state.player_o, player_o);
+}
+
+#[test]
+fn detect_status_reports_a_full_board_as_a_draw() {
+    let env = Env::default();
+    // X O X / X O O / O X X — full board with no line.
+    let cells = soroban_sdk::vec![&env, 1, 2, 1, 1, 2, 2, 2, 1, 1];
+
+    assert_eq!(detect_status(&cells, 9), DRAW);
+}
+
+#[test]
+fn validate_move_rejects_a_non_player() {
+    let env = Env::default();
+    let board = crate::components::Board::new(&env);
+    let turn = crate::components::TurnState::opening();
+
+    assert_eq!(
+        validate_move(&board, &turn, 0, false, false),
+        Err(MoveError::NotAPlayer)
+    );
+}

--- a/cli/tests/cougr_new.rs
+++ b/cli/tests/cougr_new.rs
@@ -1,0 +1,159 @@
+//! End-to-end tests that drive the compiled `cougr` binary.
+//!
+//! The fast tests assert on the generated tree and the CLI's exit codes. The
+//! `#[ignore]`d `generated_projects_pass_cargo_test` compiles all four templates
+//! against the published `cougr-core` — it is the real definition-of-done check,
+//! run in CI and locally with:
+//!
+//! ```bash
+//! cargo test -p cougr-cli -- --ignored --nocapture
+//! ```
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+const TEMPLATES: [&str; 4] = ["starter", "turn-based", "hidden-info", "session-auth"];
+
+fn cougr(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_cougr"))
+        .args(args)
+        .output()
+        .expect("run the cougr binary")
+}
+
+fn generate(name: &str, template: &str, parent: &Path) -> Output {
+    cougr(&[
+        "new",
+        name,
+        "--template",
+        template,
+        "--path",
+        parent.to_str().expect("utf-8 temp path"),
+    ])
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+#[test]
+fn every_template_generates_a_complete_project() {
+    for template in TEMPLATES {
+        let dir = tempfile::tempdir().unwrap();
+        let output = generate("demo", template, dir.path());
+        assert!(
+            output.status.success(),
+            "`--template {template}` failed: {}",
+            stderr(&output)
+        );
+
+        let project = dir.path().join("demo");
+        for expected in [
+            "Cargo.toml",
+            "README.md",
+            ".gitignore",
+            "src/lib.rs",
+            "src/components.rs",
+            "src/systems.rs",
+            "src/test.rs",
+        ] {
+            assert!(
+                project.join(expected).is_file(),
+                "`{template}` did not generate `{expected}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn starter_is_the_default_template() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = cougr(&[
+        "new",
+        "demo",
+        "--path",
+        dir.path().to_str().expect("utf-8 temp path"),
+    ]);
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let readme = std::fs::read_to_string(dir.path().join("demo/README.md")).unwrap();
+    assert!(readme.contains("--template starter"));
+}
+
+#[test]
+fn success_output_names_the_next_commands() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = generate("demo", "starter", dir.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("cd demo"));
+    assert!(stdout.contains("cargo test"));
+    assert!(stdout.contains("stellar contract build"));
+}
+
+#[test]
+fn an_unknown_template_is_a_usage_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = generate("demo", "roguelike", dir.path());
+
+    assert!(!output.status.success());
+    let message = stderr(&output);
+    assert!(message.contains("roguelike"), "{message}");
+    assert!(
+        message.contains("starter"),
+        "expected the valid values: {message}"
+    );
+    assert!(!dir.path().join("demo").exists());
+}
+
+#[test]
+fn an_invalid_name_is_reported_without_a_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = generate("2fast", "starter", dir.path());
+
+    assert!(!output.status.success());
+    let message = stderr(&output);
+    assert!(message.starts_with("error:"), "{message}");
+    assert!(!message.contains("panicked"), "{message}");
+    assert!(message.contains("help:"), "expected a hint: {message}");
+}
+
+#[test]
+fn an_existing_directory_is_never_overwritten() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().join("demo");
+    std::fs::create_dir(&project).unwrap();
+    std::fs::write(project.join("keep.txt"), "mine").unwrap();
+
+    let output = generate("demo", "starter", dir.path());
+
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("already exists"));
+    assert_eq!(
+        std::fs::read_to_string(project.join("keep.txt")).unwrap(),
+        "mine"
+    );
+    assert!(!project.join("Cargo.toml").exists());
+}
+
+/// The definition-of-done check: every template builds and its tests pass
+/// against the published `cougr-core`.
+///
+/// Ignored by default because it downloads and compiles the Soroban SDK.
+#[test]
+#[ignore = "compiles four Soroban projects; run with --ignored"]
+fn generated_projects_pass_cargo_test() {
+    for template in TEMPLATES {
+        let dir = tempfile::tempdir().unwrap();
+        let output = generate("demo", template, dir.path());
+        assert!(output.status.success(), "{}", stderr(&output));
+
+        let status = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+            .arg("test")
+            .current_dir(dir.path().join("demo"))
+            .status()
+            .expect("run cargo test in the generated project");
+
+        assert!(status.success(), "`{template}` failed `cargo test`");
+    }
+}


### PR DESCRIPTION
Closes #244. Part of #238.

## What this does

Adds `cougr-cli`, a new workspace member publishing the `cougr` binary, with its first command:

```bash
cougr new my-game --template starter
cd my-game
cargo test
```

Starting a Cougr project meant cloning the repository and hand-adapting an example. `EXAMPLE_STANDARD.md` already defines the canonical layout and ten canonical examples already implement it correctly — this turns that proven layout into a generator instead of something a developer reverse-engineers by reading source.

## Templates

Four templates, each derived from a canonical example and embedded into the binary with `rust-embed` so generation works fully offline:

| Template | Derived from | Pattern |
| --- | --- | --- |
| `starter` | `examples/spawn_and_move` | Observed components, typed ECS, `SorobanGame` |
| `turn-based` | `examples/tic_tac_toe` | Rich `Address`/`Vec` components, turn ownership |
| `hidden-info` | `examples/hidden_hand` | `circuits::hidden_cards`, Groth16 verification |
| `session-auth` | `examples/session_arena` | `SessionManager`, approve-once play, auth fallback |

Each generates the canonical `lib.rs` / `components.rs` / `systems.rs` split, a `GameHarness` test module, a README documenting the contract API and storage model, and a `Cargo.toml` depending on the **published** `cougr-core` pinned to the current major/minor — never a path dependency.

## Name substitution

One user-supplied name drives three identifiers, derived once in `name.rs`:

| Input | Crate | Module | Contract struct |
| --- | --- | --- | --- |
| `dungeon-crawl` | `dungeon-crawl` | `dungeon_crawl` | `DungeonCrawl` |

## Errors

Invalid names, an existing target directory, and unknown `--template` values all produce actionable messages with a `help:` line — no panics on user input. A failed write rolls the partial tree back so a retry does not trip the "already exists" check.

```
$ cougr new "my game"
error: `my game` is not a valid project name: ` ` is not allowed in a crate name
  help: crate names start with a letter and use letters, digits, `_` or `-` (for example: `my-game` or `dungeon_crawl`)
```

## Verification

Every template, generated fresh into a cold target directory:

| Template | `cargo fmt --check` | `clippy -D warnings` | `cargo test` | `wasm32v1-none` |
| --- | --- | --- | --- | --- |
| `starter` | clean | clean | 8 pass | 34,740 B |
| `turn-based` | clean | clean | 10 pass | 38,508 B |
| `hidden-info` | clean | clean | 10 pass | 52,791 B |
| `session-auth` | clean | clean | 12 pass | 53,662 B |

`hidden-info`'s suite includes real Groth16 verification against the pipeline fixtures, not a stub.

`cargo test -p cougr-cli` passes 23 unit + 6 CLI tests. The tests fail if a placeholder survives rendering, a template drops a file from the canonical layout, a manifest reaches for a path dependency, or a test module stops using `GameHarness`. The full generate-and-compile check is `#[ignore]`d for local speed and runs in CI:

```bash
cargo test -p cougr-cli -- --ignored
```

No disruption to existing CI: `cargo test --workspace --features testutils` still resolves with the new member, and `cargo package` for `cougr-core` succeeds with `cli/**` added to `exclude`.

## Two deliberate departures from the source examples

Both are documented in the affected template's generated README:

1. **`turn-based` calls `require_auth` on the acting player.** The canonical example omits it. A generator should not teach an unauthenticated player-identified action.
2. **`hidden-info` binds proofs to a seat assigned at `join_table`**, rather than hashing the caller's address into a player ID. This makes the positive verification path testable end to end, and means replaying another player's proof under your own address fails verification rather than needing a separate check.

## Two things worth reviewer attention

- **The `cougr-core` version pin is a manual constant.** `COUGR_CORE_VERSION = "1.1"` is guarded by a test asserting it matches `cougr-cli`'s own major/minor. That enforces the lockstep release cadence [10-repository-strategy.md](docs/strategy/10-repository-strategy.md) calls for, but it means bumping `cougr-cli` to 1.2 while `cougr-core` stays at 1.1 will fail that test rather than silently generating a wrong dependency.
- **`hidden-info` ships the Cougr development verification key**, inherited from `circuits::hidden_cards`. Anyone holding the matching proving key can forge a deal proof. It is flagged prominently in that template's generated README, but it remains a footgun for someone who deploys without reading.

## Packaging note

Template manifests are named `Cargo.toml.tmpl` and dotfiles `gitignore`, renamed on write. Cargo drops subdirectories containing a manifest when packaging a crate, which would silently strip the templates from the published binary. `cargo package -p cougr-cli --list` confirms all 40 template files ship.

## Not included in this PR

`.github/workflows/cli.yml` — a CLI validation workflow plus a per-template matrix running fmt/clippy/test/wasm against each generated project. The push was rejected because the authoring token lacks the `workflow` OAuth scope. The file is written and ready; it needs a push from someone whose token carries that scope. Everything it would run has been verified locally, as tabulated above.

## Out of scope, per the issue

No `--git`/remote-template mechanism, and no deploy step — `cougr new` tells you what to run next, it does not wrap `stellar contract deploy`.
